### PR TITLE
fix: add packageManager field and fix lint formatting

### DIFF
--- a/app/routes/groups.$groupId.availability.tsx
+++ b/app/routes/groups.$groupId.availability.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "@remix-run/react";
 
 export default function AvailabilityLayout() {
-return <Outlet />;
+	return <Outlet />;
 }

--- a/app/routes/groups.$groupId.events.tsx
+++ b/app/routes/groups.$groupId.events.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "@remix-run/react";
 
 export default function EventsLayout() {
-return <Outlet />;
+	return <Outlet />;
 }

--- a/app/routes/groups.tsx
+++ b/app/routes/groups.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "@remix-run/react";
 
 export default function GroupsLayout() {
-return <Outlet />;
+	return <Outlet />;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",
+	"packageManager": "pnpm@10.12.3",
 	"description": "GreenRoom — an improv group scheduling platform",
 	"scripts": {
 		"dev": "remix vite:dev",


### PR DESCRIPTION
Adds the missing `packageManager` field to package.json (required by pnpm/action-setup@v4 in CI) and fixes lint formatting issues in layout routes.