### PR TITLE
fix(ci): change deploy workflow to manual trigger only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,11 @@
 name: Deploy
+# Triggered manually until Azure infrastructure is provisioned
 on:
-  push:
-    branches: [master]
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The Deploy workflow runs on every push to master and fails at the "Login to Azure" step because `AZURE_CREDENTIALS`, `ACR_LOGIN_SERVER`, etc. aren't configured as GitHub secrets yet. This makes CI show red on every merge.

## Fix

Changed the deploy workflow trigger from `push to master + workflow_dispatch` to `workflow_dispatch` only. Also removed the now-redundant `if:` condition on the job.

Once Azure infrastructure is provisioned and secrets are configured, we can re-add the push trigger.

## Changes

- Removed `push.branches: [master]` trigger
- Removed redundant `if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'` condition
- Added comment explaining the manual-only trigger