### PR TITLE
feat: show timezone selector on event and availability creation pages

### DIFF
--- a/app/components/timezone-selector.tsx
+++ b/app/components/timezone-selector.tsx
@@ -1,0 +1,104 @@
+import { useFetcher } from "@remix-run/react";
+import { Globe } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+export const COMMON_TIMEZONES = [
+	"America/New_York",
+	"America/Chicago",
+	"America/Denver",
+	"America/Los_Angeles",
+	"America/Anchorage",
+	"Pacific/Honolulu",
+	"America/Phoenix",
+	"America/Toronto",
+	"America/Vancouver",
+	"America/Mexico_City",
+	"America/Sao_Paulo",
+	"America/Argentina/Buenos_Aires",
+	"Europe/London",
+	"Europe/Paris",
+	"Europe/Berlin",
+	"Europe/Amsterdam",
+	"Europe/Madrid",
+	"Europe/Rome",
+	"Europe/Moscow",
+	"Asia/Dubai",
+	"Asia/Kolkata",
+	"Asia/Singapore",
+	"Asia/Shanghai",
+	"Asia/Tokyo",
+	"Asia/Seoul",
+	"Australia/Sydney",
+	"Australia/Melbourne",
+	"Pacific/Auckland",
+	"UTC",
+];
+
+export function getTimezoneLabel(tz: string): string {
+	try {
+		const now = new Date();
+		const offsetStr = now.toLocaleString("en-US", { timeZone: tz, timeZoneName: "short" });
+		const match = offsetStr.match(/[A-Z]{2,5}$/);
+		const abbrev = match ? match[0] : "";
+		const city = tz.split("/").pop()?.replace(/_/g, " ") ?? tz;
+		return `${city}${abbrev ? ` (${abbrev})` : ""}`;
+	} catch {
+		return tz;
+	}
+}
+
+/**
+ * Inline timezone indicator with dropdown to change.
+ * Saves to user profile via /settings action using useFetcher.
+ */
+export function InlineTimezoneSelector({ timezone }: { timezone: string | null }) {
+	const fetcher = useFetcher();
+	const [isEditing, setIsEditing] = useState(false);
+	const selectRef = useRef<HTMLSelectElement>(null);
+	const currentTz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
+
+	// Focus the select when switching to edit mode
+	useEffect(() => {
+		if (isEditing && selectRef.current) {
+			selectRef.current.focus();
+		}
+	}, [isEditing]);
+
+	const handleChange = (newTimezone: string) => {
+		fetcher.submit(
+			{ intent: "update-timezone", timezone: newTimezone },
+			{ method: "post", action: "/settings" },
+		);
+		setIsEditing(false);
+	};
+
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-slate-500">
+			<Globe className="h-3 w-3" />
+			{isEditing ? (
+				<select
+					ref={selectRef}
+					defaultValue={currentTz}
+					onChange={(e) => handleChange(e.target.value)}
+					onBlur={() => setIsEditing(false)}
+					className="rounded border border-slate-300 px-1.5 py-0.5 text-xs text-slate-700 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500/20"
+				>
+					{COMMON_TIMEZONES.map((tz) => (
+						<option key={tz} value={tz}>
+							{getTimezoneLabel(tz)}
+						</option>
+					))}
+				</select>
+			) : (
+				<button
+					type="button"
+					onClick={() => setIsEditing(true)}
+					className="rounded px-1 py-0.5 text-slate-500 underline decoration-dotted underline-offset-2 transition-colors hover:text-slate-700"
+				>
+					{getTimezoneLabel(currentTz)}
+				</button>
+			)}
+			{fetcher.state === "submitting" && <span className="text-emerald-600">saving…</span>}
+		</div>
+	);
+}

--- a/app/routes/groups.$groupId.availability.new.tsx
+++ b/app/routes/groups.$groupId.availability.new.tsx
@@ -1,7 +1,16 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
-import { Form, Link, redirect, useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+	Form,
+	Link,
+	redirect,
+	useActionData,
+	useLoaderData,
+	useNavigation,
+	useParams,
+} from "@remix-run/react";
 import { useState } from "react";
 import { DateSelector } from "~/components/date-selector";
+import { InlineTimezoneSelector } from "~/components/timezone-selector";
 import { formatDateShort, formatTimeRange } from "~/lib/date-utils";
 import { createAvailabilityRequest } from "~/services/availability.server";
 import { sendAvailabilityRequestNotification } from "~/services/email.server";
@@ -13,8 +22,8 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	await requireGroupAdmin(request, groupId);
-	return {};
+	const user = await requireGroupAdmin(request, groupId);
+	return { userTimezone: user.timezone };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -110,6 +119,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function NewAvailabilityRequest() {
 	const { groupId } = useParams();
+	const { userTimezone } = useLoaderData<typeof loader>();
 	const actionData = useActionData<typeof action>();
 	const navigation = useNavigation();
 	const isSubmitting = navigation.state === "submitting";
@@ -247,6 +257,9 @@ export default function NewAvailabilityRequest() {
 					<p className="mb-4 text-xs text-slate-500">
 						If your event has a specific time, let members know what hours you&apos;re asking about.
 					</p>
+					<div className="mb-4">
+						<InlineTimezoneSelector timezone={userTimezone} />
+					</div>
 					<div className="grid gap-4 sm:grid-cols-2">
 						<div>
 							<label

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -10,6 +10,7 @@ import {
 } from "@remix-run/react";
 import { ArrowLeft, Clock, Users } from "lucide-react";
 import { useState } from "react";
+import { InlineTimezoneSelector } from "~/components/timezone-selector";
 import { formatEventTime } from "~/lib/date-utils";
 import { getAvailabilityRequest } from "~/services/availability.server";
 import {
@@ -29,7 +30,7 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdmin(request, groupId);
 
 	const url = new URL(request.url);
 	const fromRequestId = url.searchParams.get("fromRequest");
@@ -50,7 +51,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupData = await getGroupWithMembers(groupId);
 	const members = groupData?.members ?? [];
 
-	return { fromRequest, prefillDate, members, availabilityData };
+	return { fromRequest, prefillDate, members, availabilityData, userTimezone: user.timezone };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -200,7 +201,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function NewEvent() {
 	const { groupId } = useParams();
-	const { fromRequest, prefillDate, members, availabilityData } = useLoaderData<typeof loader>();
+	const { fromRequest, prefillDate, members, availabilityData, userTimezone } =
+		useLoaderData<typeof loader>();
 	const actionData = useActionData<typeof action>();
 	const navigation = useNavigation();
 	const isSubmitting = navigation.state === "submitting";
@@ -333,6 +335,9 @@ export default function NewEvent() {
 				{/* Date & Time */}
 				<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
 					<h3 className="mb-4 text-sm font-semibold text-slate-900">Date & Time</h3>
+					<div className="mb-4">
+						<InlineTimezoneSelector timezone={userTimezone} />
+					</div>
 					<div className="grid gap-4 sm:grid-cols-3">
 						<div>
 							<label htmlFor="date" className="block text-sm font-medium text-slate-700">

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remi
 import { Form, useActionData, useLoaderData, useNavigation, useSubmit } from "@remix-run/react";
 import { Globe, Save } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { COMMON_TIMEZONES, getTimezoneLabel } from "~/components/timezone-selector";
 import { requireUser, updateUserTimezone } from "~/services/auth.server";
 
 export const meta: MetaFunction = () => {
@@ -34,51 +35,6 @@ export async function action({ request }: ActionFunctionArgs) {
 	}
 
 	return { error: "Invalid action." };
-}
-
-const COMMON_TIMEZONES = [
-	"America/New_York",
-	"America/Chicago",
-	"America/Denver",
-	"America/Los_Angeles",
-	"America/Anchorage",
-	"Pacific/Honolulu",
-	"America/Phoenix",
-	"America/Toronto",
-	"America/Vancouver",
-	"America/Mexico_City",
-	"America/Sao_Paulo",
-	"America/Argentina/Buenos_Aires",
-	"Europe/London",
-	"Europe/Paris",
-	"Europe/Berlin",
-	"Europe/Amsterdam",
-	"Europe/Madrid",
-	"Europe/Rome",
-	"Europe/Moscow",
-	"Asia/Dubai",
-	"Asia/Kolkata",
-	"Asia/Singapore",
-	"Asia/Shanghai",
-	"Asia/Tokyo",
-	"Asia/Seoul",
-	"Australia/Sydney",
-	"Australia/Melbourne",
-	"Pacific/Auckland",
-	"UTC",
-];
-
-function getTimezoneLabel(tz: string): string {
-	try {
-		const now = new Date();
-		const offsetStr = now.toLocaleString("en-US", { timeZone: tz, timeZoneName: "short" });
-		const match = offsetStr.match(/[A-Z]{2,5}$/);
-		const abbrev = match ? match[0] : "";
-		const city = tz.split("/").pop()?.replace(/_/g, " ") ?? tz;
-		return `${city}${abbrev ? ` (${abbrev})` : ""}`;
-	} catch {
-		return tz;
-	}
 }
 
 export default function Settings() {


### PR DESCRIPTION
## Summary
Adds an inline timezone display and selector to both event creation and availability request creation forms. Users can now see and change their timezone without leaving the creation flow.

## Changes
- **New:** `app/components/timezone-selector.tsx` — shared `InlineTimezoneSelector` component with `COMMON_TIMEZONES` and `getTimezoneLabel` exports
- **Modified:** `app/routes/groups.$groupId.events.new.tsx` — shows timezone indicator in Date & Time section
- **Modified:** `app/routes/groups.$groupId.availability.new.tsx` — shows timezone indicator in Time Range section
- **Modified:** `app/routes/settings.tsx` — imports from shared module instead of defining locally

## How it works
- The component shows a subtle globe icon + timezone label (e.g., "Los Angeles (PST)")
- Clicking it opens a dropdown to change timezone
- Changes are saved to the user's profile via `useFetcher` (POST to `/settings` action) — no page navigation
- The `COMMON_TIMEZONES` list and `getTimezoneLabel` function are extracted from settings.tsx for reuse

## Testing
- All 72 tests pass
- TypeScript strict mode passes
- Biome lint passes
- Production build succeeds

## Known limitation (pre-existing)
Server-side date parsing uses `new Date(\`${date}T${time}:00\`)` which interprets in the server's local timezone. This is a pre-existing issue not introduced by this PR. A follow-up could add timezone-aware date construction using a library like `date-fns-tz`.

Closes #28