### PR TITLE
fix: use onAllReady to prevent stray $ on iOS Safari

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -92,7 +92,7 @@ function handleBrowserRequest(
 		const { pipe, abort } = renderToPipeableStream(
 			<RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />,
 			{
-				onShellReady() {
+				onAllReady() {
 					shellRendered = true;
 					const body = new PassThrough();
 					const stream = createReadableStreamFromReadable(body);


### PR DESCRIPTION
## Problem

## Root Cause
`handleBrowserRequest` in `app/entry.server.tsx` used `onShellReady`, which streams HTML before all data is ready. React's streaming SSR outputs `<!--$-->` Suspense boundary markers after `</html>`, which iOS Safari renders as visible text.

## Fix
Changed `onShellReady` → `onAllReady` in `handleBrowserRequest`. This waits for all data loaders to complete before sending the response, keeping Suspense markers inside the HTML document.

**Tradeoff:** Slightly slower Time To First Byte (server waits for all data), but negligible for this app's size — and it eliminates the rendering artifact on iOS.

## Testing
- ✅ TypeScript typecheck passes
- ✅ Biome lint passes
- ✅ Production build succeeds
- ✅ All 92 tests pass