### PR TITLE
fix: strip content after </html> to prevent stray $ on iOS Safari

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,4 +1,4 @@
-import { PassThrough } from "node:stream";
+import { PassThrough, Transform } from "node:stream";
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -7,6 +7,35 @@ import { renderToPipeableStream } from "react-dom/server";
 import { logger } from "~/services/logger.server";
 
 const ABORT_DELAY = 5_000;
+
+/**
+ * Strips content after </html> to prevent React SSR comment markers (<!--$-->)
+ * from appearing as visible text on iOS Safari.
+ */
+class StripAfterHtmlEnd extends Transform {
+	private ended = false;
+
+	_transform(
+		chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null, data?: Buffer | string) => void,
+	) {
+		if (this.ended) {
+			callback();
+			return;
+		}
+
+		const str = chunk.toString();
+		const idx = str.indexOf("</html>");
+		if (idx !== -1) {
+			this.ended = true;
+			this.push(str.slice(0, idx + "</html>".length));
+		} else {
+			this.push(chunk);
+		}
+		callback();
+	}
+}
 
 export default function handleRequest(
 	request: Request,
@@ -95,7 +124,8 @@ function handleBrowserRequest(
 				onAllReady() {
 					shellRendered = true;
 					const body = new PassThrough();
-					const stream = createReadableStreamFromReadable(body);
+					const stripped = body.pipe(new StripAfterHtmlEnd());
+					const stream = createReadableStreamFromReadable(stripped);
 
 					responseHeaders.set("Content-Type", "text/html");
 


### PR DESCRIPTION
## Problem

## Root Cause
PR #31 changed `handleBrowserRequest` from `onShellReady` to `onAllReady`, which was necessary but insufficient. Remix's `StreamTransfer` component still appends `<!--$-->` markers and data-streaming `<script>` tags after `</html>`, even when all data is ready.

## Fix
Added a `StripAfterHtmlEnd` Transform stream in `handleBrowserRequest` that truncates the HTTP response at `</html>`. The rendered React output pipes through `PassThrough → StripAfterHtmlEnd → ReadableStream`, so any content after `</html>` (Suspense markers, streaming scripts) is stripped before reaching the browser.

The bot handler is left unchanged since bots/crawlers don't have this rendering issue.

**Changes:**
- Import `Transform` from `node:stream`
- Add `StripAfterHtmlEnd` class (Transform stream that truncates at `</html>`)
- Pipe browser handler output through the transform: `body.pipe(new StripAfterHtmlEnd())`

## Testing
- ✅ TypeScript typecheck passes
- ✅ Biome lint passes
- ✅ Production build succeeds
- ✅ All 92 tests pass