### PR TITLE
feat: Configurable Member Permissions

### DIFF
--- a/app/routes/groups.$groupId.availability._index.tsx
+++ b/app/routes/groups.$groupId.availability._index.tsx
@@ -23,6 +23,8 @@ export default function Availability() {
 	const role = parentData?.role;
 	const groupId = parentData?.group?.id;
 	const timezone = parentData?.user?.timezone ?? undefined;
+	const canCreateRequests =
+		role === "admin" || parentData?.group?.membersCanCreateRequests === true;
 
 	return (
 		<div>
@@ -31,7 +33,7 @@ export default function Availability() {
 					<h2 className="text-2xl font-bold text-slate-900">Availability Requests</h2>
 					<p className="mt-1 text-sm text-slate-600">Manage scheduling polls for your group</p>
 				</div>
-				{role === "admin" && (
+				{canCreateRequests && (
 					<Link
 						to={`/groups/${groupId}/availability/new`}
 						className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700"
@@ -47,7 +49,7 @@ export default function Availability() {
 					<Calendar className="mx-auto h-12 w-12 text-slate-300" />
 					<h3 className="mt-4 text-sm font-medium text-slate-900">No availability requests yet</h3>
 					<p className="mt-1 text-sm text-slate-500">
-						{role === "admin"
+						{canCreateRequests
 							? "Create one to find out when your group is free."
 							: "Your group admin hasn't created any yet."}
 					</p>

--- a/app/routes/groups.$groupId.availability.new.tsx
+++ b/app/routes/groups.$groupId.availability.new.tsx
@@ -14,7 +14,7 @@ import { InlineTimezoneSelector } from "~/components/timezone-selector";
 import { formatDateShort, formatTimeRange } from "~/lib/date-utils";
 import { createAvailabilityRequest } from "~/services/availability.server";
 import { sendAvailabilityRequestNotification } from "~/services/email.server";
-import { getGroupWithMembers, requireGroupAdmin } from "~/services/groups.server";
+import { getGroupWithMembers, requireGroupAdminOrPermission } from "~/services/groups.server";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "New Availability Request — My Call Time" }];
@@ -22,13 +22,13 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateRequests");
 	return { userTimezone: user.timezone };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateRequests");
 	const formData = await request.formData();
 
 	const title = formData.get("title");

--- a/app/routes/groups.$groupId.events._index.tsx
+++ b/app/routes/groups.$groupId.events._index.tsx
@@ -26,6 +26,7 @@ export default function Events() {
 	const role = parentData?.role;
 	const groupId = parentData?.group?.id ?? "";
 	const timezone = parentData?.user?.timezone ?? undefined;
+	const canCreateEvents = role === "admin" || parentData?.group?.membersCanCreateEvents === true;
 	const [searchParams] = useSearchParams();
 
 	const [view, setView] = useState<"list" | "calendar">(
@@ -92,7 +93,7 @@ export default function Events() {
 						<option value="other">📅 Other</option>
 					</select>
 
-					{role === "admin" && (
+					{canCreateEvents && (
 						<Link
 							to={`/groups/${groupId}/events/new`}
 							className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700"
@@ -111,11 +112,11 @@ export default function Events() {
 							<CalendarDays className="h-10 w-10 text-slate-300" />
 							<h3 className="mt-3 text-base font-semibold text-slate-900">No events yet</h3>
 							<p className="mt-1 max-w-sm text-sm text-slate-500">
-								{role === "admin"
+								{canCreateEvents
 									? "Create your first event or use availability results to schedule one."
 									: "Events created by admins will appear here."}
 							</p>
-							{role === "admin" && (
+							{canCreateEvents && (
 								<Link
 									to={`/groups/${groupId}/events/new`}
 									className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700"

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -22,7 +22,7 @@ import {
 	createEvent,
 	getAvailabilityForEventDate,
 } from "~/services/events.server";
-import { getGroupWithMembers, requireGroupAdmin } from "~/services/groups.server";
+import { getGroupWithMembers, requireGroupAdminOrPermission } from "~/services/groups.server";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "Create Event — My Call Time" }];
@@ -30,7 +30,7 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
 
 	const url = new URL(request.url);
 	const fromRequestId = url.searchParams.get("fromRequest");
@@ -56,7 +56,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
 	const formData = await request.formData();
 
 	const title = formData.get("title");

--- a/app/routes/groups.$groupId.settings.tsx
+++ b/app/routes/groups.$groupId.settings.tsx
@@ -5,6 +5,7 @@ import {
 	regenerateInviteCode,
 	requireGroupAdmin,
 	updateGroup,
+	updateGroupPermissions,
 } from "~/services/groups.server";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -46,6 +47,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			return { success: true, message: `Invite code regenerated: ${newCode}` };
 		} catch {
 			return { error: "Failed to regenerate invite code.", success: false };
+		}
+	}
+
+	if (intent === "update-permissions") {
+		try {
+			await updateGroupPermissions(groupId, {
+				membersCanCreateRequests: formData.get("membersCanCreateRequests") === "on",
+				membersCanCreateEvents: formData.get("membersCanCreateEvents") === "on",
+			});
+			return { success: true, message: "Member permissions updated." };
+		} catch {
+			return { error: "Failed to update permissions.", success: false };
 		}
 	}
 
@@ -157,6 +170,60 @@ export default function GroupSettings() {
 						</button>
 					</Form>
 				</div>
+			</div>
+
+			{/* Member Permissions */}
+			<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+				<div className="border-b border-slate-100 px-6 py-4">
+					<h2 className="text-lg font-semibold text-slate-900">Member Permissions</h2>
+					<p className="mt-1 text-sm text-slate-500">
+						Control what regular members can do in this group
+					</p>
+				</div>
+				<Form method="post" className="p-6">
+					<input type="hidden" name="intent" value="update-permissions" />
+					<div className="space-y-4">
+						<label className="flex items-center justify-between gap-4">
+							<div>
+								<span className="text-sm font-medium text-slate-700">
+									Allow members to create availability requests
+								</span>
+								<p className="text-xs text-slate-500">
+									Members can create scheduling polls, not just admins
+								</p>
+							</div>
+							<input
+								type="checkbox"
+								name="membersCanCreateRequests"
+								defaultChecked={group.membersCanCreateRequests}
+								className="h-5 w-5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500/20"
+							/>
+						</label>
+						<label className="flex items-center justify-between gap-4">
+							<div>
+								<span className="text-sm font-medium text-slate-700">
+									Allow members to create events
+								</span>
+								<p className="text-xs text-slate-500">
+									Members can create rehearsals, shows, and other events
+								</p>
+							</div>
+							<input
+								type="checkbox"
+								name="membersCanCreateEvents"
+								defaultChecked={group.membersCanCreateEvents}
+								className="h-5 w-5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500/20"
+							/>
+						</label>
+					</div>
+					<button
+						type="submit"
+						disabled={isSubmitting}
+						className="mt-4 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:ring-offset-2 disabled:opacity-50"
+					>
+						{isSubmitting ? "Saving…" : "Save Permissions"}
+					</button>
+				</Form>
 			</div>
 		</div>
 	);

--- a/drizzle/0003_sturdy_shen.sql
+++ b/drizzle/0003_sturdy_shen.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "groups" ADD COLUMN "members_can_create_requests" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "members_can_create_events" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,921 @@
+{
+  "id": "4213a7a0-a601-476b-867c-ff8656b8b224",
+  "prevId": "a3d5c8e9-d281-4438-be52-dc851177f5f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_requests": {
+      "name": "availability_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_dates": {
+          "name": "requested_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_start_time": {
+          "name": "requested_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_end_time": {
+          "name": "requested_end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "availability_requests_group_id_idx": {
+          "name": "availability_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_requests_group_id_groups_id_fk": {
+          "name": "availability_requests_group_id_groups_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_requests_created_by_id_users_id_fk": {
+          "name": "availability_requests_created_by_id_users_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_responses": {
+      "name": "availability_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_responses_request_user_idx": {
+          "name": "availability_responses_request_user_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_responses_request_id_availability_requests_id_fk": {
+          "name": "availability_responses_request_id_availability_requests_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_responses_user_id_users_id_fk": {
+          "name": "availability_responses_user_id_users_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_assignments": {
+      "name": "event_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_assignments_event_user_idx": {
+          "name": "event_assignments_event_user_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_assignments_user_id_idx": {
+          "name": "event_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_assignments_event_id_events_id_fk": {
+          "name": "event_assignments_event_id_events_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_assignments_user_id_users_id_fk": {
+          "name": "event_assignments_user_id_users_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_request_id": {
+          "name": "created_from_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_time": {
+          "name": "call_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_group_start_time_idx": {
+          "name": "events_group_start_time_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_group_id_groups_id_fk": {
+          "name": "events_group_id_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_id_users_id_fk": {
+          "name": "events_created_by_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_created_from_request_id_availability_requests_id_fk": {
+          "name": "events_created_from_request_id_availability_requests_id_fk",
+          "tableFrom": "events",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "created_from_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_user_idx": {
+          "name": "group_memberships_group_user_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_can_create_requests": {
+          "name": "members_can_create_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "members_can_create_events": {
+          "name": "members_can_create_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_invite_code_idx": {
+          "name": "groups_invite_code_idx",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_id_users_id_fk": {
+          "name": "groups_created_by_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_invite_code_unique": {
+          "name": "groups_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_google_id_idx": {
+          "name": "users_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "declined"
+      ]
+    },
+    "public.availability_response_value": {
+      "name": "availability_response_value",
+      "schema": "public",
+      "values": [
+        "available",
+        "maybe",
+        "not_available"
+      ]
+    },
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "rehearsal",
+        "show",
+        "other"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,27 +1,34 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1772213446374,
-      "tag": "0000_wise_hammerhead",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1772226542765,
-      "tag": "0001_narrow_liz_osborn",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772239857754,
-      "tag": "0002_faulty_blue_shield",
-      "breakpoints": true
-    }
-  ]
+            "version": "7",
+            "dialect": "postgresql",
+            "entries": [
+                        {
+                                    "idx": 0,
+                                    "version": "7",
+                                    "when": 1772213446374,
+                                    "tag": "0000_wise_hammerhead",
+                                    "breakpoints": true
+                        },
+                        {
+                                    "idx": 1,
+                                    "version": "7",
+                                    "when": 1772226542765,
+                                    "tag": "0001_narrow_liz_osborn",
+                                    "breakpoints": true
+                        },
+                        {
+                                    "idx": 2,
+                                    "version": "7",
+                                    "when": 1772239857754,
+                                    "tag": "0002_faulty_blue_shield",
+                                    "breakpoints": true
+                        },
+                        {
+                                    "idx": 3,
+                                    "version": "7",
+                                    "when": 1772251740000,
+                                    "tag": "0003_sturdy_shen",
+                                    "breakpoints": true
+                        }
+            ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -58,6 +58,8 @@ export const groups = pgTable(
 		createdById: uuid("created_by_id")
 			.notNull()
 			.references(() => users.id),
+		membersCanCreateRequests: boolean("members_can_create_requests").default(false).notNull(),
+		membersCanCreateEvents: boolean("members_can_create_events").default(false).notNull(),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 	},


### PR DESCRIPTION
## Summary

Adds two per-group settings that let admins optionally allow regular members to create availability requests and events. Closes #32.

## Changes

### Schema
- Added `members_can_create_requests` (boolean, default false) to `groups` table
- Added `members_can_create_events` (boolean, default false) to `groups` table
- Migration: `drizzle/0003_sturdy_shen.sql`

### Service Layer (`groups.server.ts`)
- `updateGroupPermissions()` — updates the new boolean columns
- `requireGroupAdminOrPermission(request, groupId, permission)` — new auth helper that allows admin OR member with the specified permission enabled. Does NOT modify existing `requireGroupAdmin`.
- `getUserGroups()` — now includes the new columns in its select

### Settings UI (`groups.$groupId.settings.tsx`)
- New "Member Permissions" card with two checkboxes
- Handles `intent === "update-permissions"` action

### Route Guards
- `availability.new.tsx` — loader/action use `requireGroupAdminOrPermission(..., "membersCanCreateRequests")`
- `events.new.tsx` — loader/action use `requireGroupAdminOrPermission(..., "membersCanCreateEvents")`

### UI Visibility
- `availability._index.tsx` — "New Request" button shows when `canCreateRequests` (admin or permission enabled)
- `events._index.tsx` — "Create Event" button shows when `canCreateEvents` (admin or permission enabled)

### Tests (5 new)
- Admin always allowed regardless of setting
- Member allowed when permission enabled
- Member blocked (403) when permission disabled
- Non-member blocked (404)
- Both permission types tested independently

## Backwards Compatibility
- Default `false` — existing groups stay admin-only
- `requireGroupAdmin` is NOT modified — new helper is additive

## Quality Gates
- ✅ TypeScript strict mode (`pnpm run typecheck`)
- ✅ Biome lint (`pnpm run lint`)
- ✅ Production build (`pnpm run build`)
- ✅ All 97 tests pass (`pnpm test`)

## Post-Deploy
Run migration on production:
```bash
DATABASE_URL="..." pnpm run db:migrate
```