### PR TITLE
fix: await verification email send

### DIFF
--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -122,7 +122,7 @@ This link expires in 24 hours. If you didn't create an account, you can safely i
 
 	const text = `Verify your email for My Call Time: ${options.verificationUrl}. This link expires in 24 hours.`;
 
-	void sendEmail({
+	await sendEmail({
 		to: options.email,
 		subject: "Verify your email — My Call Time",
 		html,


### PR DESCRIPTION
Verification emails weren't being delivered because `void sendEmail()` (fire-and-forget) gets killed before the async email operation completes in the container. Changed to `await sendEmail()` since users can't proceed without it.