### PR TITLE
fix: await sendVerificationEmail in route callers

### DIFF
--- a/app/routes/check-email.tsx
+++ b/app/routes/check-email.tsx
@@ -45,7 +45,7 @@ export async function action({ request }: ActionFunctionArgs) {
 	const appUrl = process.env.APP_URL ?? "http://localhost:5173";
 	const token = await generateVerificationToken(userId);
 
-	sendVerificationEmail({
+	await sendVerificationEmail({
 		email,
 		name: "there",
 		verificationUrl: `${appUrl}/verify-email?token=${token}`,

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -77,7 +77,7 @@ export async function action({ request }: ActionFunctionArgs) {
 		// Generate verification token and send email
 		const appUrl = process.env.APP_URL ?? "http://localhost:5173";
 		const token = await generateVerificationToken(user.id);
-		sendVerificationEmail({
+		await sendVerificationEmail({
 			email: user.email,
 			name: user.name,
 			verificationUrl: `${appUrl}/verify-email?token=${token}`,


### PR DESCRIPTION
## Problem

PR #37 fixed `sendVerificationEmail()` to internally `await sendEmail()` instead of `void sendEmail()`. However, the **callers** of `sendVerificationEmail()` in two routes still called it without `await`:

- `app/routes/signup.tsx:80` — `sendVerificationEmail({...})` (no await)
- `app/routes/check-email.tsx:48` — `sendVerificationEmail({...})` (no await)

This means the verification email was **still** a floating promise from the route action's perspective — the HTTP response was sent before the email operation completed.

## Fix

Added `await` to both callers so the verification email completes before the response is sent.

## Safety Analysis

- `sendEmail()` has a try/catch that catches all errors and returns `{ success: false }` — **never throws**
- `sendVerificationEmail()` doesn't check the return value — always resolves normally
- Adding `await` won't cause signup to fail if the email service is down
- Trade-off: user waits ~2-3s for email send before redirect. Acceptable for verification emails.

## Other fire-and-forget emails (unchanged)

The other `void sendEmail()` calls for notifications (availability, events) are correctly fire-and-forget — they're post-action notifications where the user has already completed their action.