### PR TITLE
fix: enforce email verification + fix email delivery

### DIFF
--- a/app/services/auth.server.test.ts
+++ b/app/services/auth.server.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock session to control userId
+vi.mock("~/services/session.server", () => ({
+	getUserId: vi.fn(),
+	getSession: vi.fn(),
+	sessionStorage: { commitSession: vi.fn() },
+}));
+
+// Mock DB — control query results
+const mockLimit = vi.fn();
+const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+vi.mock("../../src/db/index.js", () => ({
+	db: {
+		select: (...args: unknown[]) => mockSelect(...args),
+	},
+}));
+
+import { getUserId } from "~/services/session.server";
+import { requireUser } from "./auth.server";
+
+// Helper to make a verified user DB record
+function makeUserRecord(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test",
+		passwordHash: "$2a$12$hash",
+		profileImage: null,
+		googleId: null,
+		emailVerified: true,
+		emailVerificationToken: null,
+		emailVerificationExpiry: null,
+		timezone: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	};
+}
+
+// The AuthUser shape returned by requireUser
+function expectedAuthUser(record: ReturnType<typeof makeUserRecord>) {
+	return {
+		id: record.id,
+		email: record.email,
+		name: record.name,
+		profileImage: record.profileImage,
+		timezone: record.timezone,
+	};
+}
+
+describe("requireUser", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function setupDbResponses(...results: unknown[][]) {
+		// Each call to db.select()...from()...where()...limit() returns the next result
+		for (let i = 0; i < results.length; i++) {
+			const limitFn = vi.fn().mockResolvedValue(results[i]);
+			const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+			const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+			if (i === 0) {
+				mockSelect.mockReturnValueOnce({ from: fromFn });
+			} else {
+				mockSelect.mockReturnValueOnce({ from: fromFn });
+			}
+		}
+	}
+
+	it("redirects to /login when no userId in session", async () => {
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+		try {
+			await requireUser(new Request("http://localhost/dashboard"));
+			expect.fail("Should have thrown a redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/login");
+		}
+	});
+
+	it("redirects to /login when user not found in DB", async () => {
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("nonexistent-id");
+		setupDbResponses([]); // getUserById returns no results
+
+		try {
+			await requireUser(new Request("http://localhost/dashboard"));
+			expect.fail("Should have thrown a redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/login");
+		}
+	});
+
+	it("redirects unverified user from /dashboard to /check-email", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		// First call: getUserById, second call: isEmailVerified
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		try {
+			await requireUser(new Request("http://localhost/dashboard"));
+			expect.fail("Should have thrown a redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/check-email");
+		}
+	});
+
+	it("redirects unverified user from /groups to /check-email", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		try {
+			await requireUser(new Request("http://localhost/groups"));
+			expect.fail("Should have thrown a redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/check-email");
+		}
+	});
+
+	it("allows unverified user on /check-email", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		const result = await requireUser(new Request("http://localhost/check-email"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+
+	it("allows unverified user on /verify-email", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		const result = await requireUser(new Request("http://localhost/verify-email?token=abc123"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+
+	it("allows unverified user on /logout", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		const result = await requireUser(new Request("http://localhost/logout"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+
+	it("allows unverified user on /settings", async () => {
+		const record = makeUserRecord({ emailVerified: false });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		setupDbResponses([record], [{ emailVerified: false }]);
+
+		const result = await requireUser(new Request("http://localhost/settings"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+
+	it("allows verified user on any path", async () => {
+		const record = makeUserRecord({ emailVerified: true });
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
+		// isEmailVerified returns true — only one extra DB call
+		setupDbResponses([record], [{ emailVerified: true }]);
+
+		const result = await requireUser(new Request("http://localhost/dashboard"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+
+	it("allows verified Google OAuth user on any path", async () => {
+		const record = makeUserRecord({
+			id: "user-2",
+			email: "google@example.com",
+			name: "Google User",
+			profileImage: "https://example.com/photo.jpg",
+			googleId: "google-123",
+			emailVerified: true,
+			timezone: "America/Los_Angeles",
+		});
+		(getUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-2");
+		setupDbResponses([record], [{ emailVerified: true }]);
+
+		const result = await requireUser(new Request("http://localhost/groups/some-id/events"));
+		expect(result).toEqual(expectedAuthUser(record));
+	});
+});

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -136,7 +136,7 @@ export async function sendVerificationEmail(options: {
 
 	const result = await sendEmail({
 		to: options.email,
-		subject: "Verify your email — My Call Time",
+		subject: "Verify your email - My Call Time",
 		html,
 		text,
 	});


### PR DESCRIPTION
## Summary

Fixes two critical security/reliability issues:

### Bug 1: Email verification enforcement (SECURITY)

**Problem:** After signup, unverified users could navigate directly to `/dashboard` or any protected route and use the app fully. The `emailVerified` field was never checked on protected routes.

**Fix:** Added email verification check in `requireUser()` — the single chokepoint called by every protected route (directly or via `requireGroupMember`/`requireGroupAdmin`). Unverified users are now redirected to `/check-email`.

**Exempt paths** (accessible without verification):
- `/check-email` — verification prompt page
- `/verify-email` — processes verification token
- `/logout` — must always work
- `/settings` — timezone auto-detection on first visit

**Path matching** uses exact match + prefix (`pathname === path || pathname.startsWith(path + "/")`) to prevent bypass via similarly-named routes.

Google OAuth users are unaffected — they are auto-verified (`emailVerified: true`) during `findOrCreateGoogleUser()`.

### Bug 2: Email delivery

**Problem:** Verification emails with em-dash (—, U+2014) in the subject line may be flagged or rejected by email providers.

**Fix:** Changed subject from `"Verify your email — My Call Time"` to `"Verify your email - My Call Time"` (ASCII hyphen).

## Testing

- 10 new unit tests covering all `requireUser()` verification scenarios
- All 116 tests pass
- Typecheck, lint, build all green

## Changes
- `app/services/auth.server.ts` — verification enforcement in `requireUser()`
- `app/services/auth.server.test.ts` — 10 new tests (NEW)
- `app/services/email.server.ts` — subject line fix