### PR TITLE
fix: pass normalized invite code to joinGroup()

### DIFF
--- a/app/routes/groups._index.tsx
+++ b/app/routes/groups._index.tsx
@@ -47,7 +47,7 @@ export async function action({ request }: ActionFunctionArgs) {
 		if (!/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/.test(codeStr)) {
 			return { error: "Invalid invite code format. Codes are 8 characters.", intent: "join" };
 		}
-		const result = await joinGroup(user.id, code);
+		const result = await joinGroup(user.id, codeStr);
 		if (!result.success) {
 			return { error: result.error, intent: "join" };
 		}

--- a/app/routes/groups.join.tsx
+++ b/app/routes/groups.join.tsx
@@ -29,8 +29,7 @@ export async function action({ request }: ActionFunctionArgs) {
 		return { error: "Invalid invite code format. Codes are 8 characters." };
 	}
 
-	const result = await joinGroup(user.id, code);
-
+	const result = await joinGroup(user.id, codeStr);
 	if (!result.success) {
 		if (result.groupId) {
 			return redirect(`/groups/${result.groupId}`);


### PR DESCRIPTION
Bug found during code review of #45.

The invite code format validation normalizes input (trim + uppercase) but the original unnormalized value was being passed to `joinGroup()`. This could cause lookup failures for lowercase or whitespace-padded codes.

**Changes:**
- `groups.join.tsx`: Pass `codeStr` instead of `code` to `joinGroup()`
- `groups._index.tsx`: Same fix for inline join form