### PR TITLE
fix: timezone-aware event times and robust availability time validation

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.edit.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.edit.test.ts
@@ -17,6 +17,7 @@ vi.mock("~/services/groups.server", () => ({
 		email: "test@example.com",
 		name: "Test User",
 		profileImage: null,
+		timezone: "America/New_York",
 	}),
 	getGroupWithMembers: vi.fn().mockResolvedValue({
 		group: { id: "g1", name: "Test Group" },
@@ -43,6 +44,7 @@ describe("event edit action — IDOR prevention", () => {
 			email: "test@example.com",
 			name: "Test User",
 			profileImage: null,
+			timezone: "America/New_York",
 		});
 	});
 
@@ -168,6 +170,7 @@ describe("event edit action — validation", () => {
 			email: "test@example.com",
 			name: "Test User",
 			profileImage: null,
+			timezone: "America/New_York",
 		});
 		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
 			event: { id: "event-1", groupId: "g1", title: "My Event" },

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -23,7 +23,7 @@ import {
 	X,
 } from "lucide-react";
 import { useState } from "react";
-import { formatDateLong, formatTime } from "~/lib/date-utils";
+import { formatDateLong, formatTime, utcToLocalParts } from "~/lib/date-utils";
 import {
 	assignToEvent,
 	bulkAssignToEvent,
@@ -67,8 +67,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			// Verify the availability request belongs to this group before exposing its data
 			const requestGroupId = await getAvailabilityRequestGroupId(data.event.createdFromRequestId);
 			if (requestGroupId === groupId) {
-				const eventDate = new Date(data.event.startTime);
-				const dateKey = `${eventDate.getFullYear()}-${String(eventDate.getMonth() + 1).padStart(2, "0")}-${String(eventDate.getDate()).padStart(2, "0")}`;
+				const dateKey = utcToLocalParts(new Date(data.event.startTime), user.timezone).date;
 				availabilityData = await getAvailabilityForEventDate(
 					data.event.createdFromRequestId,
 					dateKey,

--- a/app/routes/groups.$groupId.events.new.test.ts
+++ b/app/routes/groups.$groupId.events.new.test.ts
@@ -16,6 +16,7 @@ vi.mock("~/services/groups.server", () => ({
 		email: "test@example.com",
 		name: "Test User",
 		profileImage: null,
+		timezone: "America/New_York",
 	}),
 	getGroupWithMembers: vi.fn().mockResolvedValue({
 		group: { id: "g1", name: "Test Group" },

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -11,7 +11,7 @@ import {
 import { ArrowLeft, Clock, Users } from "lucide-react";
 import { useState } from "react";
 import { InlineTimezoneSelector } from "~/components/timezone-selector";
-import { formatEventTime } from "~/lib/date-utils";
+import { formatEventTime, localTimeToUTC } from "~/lib/date-utils";
 import { getAvailabilityRequest } from "~/services/availability.server";
 import {
 	sendEventCreatedNotification,
@@ -110,13 +110,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		title: title.trim(),
 		description: typeof description === "string" ? description.trim() || undefined : undefined,
 		eventType: eventType as "rehearsal" | "show" | "other",
-		startTime: new Date(`${date}T${startTime}:00`),
-		endTime: new Date(`${date}T${endTime}:00`),
+		startTime: localTimeToUTC(date, startTime, user.timezone),
+		endTime: localTimeToUTC(date, endTime, user.timezone),
 		location: typeof location === "string" ? location.trim() || undefined : undefined,
 		createdById: user.id,
 		createdFromRequestId:
 			typeof fromRequestId === "string" && fromRequestId ? fromRequestId : undefined,
-		callTime: hasCallTime ? new Date(`${date}T${callTime}:00`) : undefined,
+		callTime: hasCallTime ? localTimeToUTC(date, callTime.trim(), user.timezone) : undefined,
 	});
 
 	// Assign performers for show events

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -9,6 +9,7 @@ import {
 	groups,
 	users,
 } from "../../src/db/schema.js";
+import { localTimeToUTC } from "../lib/date-utils.js";
 
 type Event = typeof events.$inferSelect;
 
@@ -54,12 +55,13 @@ export async function createEventsFromAvailability(data: {
 	location?: string;
 	createdById: string;
 	autoAssignAvailable?: boolean;
+	timezone?: string | null;
 }): Promise<Event[]> {
 	const createdEvents: Event[] = [];
 
 	for (const dateInfo of data.dates) {
-		const startTime = new Date(`${dateInfo.date}T${dateInfo.startTime}:00`);
-		const endTime = new Date(`${dateInfo.date}T${dateInfo.endTime}:00`);
+		const startTime = localTimeToUTC(dateInfo.date, dateInfo.startTime, data.timezone);
+		const endTime = localTimeToUTC(dateInfo.date, dateInfo.endTime, data.timezone);
 
 		const event = await createEvent({
 			groupId: data.groupId,


### PR DESCRIPTION
## Summary

Fixes two bugs the CEO found while using the app:

### Bug 1: Availability request time fields fail validation
**Problem:** The optional time range fields on the availability request creation form could fail validation with browsers that default `<input type="time">` to "00:00" instead of empty string.

**Fix:** Replaced truthy-check validation with regex-based HH:MM format validation. Invalid or empty time values are now treated as "not specified" (all-day request). This handles all browser edge cases.

### Bug 2: Event time offset — 7PM LA becomes 12PM
**Problem:** When creating an event and selecting 7:00 PM with LA timezone, the event showed 12:00 PM. The server (UTC) was interpreting `new Date("2026-03-15T19:00:00")` as 19:00 UTC, but it should be 19:00 in the user's timezone.

**Fix:** Added `localTimeToUTC()` and `utcToLocalParts()` utilities to `app/lib/date-utils.ts`:
- `localTimeToUTC`: Converts local date/time + IANA timezone to UTC Date using iterative refinement (handles DST transitions)
- `utcToLocalParts`: Converts UTC Date back to local date/time strings for form prefilling

Updated all event date construction code (create, edit, batch) and the edit page prefill to use timezone-aware conversion.

## Files Changed (10)
- `app/lib/date-utils.ts` — Added `localTimeToUTC`, `utcToLocalParts` utilities
- `app/routes/groups.$groupId.events.new.tsx` — Timezone-aware event creation
- `app/routes/groups.$groupId.events.$eventId.edit.tsx` — Timezone-aware edit (loader + action)
- `app/routes/groups.$groupId.events.$eventId.tsx` — Timezone-aware dateKey for availability lookup
- `app/routes/groups.$groupId.availability.new.tsx` — Robust time field validation
- `app/services/events.server.ts` — Added timezone param to `createEventsFromAvailability`
- Test files: 4 updated with new test cases (168 tests total, all passing)

## Testing
- ✅ 168 unit tests passing (including 13 new tests)
- ✅ TypeScript strict mode — no errors
- ✅ Biome lint — clean (only pre-existing warning)
- ✅ Production build — succeeds
- ✅ Timezone conversion verified for: PDT, PST, EDT, UTC, JST
- ✅ DST spring-forward and fall-back edge cases tested