### PR TITLE
Enforce Content-Security-Policy (switch from report-only)

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -17,7 +17,7 @@ function setSecurityHeaders(responseHeaders: Headers) {
 	responseHeaders.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
 	responseHeaders.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
 	responseHeaders.set(
-		"Content-Security-Policy-Report-Only",
+		"Content-Security-Policy",
 		"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
 	);
 }

--- a/app/services/security-headers.test.ts
+++ b/app/services/security-headers.test.ts
@@ -16,7 +16,7 @@ describe("security headers", () => {
 		headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
 		headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
 		headers.set(
-			"Content-Security-Policy-Report-Only",
+			"Content-Security-Policy",
 			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
 		);
 
@@ -25,7 +25,7 @@ describe("security headers", () => {
 		expect(headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
 		expect(headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
 		expect(headers.get("Strict-Transport-Security")).toBe("max-age=31536000; includeSubDomains");
-		expect(headers.get("Content-Security-Policy-Report-Only")).toContain("default-src 'self'");
-		expect(headers.get("Content-Security-Policy-Report-Only")).toContain("frame-ancestors 'none'");
+		expect(headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+		expect(headers.get("Content-Security-Policy")).toContain("frame-ancestors 'none'");
 	});
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: "pnpm run dev -- --port 5176",
+		command: "pnpm run dev --port 5176",
 		port: 5176,
 		reuseExistingServer: !process.env.CI,
 		timeout: 60_000,


### PR DESCRIPTION
## What

Switch `Content-Security-Policy-Report-Only` to `Content-Security-Policy` to actively block policy violations instead of just logging them.

## Changes

- **`app/entry.server.tsx`**: Changed header from `Content-Security-Policy-Report-Only` to `Content-Security-Policy`. Policy directives unchanged:
  - `default-src 'self'`
  - `script-src 'self' 'unsafe-inline'` (Remix hydration)
  - `style-src 'self' 'unsafe-inline'` (Tailwind)
  - `img-src 'self' data:` (emoji favicons)
  - `font-src 'self'`, `connect-src 'self'`, `frame-ancestors 'none'`

- **`app/services/security-headers.test.ts`**: Updated test assertions to check `Content-Security-Policy` instead of `Content-Security-Policy-Report-Only`

- **`playwright.config.ts`**: Fixed webServer command — removed extra `--` before `--port` that prevented dev server from starting

## Testing

- ✅ TypeScript typecheck passes
- ✅ Biome lint passes
- ✅ Production build succeeds
- ✅ 168 unit tests pass (24 files)
- ✅ 74 Playwright E2E tests pass across Desktop Chrome, Mobile Safari, Mobile Chrome — no CSP violations