### PR TITLE
fix: disable Oryx CLI telemetry in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,4 @@ jobs:
           containerAppName: greenroom
           resourceGroup: ${{ secrets.AZURE_RESOURCE_GROUP }}
           imageToDeploy: ${{ secrets.ACR_LOGIN_SERVER }}/greenroom:${{ github.sha }}
+          disableTelemetry: true


### PR DESCRIPTION
Disable Oryx CLI telemetry to prevent confusing secondary errors on deploy failures.