### PR TITLE
feat: add editable display name on settings page

### DIFF
--- a/app/routes/settings.test.ts
+++ b/app/routes/settings.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock auth service
+vi.mock("~/services/auth.server", () => ({
+	requireUser: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+		timezone: "America/New_York",
+	}),
+	updateUserTimezone: vi.fn().mockResolvedValue(undefined),
+	updateUserName: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock CSRF validation — allow all by default
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { action, loader } from "~/routes/settings";
+import { requireUser, updateUserName, updateUserTimezone } from "~/services/auth.server";
+
+function makeFormData(data: Record<string, string>): FormData {
+	const formData = new FormData();
+	for (const [key, value] of Object.entries(data)) {
+		formData.set(key, value);
+	}
+	return formData;
+}
+
+function makeRequest(formData: FormData): Request {
+	return new Request("http://localhost/settings", {
+		method: "POST",
+		body: formData,
+	});
+}
+
+describe("settings route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+			timezone: "America/New_York",
+		});
+	});
+
+	describe("loader", () => {
+		it("returns the authenticated user", async () => {
+			const request = new Request("http://localhost/settings");
+			const result = await loader({ request, params: {}, context: {} });
+			expect(result).toEqual({
+				user: {
+					id: "user-1",
+					email: "test@example.com",
+					name: "Test User",
+					profileImage: null,
+					timezone: "America/New_York",
+				},
+			});
+		});
+	});
+
+	describe("action — update-name", () => {
+		it("updates the display name", async () => {
+			const formData = makeFormData({ intent: "update-name", name: "New Name" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ success: true, message: "Display name updated!" });
+			expect(updateUserName).toHaveBeenCalledWith("user-1", "New Name");
+		});
+
+		it("trims whitespace from the name", async () => {
+			const formData = makeFormData({ intent: "update-name", name: "  Trimmed Name  " });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ success: true, message: "Display name updated!" });
+			expect(updateUserName).toHaveBeenCalledWith("user-1", "Trimmed Name");
+		});
+
+		it("rejects empty name", async () => {
+			const formData = makeFormData({ intent: "update-name", name: "" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Display name is required." });
+			expect(updateUserName).not.toHaveBeenCalled();
+		});
+
+		it("rejects whitespace-only name", async () => {
+			const formData = makeFormData({ intent: "update-name", name: "   " });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Display name is required." });
+			expect(updateUserName).not.toHaveBeenCalled();
+		});
+
+		it("rejects name exceeding 100 characters", async () => {
+			const longName = "A".repeat(101);
+			const formData = makeFormData({ intent: "update-name", name: longName });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Display name must be 100 characters or less." });
+			expect(updateUserName).not.toHaveBeenCalled();
+		});
+
+		it("accepts name of exactly 100 characters", async () => {
+			const exactName = "A".repeat(100);
+			const formData = makeFormData({ intent: "update-name", name: exactName });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ success: true, message: "Display name updated!" });
+			expect(updateUserName).toHaveBeenCalledWith("user-1", exactName);
+		});
+
+		it("rejects missing name field", async () => {
+			const formData = makeFormData({ intent: "update-name" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Display name is required." });
+			expect(updateUserName).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("action — update-timezone", () => {
+		it("updates the timezone", async () => {
+			const formData = makeFormData({
+				intent: "update-timezone",
+				timezone: "America/Los_Angeles",
+			});
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ success: true, message: "Timezone updated!" });
+			expect(updateUserTimezone).toHaveBeenCalledWith("user-1", "America/Los_Angeles");
+		});
+
+		it("rejects empty timezone", async () => {
+			const formData = makeFormData({ intent: "update-timezone", timezone: "" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Timezone is required." });
+		});
+	});
+
+	describe("action — invalid intent", () => {
+		it("returns error for unknown intent", async () => {
+			const formData = makeFormData({ intent: "unknown" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({ error: "Invalid action." });
+		});
+	});
+});

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -7,11 +7,11 @@ import {
 	useRouteLoaderData,
 	useSubmit,
 } from "@remix-run/react";
-import { Globe, Save } from "lucide-react";
+import { Globe, Save, User } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { COMMON_TIMEZONES, getTimezoneLabel } from "~/components/timezone-selector";
-import { requireUser, updateUserTimezone } from "~/services/auth.server";
+import { requireUser, updateUserName, updateUserTimezone } from "~/services/auth.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 
 export const meta: MetaFunction = () => {
@@ -28,6 +28,19 @@ export async function action({ request }: ActionFunctionArgs) {
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 	const intent = formData.get("intent");
+
+	if (intent === "update-name") {
+		const name = formData.get("name");
+		if (typeof name !== "string" || !name.trim()) {
+			return { error: "Display name is required." };
+		}
+		const trimmedName = name.trim();
+		if (trimmedName.length > 100) {
+			return { error: "Display name must be 100 characters or less." };
+		}
+		await updateUserName(user.id, trimmedName);
+		return { success: true, message: "Display name updated!" };
+	}
 
 	if (intent === "update-timezone") {
 		const timezone = formData.get("timezone");
@@ -90,8 +103,47 @@ export default function Settings() {
 				</div>
 			)}
 
-			{/* Timezone */}
+			{/* Display Name */}
 			<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+				<h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+					<User className="h-5 w-5 text-slate-400" />
+					Display Name
+				</h2>
+				<p className="mt-1 text-sm text-slate-600">
+					This is how your name appears to other group members.
+				</p>
+				<Form method="post" className="mt-4">
+					<CsrfInput />
+					<input type="hidden" name="intent" value="update-name" />
+					<div className="flex items-end gap-3">
+						<div className="flex-1">
+							<label htmlFor="name" className="block text-sm font-medium text-slate-700">
+								Your Name
+							</label>
+							<input
+								type="text"
+								id="name"
+								name="name"
+								defaultValue={user.name}
+								required
+								maxLength={100}
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							/>
+						</div>
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+						>
+							<Save className="h-4 w-4" />
+							{isSubmitting ? "Saving..." : "Save"}
+						</button>
+					</div>
+				</Form>
+			</div>
+
+			{/* Timezone */}
+			<div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
 				<h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
 					<Globe className="h-5 w-5 text-slate-400" />
 					Timezone
@@ -135,14 +187,10 @@ export default function Settings() {
 				</Form>
 			</div>
 
-			{/* Profile Info (read-only) */}
+			{/* Account Info (read-only) */}
 			<div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-				<h2 className="text-lg font-semibold text-slate-900">Profile</h2>
-				<dl className="mt-4 space-y-3">
-					<div className="flex justify-between">
-						<dt className="text-sm text-slate-500">Name</dt>
-						<dd className="text-sm font-medium text-slate-900">{user.name}</dd>
-					</div>
+				<h2 className="text-lg font-semibold text-slate-900">Account</h2>
+				<dl className="mt-4">
 					<div className="flex justify-between">
 						<dt className="text-sm text-slate-500">Email</dt>
 						<dd className="text-sm font-medium text-slate-900">{user.email}</dd>

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -301,6 +301,10 @@ export async function updateUserTimezone(userId: string, timezone: string): Prom
 	await db.update(users).set({ timezone, updatedAt: new Date() }).where(eq(users.id, userId));
 }
 
+export async function updateUserName(userId: string, name: string): Promise<void> {
+	await db.update(users).set({ name, updatedAt: new Date() }).where(eq(users.id, userId));
+}
+
 // --- Email Verification ---
 
 export async function generateVerificationToken(userId: string): Promise<string> {


### PR DESCRIPTION
## Summary

Adds the ability for users to change their display name on the settings page. Previously, if you signed up via Google OAuth, your name was pulled from Google with no way to change it.

## Changes

- **`app/services/auth.server.ts`**: Added `updateUserName(userId, name)` function (mirrors existing `updateUserTimezone`)
- **`app/routes/settings.tsx`**: 
  - Added Display Name form with text input pre-filled with current name
  - Added `intent="update-name"` action handler with validation (required, max 100 chars, trimmed)
  - CSRF protection via `CsrfInput` and `validateCsrfToken`
  - Success/error feedback using existing pattern
  - Moved email to a read-only Account section
- **`app/routes/settings.test.ts`**: 11 new tests covering loader, name update (happy path, trimming, empty, whitespace-only, too long, exactly 100 chars, missing field), timezone update, and invalid intent

## Quality Gates

- ✅ `pnpm run typecheck` — no errors
- ✅ `pnpm run lint` — passes (pre-existing warning in drizzle.config.ts only)
- ✅ `pnpm run build` — production build succeeds
- ✅ `pnpm test` — all 231 tests pass (11 new)