### PR TITLE
feat: delete groups (Part 3 of #64)

### DIFF
--- a/app/routes/groups.$groupId.settings.test.ts
+++ b/app/routes/groups.$groupId.settings.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock auth service
+vi.mock("~/services/auth.server", () => ({
+	requireUser: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+}));
+
+// Mock groups service
+vi.mock("~/services/groups.server", () => ({
+	requireGroupAdmin: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+	getGroupById: vi.fn().mockResolvedValue({
+		id: "g1",
+		name: "Cool Improv Team",
+		description: "A great team",
+		inviteCode: "ABC12345",
+		membersCanCreateRequests: false,
+		membersCanCreateEvents: false,
+	}),
+	deleteGroup: vi.fn().mockResolvedValue(undefined),
+	regenerateInviteCode: vi.fn().mockResolvedValue("NEWCODE1"),
+	updateGroup: vi.fn().mockResolvedValue({}),
+	updateGroupPermissions: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock CSRF validation — allow all by default
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { action } from "~/routes/groups.$groupId.settings";
+import { deleteGroup, getGroupById, requireGroupAdmin } from "~/services/groups.server";
+
+describe("group settings action — delete-group", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+		});
+		(getGroupById as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "g1",
+			name: "Cool Improv Team",
+			description: "A great team",
+			inviteCode: "ABC12345",
+			membersCanCreateRequests: false,
+			membersCanCreateEvents: false,
+		});
+	});
+
+	function makeDeleteRequest(confirmName: string) {
+		const formData = new FormData();
+		formData.set("intent", "delete-group");
+		formData.set("confirmName", confirmName);
+		return new Request("http://localhost/groups/g1/settings", {
+			method: "POST",
+			body: formData,
+		});
+	}
+
+	it("deletes group when admin provides correct group name", async () => {
+		const result = await action({
+			request: makeDeleteRequest("Cool Improv Team"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(302);
+		expect((result as Response).headers.get("Location")).toBe("/dashboard");
+		expect(deleteGroup).toHaveBeenCalledWith("g1");
+	});
+
+	it("rejects deletion when group name does not match", async () => {
+		const result = await action({
+			request: makeDeleteRequest("Wrong Name"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Group name does not match. Please type the exact group name.",
+			success: false,
+		});
+		expect(deleteGroup).not.toHaveBeenCalled();
+	});
+
+	it("rejects deletion when confirm name is empty", async () => {
+		const result = await action({
+			request: makeDeleteRequest(""),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Group name does not match. Please type the exact group name.",
+			success: false,
+		});
+		expect(deleteGroup).not.toHaveBeenCalled();
+	});
+
+	it("rejects non-admin users (403)", async () => {
+		(requireGroupAdmin as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Response("Forbidden", { status: 403 }),
+		);
+
+		try {
+			await action({
+				request: makeDeleteRequest("Cool Improv Team"),
+				params: { groupId: "g1" },
+				context: {},
+			});
+			expect.fail("Should have thrown 403");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(403);
+		}
+
+		expect(deleteGroup).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 when group does not exist", async () => {
+		(getGroupById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+		try {
+			await action({
+				request: makeDeleteRequest("Cool Improv Team"),
+				params: { groupId: "g1" },
+				context: {},
+			});
+			expect.fail("Should have thrown 404");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(404);
+		}
+
+		expect(deleteGroup).not.toHaveBeenCalled();
+	});
+
+	it("is case-sensitive for group name confirmation", async () => {
+		const result = await action({
+			request: makeDeleteRequest("cool improv team"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Group name does not match. Please type the exact group name.",
+			success: false,
+		});
+		expect(deleteGroup).not.toHaveBeenCalled();
+	});
+});

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -212,6 +212,11 @@ export async function removeMember(groupId: string, userId: string): Promise<voi
 		.where(and(eq(groupMemberships.groupId, groupId), eq(groupMemberships.userId, userId)));
 }
 
+export async function deleteGroup(groupId: string): Promise<void> {
+	await db.delete(groups).where(eq(groups.id, groupId));
+	// FK cascades handle: memberships, availability requests (→ responses), events (→ assignments)
+}
+
 export async function updateGroup(
 	groupId: string,
 	data: { name?: string; description?: string },


### PR DESCRIPTION
## Summary

Implements Part 3 of #64: Delete Groups.

Adds the ability for group admins to permanently delete a group from the settings page, with a confirmation flow that requires typing the exact group name.

### Changes

**Service layer** (`app/services/groups.server.ts`):
- New `deleteGroup(groupId)` function -- single DELETE statement, FK cascades handle all dependent data (memberships, availability requests, responses, events, assignments)

**Route** (`app/routes/groups.$groupId.settings.tsx`):
- New `intent === delete-group` action handler
- Server-side validation: typed group name must exactly match group.name
- CSRF token validated
- requireGroupAdmin() enforced
- Redirects to /dashboard after deletion

**UI** -- Danger Zone section at the bottom of settings:
- Red-bordered section separated from the rest
- Warning text about permanent data loss
- Text input that must match group name to enable delete button
- Client-side name matching + server-side validation

### Tests (8 new tests)

**Service tests** (groups.server.test.ts):
- deleteGroup calls db.delete correctly
- Database errors propagate

**Route action tests** (groups.$groupId.settings.test.ts):
- Admin can delete with correct group name (302 redirect to /dashboard)
- Wrong group name (error, no deletion)
- Empty group name (error, no deletion)
- Non-admin (403, no deletion)
- Missing group (404, no deletion)
- Case-sensitive name matching

### Quality Gates
- TypeScript strict mode (pnpm run typecheck)
- Biome lint (pnpm run lint)
- Production build (pnpm run build)
- All 259 tests pass (pnpm test)