### PR TITLE
fix: add notificationPreferences to group membership inserts

### DIFF
--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -49,6 +49,7 @@ export async function createGroup(
 					groupId: group.id,
 					userId,
 					role: "admin",
+					notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES,
 				});
 
 				return group;
@@ -153,6 +154,7 @@ export async function joinGroup(
 		groupId: group.id,
 		userId,
 		role: "member",
+		notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES,
 	});
 
 	return { success: true, groupId: group.id };


### PR DESCRIPTION
## Bug Fix

**Problem:** Creating or joining a group fails because the `notificationPreferences` JSONB column on `group_memberships` is `NOT NULL`, but the Drizzle ORM insert statements in `createGroup` and `joinGroup` didn't provide the value.

**Fix:** Added `notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES` to both insert statements in `app/services/groups.server.ts`.

**Verified:** typecheck ✅ lint ✅ build ✅ 268/268 tests pass ✅