### PR TITLE
fix: allow logged-in users to see landing page

### DIFF
--- a/app/routes/_index.test.ts
+++ b/app/routes/_index.test.ts
@@ -1,15 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("~/services/auth.server", () => ({
-	getOptionalUser: vi.fn(),
-}));
-
 vi.mock("~/services/logger.server", () => ({
 	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 
 import { loader } from "~/routes/_index";
-import { getOptionalUser } from "~/services/auth.server";
 
 describe("GET /", () => {
 	afterEach(() => {
@@ -18,37 +13,26 @@ describe("GET /", () => {
 	});
 
 	it("returns supportUrl when SUPPORT_URL is set", async () => {
-		(getOptionalUser as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 		process.env.SUPPORT_URL = "https://www.paypal.me/TestUser";
 
-		const request = new Request("http://localhost:5173/");
-		const response = await loader({ request, params: {}, context: {} });
+		const response = loader();
 		const data = await response.json();
 
 		expect(data.supportUrl).toBe("https://www.paypal.me/TestUser");
 	});
 
 	it("returns supportUrl as null when SUPPORT_URL is not set", async () => {
-		(getOptionalUser as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-
-		const request = new Request("http://localhost:5173/");
-		const response = await loader({ request, params: {}, context: {} });
+		const response = loader();
 		const data = await response.json();
 
 		expect(data.supportUrl).toBeNull();
 	});
 
-	it("redirects authenticated users to /dashboard", async () => {
-		(getOptionalUser as ReturnType<typeof vi.fn>).mockResolvedValue({
-			id: "user-1",
-			name: "Test",
-			email: "test@example.com",
-		});
+	it("does not redirect authenticated users", async () => {
+		const response = loader();
+		const data = await response.json();
 
-		const request = new Request("http://localhost:5173/");
-
-		await expect(loader({ request, params: {}, context: {} })).rejects.toEqual(
-			expect.objectContaining({ status: 302 }),
-		);
+		expect(response.status).toBe(200);
+		expect(data.supportUrl).toBeNull();
 	});
 });

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,8 +1,6 @@
-import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/node";
 import { Link, useRouteLoaderData } from "@remix-run/react";
 import type { loader as rootLoader } from "~/root";
-import { getOptionalUser } from "~/services/auth.server";
 
 export const meta: MetaFunction = () => {
 	return [
@@ -22,9 +20,7 @@ export const meta: MetaFunction = () => {
 	];
 };
 
-export async function loader({ request }: LoaderFunctionArgs) {
-	const user = await getOptionalUser(request);
-	if (user) throw redirect("/dashboard");
+export function loader() {
 	const supportUrl = process.env.SUPPORT_URL || null;
 	return Response.json({ supportUrl });
 }
@@ -58,6 +54,7 @@ const features = [
 export default function Index() {
 	const rootData = useRouteLoaderData<typeof rootLoader>("root");
 	const supportUrl = rootData?.supportUrl;
+	const user = rootData?.user;
 	return (
 		<div>
 			{/* Hero */}
@@ -77,18 +74,29 @@ export default function Index() {
 						finding availability, and managing shows effortless.
 					</p>
 					<div className="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
-						<Link
-							to="/signup"
-							className="rounded-xl bg-emerald-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/25 transition-all hover:bg-emerald-700 hover:shadow-xl hover:shadow-emerald-600/30"
-						>
-							Get Started Free
-						</Link>
-						<Link
-							to="/login"
-							className="rounded-xl border-2 border-slate-300 px-8 py-3.5 text-base font-semibold text-slate-700 transition-all hover:border-slate-400 hover:bg-slate-50"
-						>
-							Sign In
-						</Link>
+						{user ? (
+							<Link
+								to="/dashboard"
+								className="rounded-xl bg-emerald-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/25 transition-all hover:bg-emerald-700 hover:shadow-xl hover:shadow-emerald-600/30"
+							>
+								Go to Dashboard
+							</Link>
+						) : (
+							<>
+								<Link
+									to="/signup"
+									className="rounded-xl bg-emerald-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/25 transition-all hover:bg-emerald-700 hover:shadow-xl hover:shadow-emerald-600/30"
+								>
+									Get Started Free
+								</Link>
+								<Link
+									to="/login"
+									className="rounded-xl border-2 border-slate-300 px-8 py-3.5 text-base font-semibold text-slate-700 transition-all hover:border-slate-400 hover:bg-slate-50"
+								>
+									Sign In
+								</Link>
+							</>
+						)}
 					</div>
 				</div>
 			</section>


### PR DESCRIPTION
## Summary

Remove the redirect to `/dashboard` for authenticated users on the landing page (`/`), so the URL can be shared with anyone.

## Changes

- **`app/routes/_index.tsx`**: Removed the `getOptionalUser` + redirect logic from the loader. Simplified loader to a sync function that only returns `supportUrl`. The component now reads `user` from the root loader data and conditionally renders:
  - Logged-in users: single "Go to Dashboard" CTA button
  - Logged-out users: "Get Started Free" + "Sign In" buttons (unchanged)

- **`app/routes/_index.test.ts`**: Removed the auth mock and request plumbing since the loader no longer needs them. Replaced the "redirects authenticated users" test with a "does not redirect authenticated users" test confirming 200 status.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅  
- `pnpm run build` ✅
- `pnpm test` ✅ (268/268 pass)