### PR TITLE
feat: account deletion with ownership transfer (GDPR)

### DIFF
--- a/app/routes/login.test.ts
+++ b/app/routes/login.test.ts
@@ -8,6 +8,8 @@ vi.mock("~/services/auth.server", () => ({
 	createUserSession: vi.fn(),
 	getOptionalUser: vi.fn().mockResolvedValue(null),
 	isEmailVerified: vi.fn().mockResolvedValue(true),
+	getUserDeletedAt: vi.fn().mockResolvedValue(null),
+	reactivateAccount: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock rate limiting — allow all by default

--- a/app/routes/settings.delete-account.test.ts
+++ b/app/routes/settings.delete-account.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock auth service
+vi.mock("~/services/auth.server", () => ({
+	requireUser: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+		timezone: null,
+	}),
+}));
+
+// Mock account service
+vi.mock("~/services/account.server", () => ({
+	getAccountDeletionPreview: vi.fn().mockResolvedValue({
+		soleAdminGroups: [],
+		sharedAdminGroups: [],
+		memberOnlyGroups: [],
+		createdRequestCount: 0,
+		createdEventCount: 0,
+	}),
+	executeAccountDeletion: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock CSRF validation — allow all by default
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock logger
+vi.mock("~/services/logger.server", () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}));
+
+// Mock session service
+vi.mock("~/services/session.server", () => ({
+	destroyUserSession: vi.fn().mockImplementation(async (_request, redirectTo) => {
+		return new Response(null, {
+			status: 302,
+			headers: { Location: redirectTo },
+		});
+	}),
+}));
+
+import { action, loader } from "~/routes/settings.delete-account";
+import { executeAccountDeletion, getAccountDeletionPreview } from "~/services/account.server";
+import { requireUser } from "~/services/auth.server";
+import { destroyUserSession } from "~/services/session.server";
+
+describe("settings.delete-account loader", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("requires authentication", async () => {
+		(requireUser as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Response(null, { status: 302, headers: { Location: "/login" } }),
+		);
+
+		try {
+			await loader({
+				request: new Request("http://localhost/settings/delete-account"),
+				params: {},
+				context: {},
+			});
+			expect.fail("Should have thrown redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+		}
+	});
+
+	it("returns user and preview data", async () => {
+		const result = await loader({
+			request: new Request("http://localhost/settings/delete-account"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toHaveProperty("user");
+		expect(result).toHaveProperty("preview");
+		expect(result.user.email).toBe("test@example.com");
+		expect(getAccountDeletionPreview).toHaveBeenCalledWith("user-1");
+	});
+});
+
+describe("settings.delete-account action", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+			timezone: null,
+		});
+	});
+
+	function makeDeleteRequest(confirmEmail: string, decisions: string = "[]") {
+		const formData = new FormData();
+		formData.set("intent", "delete-account");
+		formData.set("confirmEmail", confirmEmail);
+		formData.set("decisions", decisions);
+		return new Request("http://localhost/settings/delete-account", {
+			method: "POST",
+			body: formData,
+		});
+	}
+
+	it("deletes account when email matches and no sole-admin groups", async () => {
+		const result = await action({
+			request: makeDeleteRequest("test@example.com"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(302);
+		expect((result as Response).headers.get("Location")).toBe("/");
+		expect(executeAccountDeletion).toHaveBeenCalledWith("user-1", []);
+		expect(destroyUserSession).toHaveBeenCalled();
+	});
+
+	it("rejects when email does not match", async () => {
+		const result = await action({
+			request: makeDeleteRequest("wrong@example.com"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Email does not match. Please type your exact email address.",
+		});
+		expect(executeAccountDeletion).not.toHaveBeenCalled();
+	});
+
+	it("email comparison is case-insensitive", async () => {
+		const result = await action({
+			request: makeDeleteRequest("TEST@EXAMPLE.COM"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect(executeAccountDeletion).toHaveBeenCalled();
+	});
+
+	it("rejects when sole-admin group has no decision", async () => {
+		(getAccountDeletionPreview as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			soleAdminGroups: [
+				{
+					groupId: "g1",
+					groupName: "My Group",
+					role: "admin",
+					isSoleAdmin: true,
+					memberCount: 3,
+					otherAdmins: [],
+					otherMembers: [{ id: "user-2", name: "Other" }],
+				},
+			],
+			sharedAdminGroups: [],
+			memberOnlyGroups: [],
+			createdRequestCount: 0,
+			createdEventCount: 0,
+		});
+
+		const result = await action({
+			request: makeDeleteRequest("test@example.com", "[]"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Please choose what to do with all groups where you are the only admin.",
+		});
+		expect(executeAccountDeletion).not.toHaveBeenCalled();
+	});
+
+	it("accepts transfer decision for sole-admin group", async () => {
+		(getAccountDeletionPreview as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			soleAdminGroups: [
+				{
+					groupId: "g1",
+					groupName: "My Group",
+					role: "admin",
+					isSoleAdmin: true,
+					memberCount: 3,
+					otherAdmins: [],
+					otherMembers: [{ id: "user-2", name: "Other" }],
+				},
+			],
+			sharedAdminGroups: [],
+			memberOnlyGroups: [],
+			createdRequestCount: 0,
+			createdEventCount: 0,
+		});
+
+		const decisions = JSON.stringify([{ action: "transfer", groupId: "g1", newAdminId: "user-2" }]);
+
+		const result = await action({
+			request: makeDeleteRequest("test@example.com", decisions),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect(executeAccountDeletion).toHaveBeenCalledWith("user-1", [
+			{ action: "transfer", groupId: "g1", newAdminId: "user-2" },
+		]);
+	});
+
+	it("accepts delete decision for sole-admin group", async () => {
+		(getAccountDeletionPreview as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			soleAdminGroups: [
+				{
+					groupId: "g1",
+					groupName: "My Group",
+					role: "admin",
+					isSoleAdmin: true,
+					memberCount: 1,
+					otherAdmins: [],
+					otherMembers: [],
+				},
+			],
+			sharedAdminGroups: [],
+			memberOnlyGroups: [],
+			createdRequestCount: 0,
+			createdEventCount: 0,
+		});
+
+		const decisions = JSON.stringify([{ action: "delete", groupId: "g1" }]);
+
+		const result = await action({
+			request: makeDeleteRequest("test@example.com", decisions),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect(executeAccountDeletion).toHaveBeenCalledWith("user-1", [
+			{ action: "delete", groupId: "g1" },
+		]);
+	});
+
+	it("rejects transfer to non-member", async () => {
+		(getAccountDeletionPreview as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			soleAdminGroups: [
+				{
+					groupId: "g1",
+					groupName: "My Group",
+					role: "admin",
+					isSoleAdmin: true,
+					memberCount: 3,
+					otherAdmins: [],
+					otherMembers: [{ id: "user-2", name: "Other" }],
+				},
+			],
+			sharedAdminGroups: [],
+			memberOnlyGroups: [],
+			createdRequestCount: 0,
+			createdEventCount: 0,
+		});
+
+		const decisions = JSON.stringify([
+			{ action: "transfer", groupId: "g1", newAdminId: "nonexistent-user" },
+		]);
+
+		const result = await action({
+			request: makeDeleteRequest("test@example.com", decisions),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Selected transfer target is not a member of the group.",
+		});
+		expect(executeAccountDeletion).not.toHaveBeenCalled();
+	});
+
+	it("rejects invalid intent", async () => {
+		const formData = new FormData();
+		formData.set("intent", "wrong");
+		const request = new Request("http://localhost/settings/delete-account", {
+			method: "POST",
+			body: formData,
+		});
+
+		const result = await action({ request, params: {}, context: {} });
+
+		expect(result).toEqual({ error: "Invalid action." });
+	});
+
+	it("handles execution failure gracefully", async () => {
+		(executeAccountDeletion as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("DB error"),
+		);
+
+		const result = await action({
+			request: makeDeleteRequest("test@example.com"),
+			params: {},
+			context: {},
+		});
+
+		expect(result).toEqual({
+			error: "Failed to delete account. Please try again.",
+		});
+	});
+
+	it("requires authentication", async () => {
+		(requireUser as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Response(null, { status: 302, headers: { Location: "/login" } }),
+		);
+
+		try {
+			await action({
+				request: makeDeleteRequest("test@example.com"),
+				params: {},
+				context: {},
+			});
+			expect.fail("Should have thrown redirect");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(302);
+		}
+
+		expect(executeAccountDeletion).not.toHaveBeenCalled();
+	});
+});

--- a/app/routes/settings.delete-account.tsx
+++ b/app/routes/settings.delete-account.tsx
@@ -1,0 +1,454 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { Form, Link, useActionData, useLoaderData, useNavigation } from "@remix-run/react";
+import { AlertTriangle, ArrowLeft, ArrowRight, Shield, Trash2, Users } from "lucide-react";
+import { useState } from "react";
+import { CsrfInput } from "~/components/csrf-input";
+import {
+	type AccountDeletionPreview,
+	executeAccountDeletion,
+	type GroupDecision,
+	getAccountDeletionPreview,
+} from "~/services/account.server";
+import { requireUser } from "~/services/auth.server";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { logger } from "~/services/logger.server";
+import { destroyUserSession } from "~/services/session.server";
+
+export const meta: MetaFunction = () => {
+	return [{ title: "Delete Account — My Call Time" }];
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+	const user = await requireUser(request);
+	const preview = await getAccountDeletionPreview(user.id);
+	return { user, preview };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+	const user = await requireUser(request);
+	const formData = await request.formData();
+	await validateCsrfToken(request, formData);
+	const intent = formData.get("intent");
+
+	if (intent !== "delete-account") {
+		return { error: "Invalid action." };
+	}
+
+	// Validate email confirmation
+	const confirmEmail = formData.get("confirmEmail");
+	if (typeof confirmEmail !== "string" || confirmEmail.toLowerCase() !== user.email.toLowerCase()) {
+		return { error: "Email does not match. Please type your exact email address." };
+	}
+
+	// Parse group decisions
+	const decisionsJson = formData.get("decisions");
+	let decisions: GroupDecision[] = [];
+	if (typeof decisionsJson === "string" && decisionsJson) {
+		try {
+			decisions = JSON.parse(decisionsJson);
+		} catch {
+			return { error: "Invalid group decisions." };
+		}
+	}
+
+	// Validate that all sole-admin groups have a decision
+	const preview = await getAccountDeletionPreview(user.id);
+	const soleAdminGroupIds = new Set(preview.soleAdminGroups.map((g) => g.groupId));
+	const decidedGroupIds = new Set(decisions.map((d) => d.groupId));
+
+	for (const groupId of soleAdminGroupIds) {
+		if (!decidedGroupIds.has(groupId)) {
+			return { error: "Please choose what to do with all groups where you are the only admin." };
+		}
+	}
+
+	// Validate transfer targets are actual group members
+	for (const decision of decisions) {
+		if (decision.action === "transfer") {
+			const group = preview.soleAdminGroups.find((g) => g.groupId === decision.groupId);
+			if (!group) {
+				return { error: `Invalid group: ${decision.groupId}` };
+			}
+			const validMemberIds = [
+				...group.otherMembers.map((m) => m.id),
+				...group.otherAdmins.map((m) => m.id),
+			];
+			if (!validMemberIds.includes(decision.newAdminId)) {
+				return { error: "Selected transfer target is not a member of the group." };
+			}
+		}
+	}
+
+	try {
+		await executeAccountDeletion(user.id, decisions);
+		logger.info({ userId: user.id }, "Account deletion executed successfully");
+		return destroyUserSession(request, "/");
+	} catch (error) {
+		logger.error(
+			{ err: error, userId: user.id, route: "settings.delete-account" },
+			"Account deletion failed",
+		);
+		return { error: "Failed to delete account. Please try again." };
+	}
+}
+
+export default function DeleteAccount() {
+	const { user, preview } = useLoaderData<typeof loader>();
+	const actionData = useActionData<typeof action>();
+	const navigation = useNavigation();
+	const isSubmitting = navigation.state === "submitting";
+
+	const [step, setStep] = useState<"decisions" | "confirm">("decisions");
+	const [confirmEmail, setConfirmEmail] = useState("");
+	const [decisions, setDecisions] = useState<Record<string, GroupDecision>>({});
+
+	const hasSoleAdminGroups = preview.soleAdminGroups.length > 0;
+
+	// Check if all sole-admin groups have decisions
+	const allDecisionsMade = preview.soleAdminGroups.every((g) => decisions[g.groupId]);
+
+	const canProceed = !hasSoleAdminGroups || allDecisionsMade;
+	const emailMatches = confirmEmail.toLowerCase() === user.email.toLowerCase();
+
+	function setGroupDecision(groupId: string, action: "transfer" | "delete", newAdminId?: string) {
+		setDecisions((prev) => ({
+			...prev,
+			[groupId]:
+				action === "transfer"
+					? { action: "transfer", groupId, newAdminId: newAdminId ?? "" }
+					: { action: "delete", groupId },
+		}));
+	}
+
+	function setTransferTarget(groupId: string, newAdminId: string) {
+		setDecisions((prev) => ({
+			...prev,
+			[groupId]: { action: "transfer", groupId, newAdminId },
+		}));
+	}
+
+	const decisionsArray = Object.values(decisions).filter(
+		(d) => d.action === "delete" || (d.action === "transfer" && d.newAdminId),
+	);
+
+	return (
+		<div className="mx-auto max-w-2xl">
+			<Link
+				to="/settings"
+				className="mb-6 inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				Back to Settings
+			</Link>
+
+			<div className="mb-6">
+				<h1 className="flex items-center gap-2 text-2xl font-bold text-red-600">
+					<AlertTriangle className="h-6 w-6" />
+					Delete Account
+				</h1>
+				<p className="mt-1 text-sm text-slate-600">
+					This will delete your account and remove you from all groups. You have 30 days to
+					reactivate by logging back in.
+				</p>
+			</div>
+
+			{actionData && "error" in actionData && (
+				<div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+					{actionData.error}
+				</div>
+			)}
+
+			{step === "decisions" && (
+				<div className="space-y-6">
+					{/* Summary of what will happen */}
+					<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+						<h2 className="text-lg font-semibold text-slate-900">What will happen</h2>
+						<ul className="mt-3 space-y-2 text-sm text-slate-600">
+							<li className="flex items-start gap-2">
+								<span className="mt-0.5 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400" />
+								Your account will be deactivated for 30 days, then permanently deleted
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="mt-0.5 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400" />
+								You will be removed from{" "}
+								{preview.soleAdminGroups.length +
+									preview.sharedAdminGroups.length +
+									preview.memberOnlyGroups.length}{" "}
+								group(s)
+							</li>
+							{preview.createdRequestCount > 0 && (
+								<li className="flex items-start gap-2">
+									<span className="mt-0.5 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400" />
+									{preview.createdRequestCount} availability request(s) you created will be
+									reassigned
+								</li>
+							)}
+							{preview.createdEventCount > 0 && (
+								<li className="flex items-start gap-2">
+									<span className="mt-0.5 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400" />
+									{preview.createdEventCount} event(s) you created will be reassigned
+								</li>
+							)}
+							<li className="flex items-start gap-2">
+								<span className="mt-0.5 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400" />
+								Your availability responses and event assignments will be removed
+							</li>
+						</ul>
+					</div>
+
+					{/* Sole admin groups — require decisions */}
+					{preview.soleAdminGroups.length > 0 && (
+						<div className="rounded-xl border border-amber-300 bg-white shadow-sm">
+							<div className="border-b border-amber-200 px-6 py-4">
+								<h2 className="flex items-center gap-2 text-lg font-semibold text-amber-700">
+									<Shield className="h-5 w-5" />
+									Groups where you are the only admin
+								</h2>
+								<p className="mt-1 text-sm text-slate-600">
+									These groups need your decision before deletion can proceed.
+								</p>
+							</div>
+							<div className="divide-y divide-slate-100">
+								{preview.soleAdminGroups.map((group) => (
+									<SoleAdminGroupDecision
+										key={group.groupId}
+										group={group}
+										decision={decisions[group.groupId]}
+										onDecision={(action, newAdminId) =>
+											setGroupDecision(group.groupId, action, newAdminId)
+										}
+										onTransferTargetChange={(newAdminId) =>
+											setTransferTarget(group.groupId, newAdminId)
+										}
+									/>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Shared admin groups */}
+					{preview.sharedAdminGroups.length > 0 && (
+						<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+							<h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+								<Users className="h-5 w-5 text-slate-400" />
+								Groups with other admins
+							</h2>
+							<p className="mt-1 text-sm text-slate-600">
+								Your admin role and created content will be reassigned to another admin.
+							</p>
+							<ul className="mt-3 space-y-1">
+								{preview.sharedAdminGroups.map((group) => (
+									<li key={group.groupId} className="text-sm text-slate-700">
+										{group.groupName}{" "}
+										<span className="text-slate-400">
+											({group.memberCount} member{group.memberCount !== 1 ? "s" : ""})
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+
+					{/* Member-only groups */}
+					{preview.memberOnlyGroups.length > 0 && (
+						<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+							<h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+								<Users className="h-5 w-5 text-slate-400" />
+								Groups where you are a member
+							</h2>
+							<p className="mt-1 text-sm text-slate-600">You will be removed from these groups.</p>
+							<ul className="mt-3 space-y-1">
+								{preview.memberOnlyGroups.map((group) => (
+									<li key={group.groupId} className="text-sm text-slate-700">
+										{group.groupName}
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+
+					{/* No groups */}
+					{preview.soleAdminGroups.length === 0 &&
+						preview.sharedAdminGroups.length === 0 &&
+						preview.memberOnlyGroups.length === 0 && (
+							<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+								<p className="text-sm text-slate-600">You are not a member of any groups.</p>
+							</div>
+						)}
+
+					<button
+						type="button"
+						onClick={() => setStep("confirm")}
+						disabled={!canProceed}
+						className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						Continue
+						<ArrowRight className="h-4 w-4" />
+					</button>
+				</div>
+			)}
+
+			{step === "confirm" && (
+				<div className="space-y-6">
+					<div className="rounded-xl border border-red-300 bg-white shadow-sm">
+						<div className="border-b border-red-200 px-6 py-4">
+							<h2 className="text-lg font-semibold text-red-600">Confirm Account Deletion</h2>
+						</div>
+						<div className="p-6">
+							{/* Summary of decisions */}
+							{Object.values(decisions).length > 0 && (
+								<div className="mb-4 rounded-lg bg-slate-50 p-4">
+									<h3 className="text-sm font-semibold text-slate-900">Your decisions:</h3>
+									<ul className="mt-2 space-y-1">
+										{Object.values(decisions).map((decision) => {
+											const group = preview.soleAdminGroups.find(
+												(g) => g.groupId === decision.groupId,
+											);
+											if (!group) return null;
+											return (
+												<li key={decision.groupId} className="text-sm text-slate-600">
+													<span className="font-medium">{group.groupName}</span>
+													{" — "}
+													{decision.action === "delete"
+														? "will be deleted"
+														: `ownership transferred to ${
+																[...group.otherMembers, ...group.otherAdmins].find(
+																	(m) =>
+																		decision.action === "transfer" && m.id === decision.newAdminId,
+																)?.name ?? "selected member"
+															}`}
+												</li>
+											);
+										})}
+									</ul>
+								</div>
+							)}
+
+							<Form method="post">
+								<CsrfInput />
+								<input type="hidden" name="intent" value="delete-account" />
+								<input type="hidden" name="decisions" value={JSON.stringify(decisionsArray)} />
+
+								<div className="mb-4">
+									<label
+										htmlFor="confirmEmail"
+										className="block text-sm font-medium text-slate-700"
+									>
+										Type <span className="font-semibold">{user.email}</span> to confirm:
+									</label>
+									<input
+										id="confirmEmail"
+										name="confirmEmail"
+										type="text"
+										autoComplete="off"
+										value={confirmEmail}
+										onChange={(e) => setConfirmEmail(e.target.value)}
+										className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20"
+										placeholder={user.email}
+									/>
+								</div>
+
+								<div className="flex items-center gap-3">
+									<button
+										type="button"
+										onClick={() => setStep("decisions")}
+										className="rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+									>
+										<ArrowLeft className="mr-1 inline h-4 w-4" />
+										Back
+									</button>
+									<button
+										type="submit"
+										disabled={!emailMatches || isSubmitting}
+										className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										<Trash2 className="h-4 w-4" />
+										{isSubmitting ? "Deleting…" : "Permanently Delete My Account"}
+									</button>
+								</div>
+							</Form>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// --- Sub-Components ---
+
+function SoleAdminGroupDecision({
+	group,
+	decision,
+	onDecision,
+	onTransferTargetChange,
+}: {
+	group: AccountDeletionPreview["soleAdminGroups"][0];
+	decision: GroupDecision | undefined;
+	onDecision: (action: "transfer" | "delete", newAdminId?: string) => void;
+	onTransferTargetChange: (newAdminId: string) => void;
+}) {
+	const hasOtherMembers = group.otherMembers.length > 0 || group.otherAdmins.length > 0;
+	const currentAction = decision?.action;
+
+	return (
+		<div className="p-6">
+			<h3 className="text-sm font-semibold text-slate-900">{group.groupName}</h3>
+			<p className="mt-1 text-xs text-slate-500">
+				{group.memberCount} member{group.memberCount !== 1 ? "s" : ""}
+			</p>
+
+			<div className="mt-3 space-y-2">
+				{hasOtherMembers && (
+					<label className="flex items-start gap-2">
+						<input
+							type="radio"
+							name={`decision-${group.groupId}`}
+							checked={currentAction === "transfer"}
+							onChange={() => onDecision("transfer")}
+							className="mt-1 accent-emerald-600"
+						/>
+						<div>
+							<span className="text-sm font-medium text-slate-700">
+								Transfer ownership to another member
+							</span>
+							{currentAction === "transfer" && (
+								<select
+									value={decision?.action === "transfer" ? decision.newAdminId : ""}
+									onChange={(e) => onTransferTargetChange(e.target.value)}
+									className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-1.5 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								>
+									<option value="">Select a member...</option>
+									{[...group.otherAdmins, ...group.otherMembers].map((member) => (
+										<option key={member.id} value={member.id}>
+											{member.name}
+										</option>
+									))}
+								</select>
+							)}
+						</div>
+					</label>
+				)}
+
+				<label className="flex items-start gap-2">
+					<input
+						type="radio"
+						name={`decision-${group.groupId}`}
+						checked={currentAction === "delete"}
+						onChange={() => onDecision("delete")}
+						className="mt-1 accent-red-600"
+					/>
+					<div>
+						<span className="text-sm font-medium text-red-600">
+							Delete this group and all its data
+						</span>
+						<p className="text-xs text-slate-500">
+							All members, availability requests, events, and assignments will be permanently
+							deleted.
+						</p>
+					</div>
+				</label>
+			</div>
+		</div>
+	);
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,13 +1,14 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import {
 	Form,
+	Link,
 	useActionData,
 	useLoaderData,
 	useNavigation,
 	useRouteLoaderData,
 	useSubmit,
 } from "@remix-run/react";
-import { Globe, Save, User } from "lucide-react";
+import { AlertTriangle, Globe, Save, User } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { COMMON_TIMEZONES, getTimezoneLabel } from "~/components/timezone-selector";
@@ -196,6 +197,29 @@ export default function Settings() {
 						<dd className="text-sm font-medium text-slate-900">{user.email}</dd>
 					</div>
 				</dl>
+			</div>
+
+			{/* Danger Zone */}
+			<div className="mt-6 rounded-xl border border-red-300 bg-white shadow-sm">
+				<div className="border-b border-red-200 px-6 py-4">
+					<h2 className="flex items-center gap-2 text-lg font-semibold text-red-600">
+						<AlertTriangle className="h-5 w-5" />
+						Danger Zone
+					</h2>
+				</div>
+				<div className="p-6">
+					<h3 className="text-sm font-semibold text-slate-900">Delete your account</h3>
+					<p className="mt-2 text-sm text-slate-600">
+						Permanently delete your account and all associated data. You will have 30 days to
+						reactivate your account by logging back in.
+					</p>
+					<Link
+						to="/settings/delete-account"
+						className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-700"
+					>
+						Delete Account
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/services/account.server.test.ts
+++ b/app/services/account.server.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mock the DB layer ---
+
+const mockSelect = vi.fn();
+const mockTransaction = vi.fn().mockImplementation(async (cb) => {
+	return cb({
+		select: vi.fn(),
+		insert: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	});
+});
+
+vi.mock("../../src/db/index.js", () => ({
+	db: {
+		select: (...args: unknown[]) => mockSelect(...args),
+		transaction: (...args: unknown[]) => mockTransaction(...args),
+	},
+}));
+
+vi.mock("./logger.server.js", () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}));
+
+const { getAccountDeletionPreview, executeAccountDeletion } = await import(
+	"~/services/account.server"
+);
+
+describe("getAccountDeletionPreview", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns empty preview when user has no groups", async () => {
+		// Mock memberships query
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([]),
+				}),
+			}),
+		});
+
+		// Mock request count
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		// Mock event count
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		const preview = await getAccountDeletionPreview("user-1");
+
+		expect(preview.soleAdminGroups).toHaveLength(0);
+		expect(preview.sharedAdminGroups).toHaveLength(0);
+		expect(preview.memberOnlyGroups).toHaveLength(0);
+		expect(preview.createdRequestCount).toBe(0);
+		expect(preview.createdEventCount).toBe(0);
+	});
+
+	it("correctly categorizes sole-admin groups", async () => {
+		// Mock memberships query — user is admin of one group
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi
+						.fn()
+						.mockResolvedValue([{ groupId: "g1", role: "admin", groupName: "My Group" }]),
+				}),
+			}),
+		});
+
+		// Mock all members of group g1 (just the user — sole admin)
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([
+						{ userId: "user-1", role: "admin", name: "Test User" },
+						{ userId: "user-2", role: "member", name: "Other User" },
+					]),
+				}),
+			}),
+		});
+
+		// Mock request count
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 3 }]),
+			}),
+		});
+
+		// Mock event count
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 1 }]),
+			}),
+		});
+
+		const preview = await getAccountDeletionPreview("user-1");
+
+		expect(preview.soleAdminGroups).toHaveLength(1);
+		expect(preview.soleAdminGroups[0].groupId).toBe("g1");
+		expect(preview.soleAdminGroups[0].isSoleAdmin).toBe(true);
+		expect(preview.soleAdminGroups[0].otherMembers).toHaveLength(1);
+		expect(preview.soleAdminGroups[0].otherMembers[0].id).toBe("user-2");
+		expect(preview.sharedAdminGroups).toHaveLength(0);
+		expect(preview.memberOnlyGroups).toHaveLength(0);
+		expect(preview.createdRequestCount).toBe(3);
+		expect(preview.createdEventCount).toBe(1);
+	});
+
+	it("correctly categorizes shared-admin groups", async () => {
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi
+						.fn()
+						.mockResolvedValue([{ groupId: "g1", role: "admin", groupName: "Shared Group" }]),
+				}),
+			}),
+		});
+
+		// Group has two admins
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([
+						{ userId: "user-1", role: "admin", name: "Test User" },
+						{ userId: "user-2", role: "admin", name: "Other Admin" },
+					]),
+				}),
+			}),
+		});
+
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		const preview = await getAccountDeletionPreview("user-1");
+
+		expect(preview.soleAdminGroups).toHaveLength(0);
+		expect(preview.sharedAdminGroups).toHaveLength(1);
+		expect(preview.sharedAdminGroups[0].groupId).toBe("g1");
+		expect(preview.sharedAdminGroups[0].isSoleAdmin).toBe(false);
+		expect(preview.sharedAdminGroups[0].otherAdmins).toHaveLength(1);
+	});
+
+	it("correctly categorizes member-only groups", async () => {
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi
+						.fn()
+						.mockResolvedValue([{ groupId: "g1", role: "member", groupName: "Member Group" }]),
+				}),
+			}),
+		});
+
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([
+						{ userId: "user-1", role: "member", name: "Test User" },
+						{ userId: "admin-1", role: "admin", name: "Admin" },
+					]),
+				}),
+			}),
+		});
+
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		mockSelect.mockReturnValueOnce({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 0 }]),
+			}),
+		});
+
+		const preview = await getAccountDeletionPreview("user-1");
+
+		expect(preview.soleAdminGroups).toHaveLength(0);
+		expect(preview.sharedAdminGroups).toHaveLength(0);
+		expect(preview.memberOnlyGroups).toHaveLength(1);
+		expect(preview.memberOnlyGroups[0].groupId).toBe("g1");
+	});
+});
+
+describe("executeAccountDeletion", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("calls transaction for deletion", async () => {
+		// Set up the tx mock to handle the full flow
+		const mockTxUpdate = vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		});
+		const mockTxDelete = vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue(undefined),
+		});
+		const mockTxSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([]),
+			}),
+		});
+
+		mockTransaction.mockImplementationOnce(async (cb) => {
+			await cb({
+				update: mockTxUpdate,
+				delete: mockTxDelete,
+				select: mockTxSelect,
+			});
+		});
+
+		await executeAccountDeletion("user-1", []);
+
+		expect(mockTransaction).toHaveBeenCalledTimes(1);
+		// Should have updated the user with deletedAt
+		expect(mockTxUpdate).toHaveBeenCalled();
+		// Should have deleted memberships, responses, assignments
+		expect(mockTxDelete).toHaveBeenCalled();
+	});
+
+	it("handles transfer decision correctly", async () => {
+		const mockTxUpdate = vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		});
+		const mockTxDelete = vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue(undefined),
+		});
+		const mockTxSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([]),
+			}),
+		});
+
+		mockTransaction.mockImplementationOnce(async (cb) => {
+			await cb({
+				update: mockTxUpdate,
+				delete: mockTxDelete,
+				select: mockTxSelect,
+			});
+		});
+
+		await executeAccountDeletion("user-1", [
+			{ action: "transfer", groupId: "g1", newAdminId: "user-2" },
+		]);
+
+		expect(mockTransaction).toHaveBeenCalledTimes(1);
+		// update should be called for: promote new admin, reassign group createdById,
+		// reassign requests, reassign events, and final soft-delete
+		expect(mockTxUpdate).toHaveBeenCalled();
+	});
+
+	it("handles delete decision correctly", async () => {
+		const mockTxUpdate = vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		});
+		const mockTxDelete = vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue(undefined),
+		});
+		const mockTxSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([]),
+			}),
+		});
+
+		mockTransaction.mockImplementationOnce(async (cb) => {
+			await cb({
+				update: mockTxUpdate,
+				delete: mockTxDelete,
+				select: mockTxSelect,
+			});
+		});
+
+		await executeAccountDeletion("user-1", [{ action: "delete", groupId: "g1" }]);
+
+		expect(mockTransaction).toHaveBeenCalledTimes(1);
+		// Should delete the group directly within the transaction
+		expect(mockTxDelete).toHaveBeenCalled();
+	});
+
+	it("handles mixed decisions (transfer and delete)", async () => {
+		const mockTxUpdate = vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		});
+		const mockTxDelete = vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue(undefined),
+		});
+		const mockTxSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([]),
+			}),
+		});
+
+		mockTransaction.mockImplementationOnce(async (cb) => {
+			await cb({
+				update: mockTxUpdate,
+				delete: mockTxDelete,
+				select: mockTxSelect,
+			});
+		});
+
+		await executeAccountDeletion("user-1", [
+			{ action: "transfer", groupId: "g1", newAdminId: "user-2" },
+			{ action: "delete", groupId: "g2" },
+		]);
+
+		expect(mockTransaction).toHaveBeenCalledTimes(1);
+	});
+
+	it("handles empty decisions (no sole-admin groups)", async () => {
+		const mockTxUpdate = vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		});
+		const mockTxDelete = vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue(undefined),
+		});
+		const mockTxSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([]),
+			}),
+		});
+
+		mockTransaction.mockImplementationOnce(async (cb) => {
+			await cb({
+				update: mockTxUpdate,
+				delete: mockTxDelete,
+				select: mockTxSelect,
+			});
+		});
+
+		await executeAccountDeletion("user-1", []);
+
+		expect(mockTransaction).toHaveBeenCalledTimes(1);
+		// Should still soft-delete the user
+		expect(mockTxUpdate).toHaveBeenCalled();
+	});
+});

--- a/app/services/account.server.ts
+++ b/app/services/account.server.ts
@@ -1,0 +1,245 @@
+import { and, count, eq, ne } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import {
+	availabilityRequests,
+	availabilityResponses,
+	eventAssignments,
+	events,
+	groupMemberships,
+	groups,
+	users,
+} from "../../src/db/schema.js";
+import { logger } from "./logger.server.js";
+
+// --- Types ---
+
+export interface GroupOwnershipInfo {
+	groupId: string;
+	groupName: string;
+	role: "admin" | "member";
+	isSoleAdmin: boolean;
+	memberCount: number;
+	otherAdmins: Array<{ id: string; name: string }>;
+	otherMembers: Array<{ id: string; name: string }>;
+}
+
+export interface AccountDeletionPreview {
+	soleAdminGroups: GroupOwnershipInfo[];
+	sharedAdminGroups: GroupOwnershipInfo[];
+	memberOnlyGroups: GroupOwnershipInfo[];
+	createdRequestCount: number;
+	createdEventCount: number;
+}
+
+export type GroupDecision =
+	| { action: "transfer"; groupId: string; newAdminId: string }
+	| { action: "delete"; groupId: string };
+
+// --- Preview ---
+
+export async function getAccountDeletionPreview(userId: string): Promise<AccountDeletionPreview> {
+	// Get all groups user is in
+	const memberships = await db
+		.select({
+			groupId: groupMemberships.groupId,
+			role: groupMemberships.role,
+			groupName: groups.name,
+		})
+		.from(groupMemberships)
+		.innerJoin(groups, eq(groupMemberships.groupId, groups.id))
+		.where(eq(groupMemberships.userId, userId));
+
+	const soleAdminGroups: GroupOwnershipInfo[] = [];
+	const sharedAdminGroups: GroupOwnershipInfo[] = [];
+	const memberOnlyGroups: GroupOwnershipInfo[] = [];
+
+	for (const membership of memberships) {
+		// Get all members of this group (excluding the current user)
+		const allMembers = await db
+			.select({
+				userId: groupMemberships.userId,
+				role: groupMemberships.role,
+				name: users.name,
+			})
+			.from(groupMemberships)
+			.innerJoin(users, eq(groupMemberships.userId, users.id))
+			.where(eq(groupMemberships.groupId, membership.groupId));
+
+		const otherMembers = allMembers.filter((m) => m.userId !== userId);
+		const otherAdmins = otherMembers.filter((m) => m.role === "admin");
+		const otherNonAdmins = otherMembers.filter((m) => m.role !== "admin");
+
+		const info: GroupOwnershipInfo = {
+			groupId: membership.groupId,
+			groupName: membership.groupName,
+			role: membership.role as "admin" | "member",
+			isSoleAdmin: membership.role === "admin" && otherAdmins.length === 0,
+			memberCount: allMembers.length,
+			otherAdmins: otherAdmins.map((m) => ({ id: m.userId, name: m.name })),
+			otherMembers: otherNonAdmins.map((m) => ({ id: m.userId, name: m.name })),
+		};
+
+		if (membership.role === "admin") {
+			if (otherAdmins.length === 0) {
+				soleAdminGroups.push(info);
+			} else {
+				sharedAdminGroups.push(info);
+			}
+		} else {
+			memberOnlyGroups.push(info);
+		}
+	}
+
+	// Count created content
+	const [requestCount] = await db
+		.select({ count: count() })
+		.from(availabilityRequests)
+		.where(eq(availabilityRequests.createdById, userId));
+
+	const [eventCount] = await db
+		.select({ count: count() })
+		.from(events)
+		.where(eq(events.createdById, userId));
+
+	return {
+		soleAdminGroups,
+		sharedAdminGroups,
+		memberOnlyGroups,
+		createdRequestCount: requestCount?.count ?? 0,
+		createdEventCount: eventCount?.count ?? 0,
+	};
+}
+
+// --- Execute Deletion ---
+
+export async function executeAccountDeletion(
+	userId: string,
+	decisions: GroupDecision[],
+): Promise<void> {
+	await db.transaction(async (tx) => {
+		// 1. Handle sole-admin groups per user decisions
+		for (const decision of decisions) {
+			if (decision.action === "transfer") {
+				// Promote the new admin
+				await tx
+					.update(groupMemberships)
+					.set({ role: "admin" })
+					.where(
+						and(
+							eq(groupMemberships.groupId, decision.groupId),
+							eq(groupMemberships.userId, decision.newAdminId),
+						),
+					);
+
+				// Reassign createdById on the group itself
+				await tx
+					.update(groups)
+					.set({ createdById: decision.newAdminId, updatedAt: new Date() })
+					.where(eq(groups.id, decision.groupId));
+
+				// Reassign createdById on availability requests in this group
+				await tx
+					.update(availabilityRequests)
+					.set({ createdById: decision.newAdminId })
+					.where(
+						and(
+							eq(availabilityRequests.groupId, decision.groupId),
+							eq(availabilityRequests.createdById, userId),
+						),
+					);
+
+				// Reassign createdById on events in this group
+				await tx
+					.update(events)
+					.set({ createdById: decision.newAdminId, updatedAt: new Date() })
+					.where(and(eq(events.groupId, decision.groupId), eq(events.createdById, userId)));
+
+				// Remove the departing user's membership
+				await tx
+					.delete(groupMemberships)
+					.where(
+						and(
+							eq(groupMemberships.groupId, decision.groupId),
+							eq(groupMemberships.userId, userId),
+						),
+					);
+
+				logger.info(
+					{ userId, groupId: decision.groupId, newAdminId: decision.newAdminId },
+					"Transferred group ownership during account deletion",
+				);
+			} else if (decision.action === "delete") {
+				// Use direct delete — FK cascades handle cleanup
+				await tx.delete(groups).where(eq(groups.id, decision.groupId));
+
+				logger.info({ userId, groupId: decision.groupId }, "Deleted group during account deletion");
+			}
+		}
+
+		// 2. Handle shared-admin groups: reassign createdById to another admin, remove membership
+		const remainingAdminMemberships = await tx
+			.select({
+				groupId: groupMemberships.groupId,
+				role: groupMemberships.role,
+			})
+			.from(groupMemberships)
+			.where(and(eq(groupMemberships.userId, userId), eq(groupMemberships.role, "admin")));
+
+		for (const membership of remainingAdminMemberships) {
+			// Find another admin in this group to reassign to (exclude the departing user)
+			const [otherAdmin] = await tx
+				.select({ userId: groupMemberships.userId })
+				.from(groupMemberships)
+				.where(
+					and(
+						eq(groupMemberships.groupId, membership.groupId),
+						eq(groupMemberships.role, "admin"),
+						ne(groupMemberships.userId, userId),
+					),
+				)
+				.limit(1);
+
+			if (otherAdmin) {
+				// Reassign createdById references
+				await tx
+					.update(availabilityRequests)
+					.set({ createdById: otherAdmin.userId })
+					.where(
+						and(
+							eq(availabilityRequests.groupId, membership.groupId),
+							eq(availabilityRequests.createdById, userId),
+						),
+					);
+
+				await tx
+					.update(events)
+					.set({ createdById: otherAdmin.userId, updatedAt: new Date() })
+					.where(and(eq(events.groupId, membership.groupId), eq(events.createdById, userId)));
+
+				await tx
+					.update(groups)
+					.set({ createdById: otherAdmin.userId, updatedAt: new Date() })
+					.where(and(eq(groups.id, membership.groupId), eq(groups.createdById, userId)));
+			}
+		}
+
+		// 3. Remove all remaining memberships (handles member-only groups too)
+		// FK cascades on groupMemberships.userId will handle this on user soft-delete,
+		// but we explicitly remove memberships now to clean up properly
+		await tx.delete(groupMemberships).where(eq(groupMemberships.userId, userId));
+
+		// 4. Delete availability responses (explicit, though CASCADE would handle it)
+		await tx.delete(availabilityResponses).where(eq(availabilityResponses.userId, userId));
+
+		// 5. Delete/decline event assignments
+		await tx.delete(eventAssignments).where(eq(eventAssignments.userId, userId));
+
+		// 6. Soft-delete the user
+		await tx
+			.update(users)
+			.set({ deletedAt: new Date(), updatedAt: new Date() })
+			.where(eq(users.id, userId));
+
+		logger.info({ userId }, "Account soft-deleted");
+	});
+}

--- a/app/services/events.server.test.ts
+++ b/app/services/events.server.test.ts
@@ -90,6 +90,7 @@ function chainMock(resolved: unknown) {
 	chain.limit = vi.fn().mockResolvedValue(resolved);
 	chain.orderBy = vi.fn().mockReturnValue(chain);
 	chain.innerJoin = vi.fn().mockReturnValue(chain);
+	chain.leftJoin = vi.fn().mockReturnValue(chain);
 	chain.where = vi.fn().mockReturnValue(chain);
 	chain.from = vi.fn().mockReturnValue(chain);
 	return chain;
@@ -319,7 +320,7 @@ describe("events.server", () => {
 			const eventChain = chainMock(null);
 			eventChain.limit = vi.fn().mockResolvedValue([eventRow]);
 			eventChain.where = vi.fn().mockReturnValue(eventChain);
-			eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
+			eventChain.leftJoin = vi.fn().mockReturnValue(eventChain);
 			eventChain.from = vi.fn().mockReturnValue(eventChain);
 
 			// Second select chain: assignments query
@@ -348,7 +349,7 @@ describe("events.server", () => {
 			const eventChain = chainMock(null);
 			eventChain.limit = vi.fn().mockResolvedValue([]);
 			eventChain.where = vi.fn().mockReturnValue(eventChain);
-			eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
+			eventChain.leftJoin = vi.fn().mockReturnValue(eventChain);
 			eventChain.from = vi.fn().mockReturnValue(eventChain);
 			mockSelect.mockReturnValueOnce(eventChain);
 
@@ -363,7 +364,7 @@ describe("events.server", () => {
 			const eventChain = chainMock(null);
 			eventChain.limit = vi.fn().mockResolvedValue([eventRow]);
 			eventChain.where = vi.fn().mockReturnValue(eventChain);
-			eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
+			eventChain.leftJoin = vi.fn().mockReturnValue(eventChain);
 			eventChain.from = vi.fn().mockReturnValue(eventChain);
 
 			const assignChain = chainMock(null);

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -177,11 +177,12 @@ export async function getEventWithAssignments(eventId: string): Promise<{
 			createdByName: users.name,
 		})
 		.from(events)
-		.innerJoin(users, eq(events.createdById, users.id))
+		.leftJoin(users, eq(events.createdById, users.id))
 		.where(eq(events.id, eventId))
 		.limit(1);
 
 	if (!eventRow) return null;
+	const createdByName = eventRow.createdByName ?? "Deleted user";
 
 	const assignments = await db
 		.select({
@@ -197,7 +198,7 @@ export async function getEventWithAssignments(eventId: string): Promise<{
 		.orderBy(users.name);
 
 	return {
-		event: eventRow,
+		event: { ...eventRow, createdByName },
 		assignments: assignments as Array<{
 			userId: string;
 			userName: string;

--- a/drizzle/0007_lush_phantom_reporter.sql
+++ b/drizzle/0007_lush_phantom_reporter.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "availability_requests" DROP CONSTRAINT "availability_requests_created_by_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "events" DROP CONSTRAINT "events_created_by_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "groups" DROP CONSTRAINT "groups_created_by_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "availability_requests" ALTER COLUMN "created_by_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "events" ALTER COLUMN "created_by_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "group_memberships" ALTER COLUMN "notification_preferences" SET DEFAULT '{"availabilityRequests":{"email":true},"eventNotifications":{"email":true},"showReminders":{"email":true}}'::jsonb;--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "created_by_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "availability_requests" ADD CONSTRAINT "availability_requests_created_by_id_users_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_created_by_id_users_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_created_by_id_users_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,961 @@
+{
+  "id": "9183b6ab-1ada-48b3-91dc-31f926f84b4c",
+  "prevId": "8936de18-65ef-4bb9-b0fe-c2f62d1a7a79",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_requests": {
+      "name": "availability_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_dates": {
+          "name": "requested_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_start_time": {
+          "name": "requested_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_end_time": {
+          "name": "requested_end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "availability_requests_group_id_idx": {
+          "name": "availability_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_requests_group_id_groups_id_fk": {
+          "name": "availability_requests_group_id_groups_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_requests_created_by_id_users_id_fk": {
+          "name": "availability_requests_created_by_id_users_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_responses": {
+      "name": "availability_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_responses_request_user_idx": {
+          "name": "availability_responses_request_user_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_responses_request_id_availability_requests_id_fk": {
+          "name": "availability_responses_request_id_availability_requests_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_responses_user_id_users_id_fk": {
+          "name": "availability_responses_user_id_users_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_assignments": {
+      "name": "event_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_assignments_event_user_idx": {
+          "name": "event_assignments_event_user_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_assignments_user_id_idx": {
+          "name": "event_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_assignments_event_id_events_id_fk": {
+          "name": "event_assignments_event_id_events_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_assignments_user_id_users_id_fk": {
+          "name": "event_assignments_user_id_users_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_request_id": {
+          "name": "created_from_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_time": {
+          "name": "call_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_group_start_time_idx": {
+          "name": "events_group_start_time_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_group_id_groups_id_fk": {
+          "name": "events_group_id_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_id_users_id_fk": {
+          "name": "events_created_by_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_created_from_request_id_availability_requests_id_fk": {
+          "name": "events_created_from_request_id_availability_requests_id_fk",
+          "tableFrom": "events",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "created_from_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"availabilityRequests\":{\"email\":true},\"eventNotifications\":{\"email\":true},\"showReminders\":{\"email\":true}}'::jsonb"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_user_idx": {
+          "name": "group_memberships_group_user_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_can_create_requests": {
+          "name": "members_can_create_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "members_can_create_events": {
+          "name": "members_can_create_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_invite_code_idx": {
+          "name": "groups_invite_code_idx",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_id_users_id_fk": {
+          "name": "groups_created_by_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_invite_code_unique": {
+          "name": "groups_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_expiry": {
+          "name": "email_verification_expiry",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_google_id_idx": {
+          "name": "users_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verification_token_idx": {
+          "name": "users_email_verification_token_idx",
+          "columns": [
+            {
+              "expression": "email_verification_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "declined"
+      ]
+    },
+    "public.availability_response_value": {
+      "name": "availability_response_value",
+      "schema": "public",
+      "values": [
+        "available",
+        "maybe",
+        "not_available"
+      ]
+    },
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "rehearsal",
+        "show",
+        "other"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772329406527,
       "tag": "0006_overconfident_black_tom",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1772385549913,
+      "tag": "0007_lush_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -40,6 +40,7 @@ export const users = pgTable(
 		emailVerificationToken: varchar("email_verification_token", { length: 255 }),
 		emailVerificationExpiry: timestamp("email_verification_expiry", { withTimezone: true }),
 		timezone: varchar("timezone", { length: 100 }),
+		deletedAt: timestamp("deleted_at", { withTimezone: true }),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 	},
@@ -58,9 +59,7 @@ export const groups = pgTable(
 		name: varchar("name", { length: 255 }).notNull(),
 		description: text("description"),
 		inviteCode: varchar("invite_code", { length: 8 }).notNull().unique(),
-		createdById: uuid("created_by_id")
-			.notNull()
-			.references(() => users.id),
+		createdById: uuid("created_by_id").references(() => users.id, { onDelete: "set null" }),
 		membersCanCreateRequests: boolean("members_can_create_requests").default(false).notNull(),
 		membersCanCreateEvents: boolean("members_can_create_events").default(false).notNull(),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
@@ -130,9 +129,7 @@ export const availabilityRequests = pgTable(
 		requestedStartTime: varchar("requested_start_time", { length: 5 }),
 		requestedEndTime: varchar("requested_end_time", { length: 5 }),
 		status: availabilityStatusEnum("status").default("open").notNull(),
-		createdById: uuid("created_by_id")
-			.notNull()
-			.references(() => users.id),
+		createdById: uuid("created_by_id").references(() => users.id, { onDelete: "set null" }),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 		expiresAt: timestamp("expires_at", { withTimezone: true }),
 	},
@@ -175,9 +172,7 @@ export const events = pgTable(
 		startTime: timestamp("start_time", { withTimezone: true }).notNull(),
 		endTime: timestamp("end_time", { withTimezone: true }).notNull(),
 		location: varchar("location", { length: 500 }),
-		createdById: uuid("created_by_id")
-			.notNull()
-			.references(() => users.id),
+		createdById: uuid("created_by_id").references(() => users.id, { onDelete: "set null" }),
 		createdFromRequestId: uuid("created_from_request_id").references(() => availabilityRequests.id),
 		callTime: timestamp("call_time", { withTimezone: true }),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),


### PR DESCRIPTION
## Summary

Implements Part 4 of #64: GDPR-compliant account deletion with soft-delete, 30-day grace period, ownership transfer for sole-admin groups, and multi-step confirmation UI.

**Closes #25**

## What Changed

### Schema
- Added `deletedAt` timestamp column to `users` table (nullable)
- Made `createdById` nullable on `groups`, `availabilityRequests`, `events`
- Added `ON DELETE SET NULL` to all three `createdById` foreign keys
- Converted `innerJoin` to `leftJoin` for all `createdById → users` queries with "Deleted user" fallback
- Migration: `drizzle/0007_lush_phantom_reporter.sql`

### Auth (`app/services/auth.server.ts`)
- `requireUser()` checks `deletedAt` — destroys session for soft-deleted users
- `getOptionalUser()` treats soft-deleted users as not logged in
- Login (email/password + Google OAuth) reactivates soft-deleted accounts within 30-day grace period
- New helpers: `getUserDeletedAt()`, `reactivateAccount()`

### Account Service (`app/services/account.server.ts` — new)
- `getAccountDeletionPreview(userId)` — categorizes groups into sole-admin, shared-admin, member-only; counts created content
- `executeAccountDeletion(userId, decisions)` — runs in a transaction:
  - **Sole-admin groups**: transfer ownership or delete per user decision
  - **Shared-admin groups**: reassign `createdById` to another admin
  - **All groups**: remove memberships, availability responses, event assignments
  - **User**: soft-delete (set `deletedAt`)

### Routes
- `settings.tsx`: Added "Danger Zone" section with link to deletion flow
- `settings.delete-account.tsx` (new): Multi-step deletion flow
  - Step 1: Show what user owns, collect decisions for sole-admin groups (transfer vs delete)
  - Step 2: Preview + type email to confirm
  - Execute in transaction, destroy session, redirect to `/`

### Tests (290 total, all passing)
- `account.server.test.ts`: Preview categorization, execution with transfers/deletes
- `settings.delete-account.test.ts`: Auth, validation, edge cases, error handling
- Updated `auth.server.test.ts` for soft-delete behavior
- Updated `events.server.test.ts` for leftJoin mock chains
- Updated `login.test.ts` for reactivation mock

## Security
- CSRF protection on all mutations
- `requireUser()` auth guard on loader and action
- Transfer targets validated against actual group members
- Email confirmation (case-insensitive) required to proceed
- All operations in a database transaction — no partial deletions
- 30-day soft-delete grace period before permanent deletion

## Edge Cases Handled
- User with no groups → simple soft-delete
- Sole admin with other members → must transfer or delete
- Sole admin with no other members → must delete
- Multiple sole-admin groups → independent decisions per group
- Shared admin groups → auto-reassign to another admin (excludes departing user)
- Google OAuth reactivation within grace period
- Concurrent deletion → transaction isolation

## Quality Gates
- ✅ `pnpm run typecheck` — 0 errors
- ✅ `pnpm run lint` — 0 errors (1 pre-existing warning)
- ✅ `pnpm run build` — succeeds
- ✅ `pnpm test` — 290 passed