### PR TITLE
fix: add Google profile image domain to CSP img-src directive

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -22,7 +22,7 @@ function setSecurityHeaders(responseHeaders: Headers) {
 	responseHeaders.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
 	responseHeaders.set(
 		"Content-Security-Policy",
-		"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
+		"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
 	);
 }
 

--- a/app/services/security-headers.test.ts
+++ b/app/services/security-headers.test.ts
@@ -17,7 +17,7 @@ describe("security headers", () => {
 		headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
 		headers.set(
 			"Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
 		);
 
 		expect(headers.get("X-Frame-Options")).toBe("DENY");


### PR DESCRIPTION
## Summary

Google profile pictures from `lh3.googleusercontent.com` were blocked by the Content-Security-Policy `img-src` directive, which only allowed `'self'` and `data:` URIs. This caused broken avatar images for users who signed in with Google OAuth.

## Changes

- Added `https://lh3.googleusercontent.com` to the `img-src` CSP directive in `app/entry.server.tsx`
- Updated the CSP test in `app/services/security-headers.test.ts` to match

## Investigation

Checked whether Application Insights or other external resources need CSP exceptions:
- **App Insights**: Uses the Node.js SDK (`applicationinsights` package) which runs server-side only. CSP only applies to browser requests, so no `connect-src` changes needed.
- **No other external resources** loaded client-side that would need CSP exceptions.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅ (pre-existing warning in drizzle.config.ts)
- `pnpm run build` ✅
- `pnpm test` ✅ (301 tests pass)