### PR TITLE
feat: add 'I won't be there' decline button for event self-registration

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -183,6 +183,73 @@ describe("event detail action — IDOR prevention", () => {
 	});
 });
 
+describe("event detail action — decline attendance", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+		});
+		(isGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+	});
+
+	it("allows self-declining attendance on event in the same group", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: { id: "event-1", groupId: "g1", title: "My Event" },
+			assignments: [],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "decline-attendance");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		const result = await action({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(assignToEvent).toHaveBeenCalledWith("event-1", "user-1", "Viewer");
+		expect(updateAssignmentStatus).toHaveBeenCalledWith("event-1", "user-1", "declined");
+	});
+
+	it("prevents self-declining on event from another group", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: { id: "event-1", groupId: "other-group", title: "Other Group Event" },
+			assignments: [],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "decline-attendance");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		try {
+			await action({
+				request,
+				params: { groupId: "g1", eventId: "event-1" },
+				context: {},
+			});
+			expect.fail("Should have thrown 404");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(404);
+		}
+
+		expect(assignToEvent).not.toHaveBeenCalled();
+	});
+});
+
 describe("event detail action — delete authorization", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -124,6 +124,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		return { success: true };
 	}
 
+	if (intent === "decline-attendance") {
+		// Self-register as viewer with declined status
+		await assignToEvent(eventId, user.id, "Viewer");
+		await updateAssignmentStatus(eventId, user.id, "declined");
+		return { success: true };
+	}
+
 	if (intent === "delete") {
 		const admin = await isGroupAdmin(user.id, groupId);
 		const isCreator = eventData.event.createdById === user.id;
@@ -643,17 +650,30 @@ export default function EventDetail() {
 									)}
 									{canSelfRegister && (
 										<div className="border-t border-slate-100 p-4">
-											<Form method="post">
-												<CsrfInput />
-												<input type="hidden" name="intent" value="attend" />
-												<button
-													type="submit"
-													disabled={isSubmitting}
-													className="inline-flex items-center gap-1.5 rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 disabled:opacity-50"
-												>
-													<Calendar className="h-4 w-4" /> I'll be there
-												</button>
-											</Form>
+											<div className="flex flex-col gap-2 sm:flex-row">
+												<Form method="post">
+													<CsrfInput />
+													<input type="hidden" name="intent" value="attend" />
+													<button
+														type="submit"
+														disabled={isSubmitting}
+														className="inline-flex items-center gap-1.5 rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 disabled:opacity-50"
+													>
+														<Calendar className="h-4 w-4" /> I'll be there
+													</button>
+												</Form>
+												<Form method="post">
+													<CsrfInput />
+													<input type="hidden" name="intent" value="decline-attendance" />
+													<button
+														type="submit"
+														disabled={isSubmitting}
+														className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50"
+													>
+														<X className="h-4 w-4" /> I won't be there
+													</button>
+												</Form>
+											</div>
 										</div>
 									)}
 								</>
@@ -1015,18 +1035,31 @@ export default function EventDetail() {
 					{!isShow && canSelfRegister && (
 						<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
 							<h3 className="text-sm font-semibold text-slate-900">Attending?</h3>
-							<p className="mt-1 text-xs text-slate-500">Let your group know you'll be there.</p>
-							<Form method="post" className="mt-3">
-								<CsrfInput />
-								<input type="hidden" name="intent" value="attend" />
-								<button
-									type="submit"
-									disabled={isSubmitting}
-									className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
-								>
-									<Calendar className="h-4 w-4" /> I'll be there
-								</button>
-							</Form>
+							<p className="mt-1 text-xs text-slate-500">Let your group know if you can make it.</p>
+							<div className="mt-3 flex flex-col gap-2 sm:flex-row">
+								<Form method="post">
+									<CsrfInput />
+									<input type="hidden" name="intent" value="attend" />
+									<button
+										type="submit"
+										disabled={isSubmitting}
+										className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+									>
+										<Calendar className="h-4 w-4" /> I'll be there
+									</button>
+								</Form>
+								<Form method="post">
+									<CsrfInput />
+									<input type="hidden" name="intent" value="decline-attendance" />
+									<button
+										type="submit"
+										disabled={isSubmitting}
+										className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50"
+									>
+										<X className="h-4 w-4" /> I won't be there
+									</button>
+								</Form>
+							</div>
 						</div>
 					)}
 


### PR DESCRIPTION
## Summary

Adds a **"I won't be there"** button next to the existing **"I'll be there"** button on event detail pages, allowing non-assigned members to explicitly decline attendance.

## Changes

### Action handler
- New `decline-attendance` intent creates a Viewer assignment with `declined` status (mirrors the existing `attend` intent which creates with `confirmed` status)

### UI (both show and non-show events)
- Added secondary outline-styled decline button (`border border-slate-300`) next to the green attend button
- Buttons are side-by-side on desktop (`sm:flex-row`), stacked on mobile (`flex-col`)
- Updated non-show subtitle: "Let your group know if you can make it."

### Post-click behavior
- After clicking either button, the user gets a Viewer assignment → `canSelfRegister` becomes `false` → the existing **"Your Status"** sidebar section shows their confirmed/declined state with an option to change their mind

### Tests
- Added 2 new tests: successful decline-attendance + IDOR prevention for cross-group decline

## Quality gates
- ✅ `pnpm run typecheck` — passes
- ✅ `pnpm run lint` — passes (pre-existing warning in drizzle.config.ts)
- ✅ `pnpm run build` — passes
- ✅ `pnpm test` — 303/303 tests pass