### PR TITLE
fix: style event status change links as visible buttons

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -984,7 +984,10 @@ export default function EventDetail() {
 									<Form method="post" className="mt-3">
 										<CsrfInput />
 										<input type="hidden" name="intent" value="decline" />
-										<button type="submit" className="text-xs text-slate-500 hover:text-red-600">
+										<button
+											type="submit"
+											className="border border-slate-300 rounded-lg px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+										>
 											Change to Declined
 										</button>
 									</Form>
@@ -997,7 +1000,10 @@ export default function EventDetail() {
 									<Form method="post" className="mt-3">
 										<CsrfInput />
 										<input type="hidden" name="intent" value="confirm" />
-										<button type="submit" className="text-xs text-slate-500 hover:text-emerald-600">
+										<button
+											type="submit"
+											className="border border-emerald-300 rounded-lg px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50"
+										>
 											Change to Confirmed
 										</button>
 									</Form>


### PR DESCRIPTION
## Problem

On the event detail page, after a user confirms or declines attendance, the 'Change to Declined' / 'Change to Confirmed' options were styled as tiny text links. Users could not tell they were clickable.

## Fix

Replaced the text link styling with proper outline buttons:
- **Change to Declined**: slate outline button
- **Change to Confirmed**: emerald outline button

Both are now clearly recognizable as clickable buttons, consistent with the existing button patterns on the page.

## Testing

- typecheck, lint, build, and all 303 tests pass