### PR TITLE
chore: quality hardening sprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,16 @@ app/
 │   ├── login.tsx               # Email/password + Google OAuth login
 │   ├── signup.tsx              # Registration with password strength meter
 │   ├── logout.tsx              # POST-only logout action
+│   ├── check-email.tsx         # Email verification prompt, resend verification
+│   ├── verify-email.tsx        # Validates email verification token from ?token=
 │   ├── auth.google.tsx         # Redirects to Google OAuth consent
 │   ├── auth.google.callback.tsx # Handles Google OAuth code exchange
 │   ├── api.health.tsx          # Health check endpoint (GET)
 │   ├── api.events.$eventId.ics.tsx # iCal export (GET, role-aware start times)
 │   ├── $.tsx                   # Catch-all 404 page
 │   ├── dashboard.tsx           # Authenticated dashboard (requires login)
+│   ├── settings.tsx            # User settings: timezone preference, display name
+│   ├── settings_.delete-account.tsx # Account deletion (soft-delete with 30-day reactivation)
 │   ├── groups.tsx              # Groups layout (Outlet wrapper)
 │   ├── groups._index.tsx       # Groups list with inline join/create forms
 │   ├── groups.new.tsx          # Create group form
@@ -53,21 +57,27 @@ app/
 │   ├── groups.$groupId.events.new.tsx    # Create event (admin or permitted member, supports ?fromRequest=)
 │   ├── groups.$groupId.events.$eventId.tsx      # Event detail: cast list, confirm/decline
 │   ├── groups.$groupId.events.$eventId.edit.tsx # Edit/delete event (admin)
-│   ├── groups.$groupId.settings.tsx      # Group settings: edit name, permissions, regenerate invite code
+│   ├── groups.$groupId.notifications.tsx # Per-group notification preferences
+│   ├── groups.$groupId.settings.tsx      # Group settings: edit name, permissions, regenerate invite code, delete group
 │   └── settings.tsx              # User settings: timezone preference
 ├── services/                   # Server-side business logic (*.server.ts)
+│   ├── account.server.ts       # Account deletion (soft-delete, reactivation, sole-admin handling)
 │   ├── auth.server.ts          # Authentication: form strategy, Google OAuth, requireUser()
-│   ├── session.server.ts       # Cookie session storage, getUserId(), createUserSession()
-│   ├── groups.server.ts        # Group CRUD, membership, invite codes, permissions, requireGroupMember/Admin/AdminOrPermission
 │   ├── availability.server.ts  # Availability requests, responses, aggregation
-│   ├── events.server.ts        # Events CRUD, assignments, bulk assign, cross-group queries
+│   ├── csrf.server.ts          # CSRF token generation, validation (cookie-backed)
 │   ├── dashboard.server.ts     # Dashboard data aggregation (parallel queries)
 │   ├── email.server.ts         # Azure Communication Services email with graceful fallback
+│   ├── events.server.ts        # Events CRUD, assignments, bulk assign, cross-group queries
+│   ├── groups.server.ts        # Group CRUD, membership, invite codes, permissions, requireGroupMember/Admin/AdminOrPermission
 │   ├── logger.server.ts        # Pino structured logger, configurable via LOG_LEVEL env var
+│   ├── notification-utils.server.ts # Shared notification preferences utilities (mergeWithDefaults)
 │   ├── rate-limit.server.ts    # In-memory sliding window rate limiter for auth routes
+│   ├── reminder.server.ts      # Event reminder cron job (advisory lock, 24h before)
+│   ├── session.server.ts       # Cookie session storage, getUserId(), createUserSession()
 │   └── telemetry.server.ts     # Application Insights SDK init + getTelemetryClient() helper
 └── components/                 # Reusable React components
     ├── availability-grid.tsx   # Date × status grid for submitting availability
+    ├── csrf-input.tsx          # Hidden CSRF token input (reads from root loader data)
     ├── date-selector.tsx       # Calendar-based date picker for creating requests
     ├── event-calendar.tsx      # Monthly calendar view with event dots
     ├── event-card.tsx          # Reusable event card (used in dashboard, lists, sidebar)
@@ -266,7 +276,8 @@ export async function action({ request }: ActionFunctionArgs) {
 | `/api/health` | Public | Returns `{ status: "ok", timestamp }` |
 | `/api/events/:eventId/ics` | `requireUser` + `requireGroupMember` | Downloads .ics file (role-aware start times for performers) |
 | `/dashboard` | `requireUser` | Action items, upcoming events, group list |
-| `/settings` | `requireUser` | Timezone preference, auto-detects on first visit |
+| `/settings` | `requireUser` | Timezone preference, display name, auto-detects timezone on first visit |
+| `/settings/delete-account` | `requireUser` | Account deletion (soft-delete with 30-day reactivation window) |
 | `/groups` | `requireUser` | Layout (Outlet wrapper) |
 | `/groups` (index) | `requireUser` | List user's groups + inline join form |
 | `/groups/new` | `requireUser` | Create group form |
@@ -282,22 +293,23 @@ export async function action({ request }: ActionFunctionArgs) {
 | `/groups/:groupId/events/new` | `requireGroupAdminOrPermission` | Create event (supports `?fromRequest=&date=`) |
 | `/groups/:groupId/events/:eventId` | `requireGroupMember` | Event detail, cast list, confirm/decline |
 | `/groups/:groupId/events/:eventId/edit` | `requireGroupAdmin` | Edit/delete event |
-| `/groups/:groupId/settings` | `requireGroupAdmin` | Edit group name/description, regenerate invite code |
+| `/groups/:groupId/notifications` | `requireGroupMember` | Per-group notification preferences (email channels) |
+| `/groups/:groupId/settings` | `requireGroupAdmin` | Edit group name/description, permissions, regenerate invite code, delete group |
 
 ## Database Schema
 
-6 tables + 5 enums. All PKs are UUIDs (`defaultRandom()`). All timestamps are `with time zone`.
+7 tables + 5 enums. All PKs are UUIDs (`defaultRandom()`). All timestamps are `with time zone`.
 
 ### Tables
 
 | Table | Key Columns | Notes |
 |-------|-------------|-------|
-| `users` | id, email (unique), passwordHash, name, googleId (unique), emailVerified, timezone | Supports email/password + Google OAuth. `passwordHash` is null for Google-only users. `timezone` is IANA timezone string, auto-detected on first visit |
+| `users` | id, email (unique), passwordHash, name, googleId (unique), emailVerified, timezone, profileImage, deletedAt | Supports email/password + Google OAuth. `passwordHash` is null for Google-only users. `timezone` is IANA timezone string, auto-detected on first visit. `deletedAt` enables soft-delete (30-day reactivation). `profileImage` from Google OAuth. |
 | `groups` | id, name, description, inviteCode (unique, 8 chars), createdById → users, membersCanCreateRequests, membersCanCreateEvents | Invite code uses chars `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (no ambiguous I/O/0/1). Permission booleans default to `false` (admin-only). |
-| `group_memberships` | id, groupId → groups, userId → users, role (admin/member) | Unique on (groupId, userId). Creator gets admin role |
-| `availability_requests` | id, groupId → groups, title, requestedDates (JSONB `string[]`), status (open/closed), expiresAt, requestedStartTime, requestedEndTime | `requestedDates` is a JSON array of ISO date strings. `requestedStartTime`/`requestedEndTime` are nullable "HH:MM" strings for time range (null = all day) |
+| `group_memberships` | id, groupId → groups, userId → users, role (admin/member), notificationPreferences (JSONB) | Unique on (groupId, userId). Creator gets admin role. Per-group notification preferences. |
+| `availability_requests` | id, groupId → groups, title, requestedDates (JSONB `string[]`), status (open/closed), expiresAt, requestedStartTime, requestedEndTime, dateRangeStart, dateRangeEnd | `requestedDates` is a JSON array of ISO date strings. `requestedStartTime`/`requestedEndTime` are nullable "HH:MM" strings for time range (null = all day). `dateRangeStart`/`dateRangeEnd` are timestamps. |
 | `availability_responses` | id, requestId → availability_requests, userId → users, responses (JSONB) | `responses` is `Record<string, "available" | "maybe" | "not_available">`. Upsert on (requestId, userId) |
-| `events` | id, groupId → groups, title, eventType, startTime, endTime, callTime, location, createdFromRequestId | Links back to availability request if created from one. `callTime` is nullable (only for shows — performer arrival time) |
+| `events` | id, groupId → groups, title, eventType, startTime, endTime, callTime, location, createdFromRequestId, reminderSentAt | Links back to availability request if created from one. `callTime` is nullable (only for shows — performer arrival time). `reminderSentAt` tracks when reminder email was sent. |
 | `event_assignments` | id, eventId → events, userId → users, role, status (pending/confirmed/declined) | Unique on (eventId, userId). `onConflictDoNothing` for bulk assigns. Role values: "Performer" (shows), "Viewer" (self-registered attendees) |
 
 ### Enums

--- a/app/routes/groups.$groupId._index.test.ts
+++ b/app/routes/groups.$groupId._index.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock auth service
+vi.mock("~/services/auth.server", () => ({
+	requireUser: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+}));
+
+// Mock groups service
+vi.mock("~/services/groups.server", () => ({
+	requireGroupAdmin: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+	removeMember: vi.fn().mockResolvedValue(undefined),
+	getGroupWithMembers: vi.fn(),
+	requireGroupMember: vi.fn(),
+}));
+
+vi.mock("~/services/availability.server", () => ({
+	getOpenAvailabilityRequestCount: vi.fn(),
+}));
+
+vi.mock("~/services/events.server", () => ({
+	getGroupEvents: vi.fn(),
+}));
+
+// Mock CSRF
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock logger
+vi.mock("~/services/logger.server", () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { action } from "~/routes/groups.$groupId._index";
+import { removeMember } from "~/services/groups.server";
+import { logger } from "~/services/logger.server";
+
+describe("group index action — remove-member", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function makeRequest(intent: string, userId?: string) {
+		const formData = new FormData();
+		formData.set("intent", intent);
+		if (userId !== undefined) {
+			formData.set("userId", userId);
+		}
+		return new Request("http://localhost/groups/g1", {
+			method: "POST",
+			body: formData,
+		});
+	}
+
+	it("returns success for remove-member with valid userId", async () => {
+		const result = await action({
+			request: makeRequest("remove-member", "user-2"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(removeMember).toHaveBeenCalledWith("g1", "user-2");
+	});
+
+	it("returns error when userId is not a string (missing)", async () => {
+		const result = await action({
+			request: makeRequest("remove-member"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid user." });
+		expect(removeMember).not.toHaveBeenCalled();
+	});
+
+	it("returns error when userId is empty string", async () => {
+		const result = await action({
+			request: makeRequest("remove-member", ""),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid user." });
+		expect(removeMember).not.toHaveBeenCalled();
+	});
+
+	it("returns error when removeMember throws", async () => {
+		(removeMember as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("Cannot remove the last admin"),
+		);
+
+		const result = await action({
+			request: makeRequest("remove-member", "user-2"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Cannot remove the last admin" });
+		expect(logger.error).toHaveBeenCalled();
+	});
+
+	it("returns success for unknown intent", async () => {
+		const result = await action({
+			request: makeRequest("unknown-intent"),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(removeMember).not.toHaveBeenCalled();
+	});
+});

--- a/app/routes/groups.$groupId._index.tsx
+++ b/app/routes/groups.$groupId._index.tsx
@@ -37,7 +37,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 	if (intent === "remove-member") {
 		const userId = formData.get("userId");
-		if (typeof userId !== "string") {
+		if (typeof userId !== "string" || !userId.trim()) {
 			return { error: "Invalid user." };
 		}
 		try {

--- a/app/routes/groups.$groupId.availability._index.test.ts
+++ b/app/routes/groups.$groupId.availability._index.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock groups service
+vi.mock("~/services/groups.server", () => ({
+	requireGroupMember: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+}));
+
+// Mock availability service
+vi.mock("~/services/availability.server", () => ({
+	getGroupAvailabilityRequests: vi.fn().mockResolvedValue([]),
+}));
+
+import { loader } from "~/routes/groups.$groupId.availability._index";
+import { getGroupAvailabilityRequests } from "~/services/availability.server";
+import { requireGroupMember } from "~/services/groups.server";
+
+describe("availability index loader", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+		});
+		(getGroupAvailabilityRequests as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+	});
+
+	it("requires group membership", async () => {
+		const request = new Request("http://localhost/groups/g1/availability");
+		await loader({ request, params: { groupId: "g1" }, context: {} });
+		expect(requireGroupMember).toHaveBeenCalledWith(request, "g1");
+	});
+
+	it("returns availability requests", async () => {
+		const mockRequests = [
+			{
+				id: "r1",
+				title: "March Rehearsals",
+				status: "open",
+				dateRangeStart: new Date("2026-03-01"),
+				dateRangeEnd: new Date("2026-03-28"),
+				requestedStartTime: "19:00",
+				requestedEndTime: "21:00",
+				memberCount: 8,
+				responseCount: 5,
+				createdByName: "Admin User",
+			},
+		];
+		(getGroupAvailabilityRequests as ReturnType<typeof vi.fn>).mockResolvedValue(mockRequests);
+
+		const request = new Request("http://localhost/groups/g1/availability");
+		const result = await loader({ request, params: { groupId: "g1" }, context: {} });
+		expect(result).toEqual({ requests: mockRequests });
+	});
+
+	it("passes groupId to getGroupAvailabilityRequests", async () => {
+		const request = new Request("http://localhost/groups/group-xyz/availability");
+		await loader({ request, params: { groupId: "group-xyz" }, context: {} });
+		expect(getGroupAvailabilityRequests).toHaveBeenCalledWith("group-xyz");
+	});
+
+	it("defaults to empty groupId when param is missing", async () => {
+		const request = new Request("http://localhost/groups//availability");
+		await loader({ request, params: {}, context: {} });
+		expect(requireGroupMember).toHaveBeenCalledWith(request, "");
+	});
+});

--- a/app/routes/groups.$groupId.events._index.test.ts
+++ b/app/routes/groups.$groupId.events._index.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock groups service
+vi.mock("~/services/groups.server", () => ({
+	requireGroupMember: vi.fn().mockResolvedValue({
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		profileImage: null,
+	}),
+}));
+
+// Mock events service
+vi.mock("~/services/events.server", () => ({
+	getGroupEvents: vi.fn().mockResolvedValue([]),
+}));
+
+import { loader } from "~/routes/groups.$groupId.events._index";
+import { getGroupEvents } from "~/services/events.server";
+import { requireGroupMember } from "~/services/groups.server";
+
+describe("events index loader", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+		});
+		(getGroupEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+	});
+
+	it("requires group membership", async () => {
+		const request = new Request("http://localhost/groups/g1/events");
+		await loader({ request, params: { groupId: "g1" }, context: {} });
+		expect(requireGroupMember).toHaveBeenCalledWith(request, "g1");
+	});
+
+	it("returns events and userId", async () => {
+		const mockEvents = [
+			{
+				id: "e1",
+				title: "Show Night",
+				eventType: "show",
+				startTime: new Date("2026-03-15T19:00:00Z"),
+				endTime: new Date("2026-03-15T21:00:00Z"),
+				location: "Theater",
+				assignmentCount: 5,
+				confirmedCount: 3,
+			},
+		];
+		(getGroupEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+		const request = new Request("http://localhost/groups/g1/events");
+		const result = await loader({ request, params: { groupId: "g1" }, context: {} });
+		expect(result).toEqual({ events: mockEvents, userId: "user-1" });
+	});
+
+	it("passes groupId to getGroupEvents", async () => {
+		const request = new Request("http://localhost/groups/group-abc/events");
+		await loader({ request, params: { groupId: "group-abc" }, context: {} });
+		expect(getGroupEvents).toHaveBeenCalledWith("group-abc");
+	});
+
+	it("defaults to empty groupId when param is missing", async () => {
+		const request = new Request("http://localhost/groups//events");
+		await loader({ request, params: {}, context: {} });
+		expect(requireGroupMember).toHaveBeenCalledWith(request, "");
+	});
+});

--- a/app/routes/logout.test.ts
+++ b/app/routes/logout.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/services/session.server", () => ({
+	destroyUserSession: vi
+		.fn()
+		.mockResolvedValue(new Response(null, { status: 302, headers: { Location: "/" } })),
+}));
+
+import { action, loader } from "~/routes/logout";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { destroyUserSession } from "~/services/session.server";
+
+describe("logout", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("loader", () => {
+		it("redirects to /", async () => {
+			const response = await loader();
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/");
+		});
+	});
+
+	describe("action", () => {
+		it("validates CSRF then destroys session", async () => {
+			const formData = new FormData();
+			const request = new Request("http://localhost/logout", {
+				method: "POST",
+				body: formData,
+			});
+
+			const response = await action({ request, params: {}, context: {} });
+
+			expect(validateCsrfToken).toHaveBeenCalledWith(request, formData);
+			expect(destroyUserSession).toHaveBeenCalledWith(request, "/");
+			expect((response as Response).status).toBe(302);
+			expect((response as Response).headers.get("Location")).toBe("/");
+		});
+
+		it("throws when CSRF validation fails", async () => {
+			const csrfError = new Response("Invalid CSRF token", { status: 403 });
+			(validateCsrfToken as ReturnType<typeof vi.fn>).mockRejectedValueOnce(csrfError);
+
+			const formData = new FormData();
+			const request = new Request("http://localhost/logout", {
+				method: "POST",
+				body: formData,
+			});
+
+			await expect(action({ request, params: {}, context: {} })).rejects.toBe(csrfError);
+			expect(destroyUserSession).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/app/services/dashboard.server.test.ts
+++ b/app/services/dashboard.server.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Create a chainable mock that returns a resolved value when awaited
+function createChainableMock(resolvedValue: unknown[] = []) {
+	const chain: Record<string, unknown> & { then: (resolve: (v: unknown) => void) => void } = {
+		// biome-ignore lint/suspicious/noThenProperty: needed to make the mock awaitable for Promise.all
+		then: (resolve: (v: unknown) => void) => resolve(resolvedValue),
+	};
+	const methods = ["select", "from", "innerJoin", "leftJoin", "where", "orderBy", "limit"];
+	for (const method of methods) {
+		chain[method] = vi.fn().mockReturnValue(chain);
+	}
+	return chain;
+}
+
+let callIndex = 0;
+let chains: ReturnType<typeof createChainableMock>[];
+
+function resetChains(overrides?: Record<number, unknown[]>) {
+	callIndex = 0;
+	chains = [
+		createChainableMock(overrides?.[0] ?? []), // userGroups
+		createChainableMock(overrides?.[1] ?? []), // upcomingEvents
+		createChainableMock(overrides?.[2] ?? []), // pendingRequests
+		createChainableMock(overrides?.[3] ?? []), // pendingConfirmations
+	];
+}
+
+const mockSelectFn = vi.fn().mockImplementation(() => chains[callIndex++]);
+
+vi.mock("../../src/db/index.js", () => ({
+	db: {
+		select: mockSelectFn,
+	},
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+	availabilityRequests: {
+		id: "id",
+		groupId: "groupId",
+		title: "title",
+		status: "status",
+		expiresAt: "expiresAt",
+		dateRangeStart: "dateRangeStart",
+		dateRangeEnd: "dateRangeEnd",
+	},
+	eventAssignments: { eventId: "eventId", userId: "userId", status: "status" },
+	events: {
+		id: "id",
+		groupId: "groupId",
+		title: "title",
+		description: "description",
+		eventType: "eventType",
+		startTime: "startTime",
+		endTime: "endTime",
+		location: "location",
+		createdById: "createdById",
+		createdFromRequestId: "createdFromRequestId",
+		createdAt: "createdAt",
+		updatedAt: "updatedAt",
+	},
+	groupMemberships: { groupId: "groupId", userId: "userId", role: "role" },
+	groups: {
+		id: "id",
+		name: "name",
+		description: "description",
+		inviteCode: "inviteCode",
+		createdById: "createdById",
+		createdAt: "createdAt",
+		updatedAt: "updatedAt",
+	},
+}));
+
+const mockFormatDateRange = vi.fn().mockReturnValue("Mar 1 – Mar 28, 2026");
+
+vi.mock("../lib/date-utils.js", () => ({
+	formatDateRange: mockFormatDateRange,
+}));
+
+const { getDashboardData } = await import("~/services/dashboard.server");
+
+describe("getDashboardData", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetChains();
+	});
+
+	it("returns structured data with all sections", async () => {
+		const result = await getDashboardData("user-1");
+
+		expect(mockSelectFn).toHaveBeenCalledTimes(4);
+		expect(result).toEqual({
+			groups: [],
+			upcomingEvents: [],
+			pendingRequests: [],
+			pendingConfirmations: [],
+		});
+	});
+
+	it("formats date ranges for pending requests", async () => {
+		resetChains({
+			2: [
+				{
+					id: "req-1",
+					title: "March Availability",
+					groupId: "group-1",
+					groupName: "Cool Group",
+					expiresAt: null,
+					dateRangeStart: "2026-03-01",
+					dateRangeEnd: "2026-03-28",
+				},
+				{
+					id: "req-2",
+					title: "April Availability",
+					groupId: "group-1",
+					groupName: "Cool Group",
+					expiresAt: null,
+					dateRangeStart: "2026-04-01",
+					dateRangeEnd: "2026-04-30",
+				},
+			],
+		});
+
+		const result = await getDashboardData("user-1");
+
+		expect(mockFormatDateRange).toHaveBeenCalledTimes(2);
+		expect(mockFormatDateRange).toHaveBeenCalledWith("2026-03-01", "2026-03-28");
+		expect(mockFormatDateRange).toHaveBeenCalledWith("2026-04-01", "2026-04-30");
+		expect(result.pendingRequests).toHaveLength(2);
+		expect(result.pendingRequests[0]).toEqual({
+			id: "req-1",
+			title: "March Availability",
+			groupId: "group-1",
+			groupName: "Cool Group",
+			expiresAt: null,
+			dateRange: "Mar 1 – Mar 28, 2026",
+		});
+	});
+
+	it("passes userId to queries without throwing", async () => {
+		await expect(getDashboardData("user-123")).resolves.toBeDefined();
+		expect(mockSelectFn).toHaveBeenCalledTimes(4);
+	});
+});

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -1,22 +1,10 @@
 import { EmailClient } from "@azure/communication-email";
 import type { NotificationPreferences } from "../../src/db/schema.js";
-import { DEFAULT_NOTIFICATION_PREFERENCES } from "../../src/db/schema.js";
 import { logger } from "./logger.server.js";
+import { mergeWithDefaults } from "./notification-utils.server.js";
 import { getTelemetryClient } from "./telemetry.server.js";
 
 // --- Core Email Sender ---
-
-function mergeWithDefaults(
-	stored: Partial<NotificationPreferences> | null | undefined,
-): NotificationPreferences {
-	const defaults = DEFAULT_NOTIFICATION_PREFERENCES;
-	if (!stored) return { ...defaults };
-	return {
-		availabilityRequests: { ...defaults.availabilityRequests, ...stored.availabilityRequests },
-		eventNotifications: { ...defaults.eventNotifications, ...stored.eventNotifications },
-		showReminders: { ...defaults.showReminders, ...stored.showReminders },
-	};
-}
 
 let emailClient: EmailClient | null = null;
 const senderAddress = "DoNotReply@mycalltime.app";

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -9,6 +9,7 @@ import {
 	users,
 } from "../../src/db/schema.js";
 import { requireUser } from "./auth.server.js";
+import { mergeWithDefaults } from "./notification-utils.server.js";
 
 type Group = typeof groups.$inferSelect;
 
@@ -279,21 +280,8 @@ export async function updateGroupPermissions(
 
 // --- Notification Preferences ---
 
-/**
- * Merge stored preferences with defaults for forward-compatibility.
- * New categories or channels added later will default to true.
- */
-export function mergeWithDefaults(
-	stored: Partial<NotificationPreferences> | null | undefined,
-): NotificationPreferences {
-	const defaults = DEFAULT_NOTIFICATION_PREFERENCES;
-	if (!stored) return { ...defaults };
-	return {
-		availabilityRequests: { ...defaults.availabilityRequests, ...stored.availabilityRequests },
-		eventNotifications: { ...defaults.eventNotifications, ...stored.eventNotifications },
-		showReminders: { ...defaults.showReminders, ...stored.showReminders },
-	};
-}
+// Re-export mergeWithDefaults from shared utility for backward compatibility
+export { mergeWithDefaults } from "./notification-utils.server.js";
 
 export async function getNotificationPreferences(
 	userId: string,

--- a/app/services/notification-utils.server.ts
+++ b/app/services/notification-utils.server.ts
@@ -1,0 +1,18 @@
+import type { NotificationPreferences } from "../../src/db/schema.js";
+import { DEFAULT_NOTIFICATION_PREFERENCES } from "../../src/db/schema.js";
+
+/**
+ * Merge stored preferences with defaults for forward-compatibility.
+ * New categories or channels added later will default to true.
+ */
+export function mergeWithDefaults(
+	stored: Partial<NotificationPreferences> | null | undefined,
+): NotificationPreferences {
+	const defaults = DEFAULT_NOTIFICATION_PREFERENCES;
+	if (!stored) return { ...defaults };
+	return {
+		availabilityRequests: { ...defaults.availabilityRequests, ...stored.availabilityRequests },
+		eventNotifications: { ...defaults.eventNotifications, ...stored.eventNotifications },
+		showReminders: { ...defaults.showReminders, ...stored.showReminders },
+	};
+}

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "drizzle-kit";
 
+if (!process.env.DATABASE_URL) {
+	throw new Error("DATABASE_URL environment variable is required");
+}
+
 export default defineConfig({
 	out: "./drizzle",
 	schema: "./src/db/schema.ts",
 	dialect: "postgresql",
 	dbCredentials: {
-		url: process.env.DATABASE_URL!,
+		url: process.env.DATABASE_URL,
 	},
 });


### PR DESCRIPTION
## Quality Hardening Sprint

### What was done

**Lint cleanup:**
- Fixed `drizzle.config.ts` lint warning (`noNonNullAssertion` → explicit null check with thrown error)
- Lint now passes with **0 warnings** (down from 1)

**Code deduplication:**
- Extracted duplicate `mergeWithDefaults` function from `groups.server.ts` and `email.server.ts` into shared `notification-utils.server.ts`
- `groups.server.ts` re-exports for backward compatibility

**Security fix:**
- Fixed empty string bypassing validation in remove-member action (`groups.$groupId._index.tsx`)

**Test coverage (+19 tests):**
- `logout.test.ts` — CSRF validation, session destruction (3 tests)
- `groups.$groupId._index.test.ts` — remove-member action: valid, missing, empty, error handling (5 tests)
- `dashboard.server.test.ts` — parallel query structure, date formatting (3 tests)
- `groups.$groupId.events._index.test.ts` — loader auth and data flow (4 tests)
- `groups.$groupId.availability._index.test.ts` — loader auth and data flow (4 tests)

**Documentation updates:**
- Updated `AGENTS.md`: added missing routes (`check-email`, `verify-email`, `notifications`, `delete-account`), services (`account`, `csrf`, `notification-utils`, `reminder`), components (`csrf-input`), and schema columns (`deletedAt`, `profileImage`, `reminderSentAt`, `notificationPreferences`)

**Housekeeping:**
- Pruned 14 stale remote branches

### Quality gates
- ✅ `pnpm run typecheck` — clean
- ✅ `pnpm run lint` — 0 warnings, 0 errors
- ✅ `pnpm run build` — succeeds
- ✅ `pnpm test` — **322 tests passing** (up from 303)