### PR TITLE
feat: add usage telemetry tracking for key user actions

### DIFF
--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -7,6 +7,7 @@ import { FormStrategy } from "remix-auth-form";
 import { db } from "../../src/db/index.js";
 import { users } from "../../src/db/schema.js";
 import { destroyUserSession, getSession, getUserId, sessionStorage } from "./session.server.js";
+import { trackEvent } from "./telemetry.server.js";
 
 type UserRecord = typeof users.$inferSelect;
 
@@ -140,6 +141,7 @@ export async function registerUser(
 			throw new Error("Failed to create user.");
 		}
 
+		trackEvent("UserCreated", { method: "email" });
 		return { user: toAuthUser(user), isNew: true };
 	} catch (error) {
 		// Handle race condition: concurrent signup with same email hits unique constraint
@@ -196,6 +198,7 @@ export async function findOrCreateGoogleUser(profile: {
 
 	const user = result[0];
 	if (!user) throw new Error("Failed to create user.");
+	trackEvent("UserCreated", { method: "google" });
 	return toAuthUser(user);
 }
 

--- a/app/services/availability.server.ts
+++ b/app/services/availability.server.ts
@@ -7,6 +7,7 @@ import {
 	groupMemberships,
 	users,
 } from "../../src/db/schema.js";
+import { trackEvent } from "./telemetry.server.js";
 
 type AvailabilityRequest = typeof availabilityRequests.$inferSelect;
 
@@ -40,6 +41,7 @@ export async function createAvailabilityRequest(data: {
 		})
 		.returning();
 	if (!request) throw new Error("Failed to create availability request.");
+	trackEvent("AvailabilityRequestCreated", { groupId: data.groupId });
 	return request;
 }
 

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -10,6 +10,7 @@ import {
 	users,
 } from "../../src/db/schema.js";
 import { localTimeToUTC } from "../lib/date-utils.js";
+import { trackEvent } from "./telemetry.server.js";
 
 type Event = typeof events.$inferSelect;
 
@@ -43,6 +44,7 @@ export async function createEvent(data: {
 		})
 		.returning();
 	if (!event) throw new Error("Failed to create event.");
+	trackEvent("EventCreated", { groupId: data.groupId, eventType: data.eventType });
 	return event;
 }
 

--- a/app/services/telemetry.server.test.ts
+++ b/app/services/telemetry.server.test.ts
@@ -17,4 +17,45 @@ describe("telemetry.server", () => {
 		const { getTelemetryClient } = await import("./telemetry.server");
 		expect(getTelemetryClient()).toBeNull();
 	});
+
+	it("trackEvent is a no-op when client is null", async () => {
+		vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", "");
+		const { trackEvent } = await import("./telemetry.server");
+		// Should not throw
+		expect(() => trackEvent("TestEvent", { key: "value" })).not.toThrow();
+	});
+
+	it("trackEvent calls client.trackEvent when client is available", async () => {
+		const mockTrackEvent = vi.fn();
+		vi.doMock("applicationinsights", () => ({
+			default: {
+				setup: vi.fn().mockReturnValue({
+					setAutoCollectRequests: vi.fn().mockReturnValue({
+						setAutoCollectExceptions: vi.fn().mockReturnValue({
+							setAutoCollectDependencies: vi.fn().mockReturnValue({
+								setAutoCollectPerformance: vi.fn().mockReturnValue({
+									setSendLiveMetrics: vi.fn().mockReturnValue({
+										start: vi.fn(),
+									}),
+								}),
+							}),
+						}),
+					}),
+				}),
+				defaultClient: {
+					trackEvent: mockTrackEvent,
+					context: { tags: {}, keys: { cloudRole: "cloudRole" } },
+				},
+			},
+		}));
+
+		vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=test-key");
+		const { trackEvent } = await import("./telemetry.server");
+
+		trackEvent("UserCreated", { method: "email" });
+		expect(mockTrackEvent).toHaveBeenCalledWith({
+			name: "UserCreated",
+			properties: { method: "email" },
+		});
+	});
 });

--- a/app/services/telemetry.server.ts
+++ b/app/services/telemetry.server.ts
@@ -26,3 +26,11 @@ if (connectionString) {
 export function getTelemetryClient(): appInsights.TelemetryClient | null {
 	return connectionString ? appInsights.defaultClient : null;
 }
+
+/**
+ * Track a custom event in Application Insights.
+ * Safe no-op when App Insights isn't configured (e.g., local dev).
+ */
+export function trackEvent(name: string, properties?: Record<string, string>): void {
+	getTelemetryClient()?.trackEvent({ name, properties });
+}


### PR DESCRIPTION
## Summary

Adds custom Application Insights event tracking at key user action points for usage telemetry.

### Changes

1. **`app/services/telemetry.server.ts`** — Added `trackEvent(name, properties?)` helper that wraps `getTelemetryClient()?.trackEvent()`. Safe no-op when App Insights isn't configured.

2. **`app/services/auth.server.ts`** — Tracks `UserCreated` events with `{ method: "email" }` (email signup) and `{ method: "google" }` (Google OAuth new user creation).

3. **`app/services/availability.server.ts`** — Tracks `AvailabilityRequestCreated` events with `{ groupId }`.

4. **`app/services/events.server.ts`** — Tracks `EventCreated` events with `{ groupId, eventType }`.

5. **`app/services/telemetry.server.test.ts`** — Added tests for `trackEvent` (no-op when client is null, calls `client.trackEvent` when configured).

### Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅ 
- `pnpm run build` ✅
- `pnpm test` ✅ (305 tests pass)

### Querying these events in App Insights

```kql
customEvents
| where name in ('UserCreated', 'AvailabilityRequestCreated', 'EventCreated')
| where timestamp > ago(24h)
| summarize count() by name, tostring(customDimensions)
```