### PR TITLE
fix: correct notification preferences link in reminder emails

### DIFF
--- a/app/services/reminder.server.ts
+++ b/app/services/reminder.server.ts
@@ -120,7 +120,7 @@ export async function processReminders(): Promise<void> {
 				);
 
 			const eventUrl = `${appUrl}/groups/${event.groupId}/events/${event.id}`;
-			const preferencesUrl = `${appUrl}/groups/${event.groupId}/settings`;
+			const preferencesUrl = `${appUrl}/groups/${event.groupId}/notifications`;
 
 			for (const attendee of attendees) {
 				// Format times in each attendee's timezone for accurate display


### PR DESCRIPTION
## Summary

The "Manage notification preferences" link in **reminder emails** (sent 24h before events) pointed to `/groups/:groupId/settings` instead of `/groups/:groupId/notifications`.

The other email senders (availability requests, event creation, event assignments) already used the correct `/notifications` route — only `reminder.server.ts` had the wrong URL.

## Changes

- **`app/services/reminder.server.ts`**: Changed `preferencesUrl` from `/groups/${event.groupId}/settings` to `/groups/${event.groupId}/notifications`

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅  
- `pnpm run build` ✅
- `pnpm test` — 324/324 tests pass ✅