### PR TITLE
fix: display event times in recipient's timezone in notification emails

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -423,6 +423,7 @@ describe("event detail action — assignment notifications", () => {
 				expect.objectContaining({
 					eventTitle: "Friday Show",
 					eventType: "show",
+					dateTime: "Sun, Mar 15 · 12:00 PM – 2:00 PM",
 					groupName: "Test Group",
 					recipient: expect.objectContaining({
 						email: "new@example.com",

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -177,15 +177,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
 					const eventUrl = `${appUrl}/groups/${groupId}/events/${eventId}`;
 					const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
 					const event = eventData.event;
-					const dateTime = formatEventTime(
-						event.startTime as unknown as string,
-						event.endTime as unknown as string,
-					);
 					const groupName = groupData?.group.name ?? "";
 
 					for (const userId of newlyAssignedIds) {
 						const member = prefsMap.get(userId);
 						if (!member) continue;
+						const tz = member.timezone ?? undefined;
+						const dateTime = formatEventTime(
+							event.startTime as unknown as string,
+							event.endTime as unknown as string,
+							tz,
+						);
 						void sendEventAssignmentNotification({
 							eventTitle: event.title,
 							eventType: event.eventType,

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -12,7 +12,7 @@ import { ArrowLeft, Clock, Users } from "lucide-react";
 import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { InlineTimezoneSelector } from "~/components/timezone-selector";
-import { formatEventTime, localTimeToUTC } from "~/lib/date-utils";
+import { localTimeToUTC } from "~/lib/date-utils";
 import { getAvailabilityRequest } from "~/services/availability.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import {
@@ -158,7 +158,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		if (!groupData) return;
 
 		const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m.notificationPreferences]));
-		const dateTime = formatEventTime(`${date}T${startTime}:00`, `${date}T${endTime}:00`);
 
 		if (validFromRequestId && typeof date === "string") {
 			// Availability-aware notifications
@@ -166,18 +165,25 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			const memberMap = new Map(
 				groupData.members.map((m) => [
 					m.id,
-					{ email: m.email, name: m.name, notificationPreferences: prefsMap.get(m.id) },
+					{
+						email: m.email,
+						name: m.name,
+						timezone: m.timezone,
+						notificationPreferences: prefsMap.get(m.id),
+					},
 				]),
 			);
 
 			const availableRecipients: Array<{
 				email: string;
 				name: string;
+				timezone?: string | null;
 				notificationPreferences?: NotificationPreferences;
 			}> = [];
 			const maybeRecipients: Array<{
 				email: string;
 				name: string;
+				timezone?: string | null;
 				notificationPreferences?: NotificationPreferences;
 			}> = [];
 			const respondedUserIds = new Set<string>();
@@ -204,13 +210,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				.map((m) => ({
 					email: m.email,
 					name: m.name,
+					timezone: m.timezone,
 					notificationPreferences: prefsMap.get(m.id),
 				}));
 
 			void sendEventFromAvailabilityNotification({
 				eventTitle: event.title,
 				eventType: event.eventType,
-				dateTime,
+				startTime: event.startTime,
+				endTime: event.endTime,
 				location: event.location ?? undefined,
 				groupName: groupData.group.name,
 				eventUrl,
@@ -226,6 +234,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				.map((m) => ({
 					email: m.email,
 					name: m.name,
+					timezone: m.timezone,
 					notificationPreferences: prefsMap.get(m.id),
 				}));
 			if (recipients.length === 0) return;
@@ -233,7 +242,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			void sendEventCreatedNotification({
 				eventTitle: event.title,
 				eventType: event.eventType,
-				dateTime,
+				startTime: event.startTime,
+				endTime: event.endTime,
 				location: event.location ?? undefined,
 				groupName: groupData.group.name,
 				recipients,

--- a/app/services/email-notification-filtering.test.ts
+++ b/app/services/email-notification-filtering.test.ts
@@ -67,7 +67,8 @@ describe("email notification filtering", () => {
 		await sendEventCreatedNotification({
 			eventTitle: "Friday Show",
 			eventType: "show",
-			dateTime: "Fri, Mar 15 · 7:00 PM",
+			startTime: "2026-03-15T19:00:00.000Z",
+			endTime: "2026-03-15T21:00:00.000Z",
 			groupName: "Test Group",
 			recipients: [
 				{

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -1,5 +1,6 @@
 import { EmailClient } from "@azure/communication-email";
 import type { NotificationPreferences } from "../../src/db/schema.js";
+import { formatEventTime } from "../lib/date-utils.js";
 import { logger } from "./logger.server.js";
 import { mergeWithDefaults } from "./notification-utils.server.js";
 import { getTelemetryClient } from "./telemetry.server.js";
@@ -216,12 +217,14 @@ ${ctaButton(options.requestUrl, "Submit Your Availability")}
 export async function sendEventCreatedNotification(options: {
 	eventTitle: string;
 	eventType: string;
-	dateTime: string;
+	startTime: string | Date;
+	endTime: string | Date;
 	location?: string;
 	groupName: string;
 	recipients: Array<{
 		email: string;
 		name: string;
+		timezone?: string | null;
 		notificationPreferences?: NotificationPreferences;
 	}>;
 	eventUrl: string;
@@ -237,13 +240,19 @@ export async function sendEventCreatedNotification(options: {
 		const prefs = mergeWithDefaults(recipient.notificationPreferences);
 		if (!prefs.eventNotifications.email) continue;
 
+		const dateTime = formatEventTime(
+			options.startTime,
+			options.endTime,
+			recipient.timezone ?? undefined,
+		);
+
 		const html = emailLayout(
 			`
 <h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">New Event Created</h2>
 <p style="color:#475569;margin:0 0 20px;">Hi ${escapeHtml(recipient.name)}, you've been assigned to an upcoming event.</p>
 ${infoCard([
 	`<p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#0f172a;">${typeEmoji} ${escapeHtml(options.eventTitle)}</p>`,
-	`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(options.dateTime)}</p>`,
+	`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(dateTime)}</p>`,
 	locationLine,
 ])}
 ${ctaButton(options.eventUrl, "View Event Details")}
@@ -251,7 +260,7 @@ ${ctaButton(options.eventUrl, "View Event Details")}
 			{ preferencesUrl: options.preferencesUrl },
 		);
 
-		const text = `Hi ${recipient.name},\n\nYou've been assigned to an upcoming event.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${options.dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details and confirm: ${options.eventUrl}`;
+		const text = `Hi ${recipient.name},\n\nYou've been assigned to an upcoming event.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details and confirm: ${options.eventUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
@@ -303,23 +312,27 @@ ${ctaButton(options.eventUrl, "Confirm Attendance")}
 export async function sendEventFromAvailabilityNotification(options: {
 	eventTitle: string;
 	eventType: string;
-	dateTime: string;
+	startTime: string | Date;
+	endTime: string | Date;
 	location?: string;
 	groupName: string;
 	eventUrl: string;
 	availableRecipients: Array<{
 		email: string;
 		name: string;
+		timezone?: string | null;
 		notificationPreferences?: NotificationPreferences;
 	}>;
 	maybeRecipients: Array<{
 		email: string;
 		name: string;
+		timezone?: string | null;
 		notificationPreferences?: NotificationPreferences;
 	}>;
 	noResponseRecipients: Array<{
 		email: string;
 		name: string;
+		timezone?: string | null;
 		notificationPreferences?: NotificationPreferences;
 	}>;
 	preferencesUrl?: string;
@@ -330,18 +343,22 @@ export async function sendEventFromAvailabilityNotification(options: {
 		? `<p style="margin:0;font-size:13px;color:#475569;">📍 ${escapeHtml(options.location)}</p>`
 		: "";
 
-	const eventBlock = infoCard([
-		`<p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#0f172a;">${typeEmoji} ${escapeHtml(options.eventTitle)}</p>`,
-		`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(options.dateTime)}</p>`,
-		locationLine,
-	]);
-
 	const layoutOpts = { preferencesUrl: options.preferencesUrl };
 
 	// Email people who said "available" — they're confirmed
 	for (const recipient of options.availableRecipients) {
 		const prefs = mergeWithDefaults(recipient.notificationPreferences);
 		if (!prefs.eventNotifications.email) continue;
+		const dateTime = formatEventTime(
+			options.startTime,
+			options.endTime,
+			recipient.timezone ?? undefined,
+		);
+		const eventBlock = infoCard([
+			`<p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#0f172a;">${typeEmoji} ${escapeHtml(options.eventTitle)}</p>`,
+			`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(dateTime)}</p>`,
+			locationLine,
+		]);
 
 		const html = emailLayout(
 			`
@@ -353,7 +370,7 @@ ${ctaButton(options.eventUrl, "View Event Details")}
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nGreat news - you're confirmed! The event you said you were available for is happening.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${options.dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details: ${options.eventUrl}`;
+		const text = `Hi ${recipient.name},\n\nGreat news - you're confirmed! The event you said you were available for is happening.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details: ${options.eventUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
@@ -367,6 +384,16 @@ ${ctaButton(options.eventUrl, "View Event Details")}
 	for (const recipient of options.maybeRecipients) {
 		const prefs = mergeWithDefaults(recipient.notificationPreferences);
 		if (!prefs.eventNotifications.email) continue;
+		const dateTime = formatEventTime(
+			options.startTime,
+			options.endTime,
+			recipient.timezone ?? undefined,
+		);
+		const eventBlock = infoCard([
+			`<p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#0f172a;">${typeEmoji} ${escapeHtml(options.eventTitle)}</p>`,
+			`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(dateTime)}</p>`,
+			locationLine,
+		]);
 
 		const html = emailLayout(
 			`
@@ -378,11 +405,11 @@ ${ctaButton(options.eventUrl, "Confirm Attendance")}
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nYou said you might be free - the event is now scheduled!\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${options.dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nConfirm your attendance: ${options.eventUrl}`;
+		const text = `Hi ${recipient.name},\n\nYou said you might be free - the event is now scheduled!\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nConfirm your attendance: ${options.eventUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
-			subject: `${typeEmoji} Can you make it? "${options.eventTitle}" is on ${options.dateTime}`,
+			subject: `${typeEmoji} Can you make it? "${options.eventTitle}" is on ${dateTime}`,
 			html,
 			text,
 		});
@@ -392,6 +419,16 @@ ${ctaButton(options.eventUrl, "Confirm Attendance")}
 	for (const recipient of options.noResponseRecipients) {
 		const prefs = mergeWithDefaults(recipient.notificationPreferences);
 		if (!prefs.eventNotifications.email) continue;
+		const dateTime = formatEventTime(
+			options.startTime,
+			options.endTime,
+			recipient.timezone ?? undefined,
+		);
+		const eventBlock = infoCard([
+			`<p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#0f172a;">${typeEmoji} ${escapeHtml(options.eventTitle)}</p>`,
+			`<p style="margin:0 0 4px;font-size:13px;color:#475569;">${escapeHtml(options.groupName)} · ${escapeHtml(dateTime)}</p>`,
+			locationLine,
+		]);
 
 		const html = emailLayout(
 			`
@@ -403,11 +440,11 @@ ${ctaButton(options.eventUrl, "View Event Details")}
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nA new event has been scheduled for your group.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${options.dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details: ${options.eventUrl}`;
+		const text = `Hi ${recipient.name},\n\nA new event has been scheduled for your group.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details: ${options.eventUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
-			subject: `${typeEmoji} New event — "${options.eventTitle}" on ${options.dateTime}`,
+			subject: `${typeEmoji} New event — "${options.eventTitle}" on ${dateTime}`,
 			html,
 			text,
 		});

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -105,6 +105,7 @@ export async function getGroupWithMembers(groupId: string): Promise<{
 		profileImage: string | null;
 		role: string;
 		joinedAt: Date;
+		timezone: string | null;
 	}>;
 } | null> {
 	const [group] = await db.select().from(groups).where(eq(groups.id, groupId)).limit(1);
@@ -118,6 +119,7 @@ export async function getGroupWithMembers(groupId: string): Promise<{
 			profileImage: users.profileImage,
 			role: groupMemberships.role,
 			joinedAt: groupMemberships.joinedAt,
+			timezone: users.timezone,
 		})
 		.from(groupMemberships)
 		.innerJoin(users, eq(groupMemberships.userId, users.id))
@@ -311,6 +313,7 @@ export async function getGroupMembersWithPreferences(groupId: string): Promise<
 		id: string;
 		name: string;
 		email: string;
+		timezone: string | null;
 		notificationPreferences: NotificationPreferences;
 	}>
 > {
@@ -319,6 +322,7 @@ export async function getGroupMembersWithPreferences(groupId: string): Promise<
 			id: users.id,
 			name: users.name,
 			email: users.email,
+			timezone: users.timezone,
 			notificationPreferences: groupMemberships.notificationPreferences,
 		})
 		.from(groupMemberships)


### PR DESCRIPTION
## Problem

Event notification emails showed times in UTC instead of the recipient's timezone. A PST user would see "Tue, Mar 4 · 3:00 AM" instead of "Mon, Mar 3 · 7:00 PM" for the same event.

## Root Cause

`formatEventTime()` was called without the user's timezone in two notification flows:
1. Event creation notifications (`events.new.tsx`)
2. Event assignment notifications (`events.$eventId.tsx`)

The reminder email (`reminder.server.ts`) already did this correctly — it formats per-attendee with their stored timezone.

## Fix

### Data Layer
- `getGroupWithMembers()` and `getGroupMembersWithPreferences()` now include `users.timezone` in their queries and return types.

### Email Functions  
- `sendEventCreatedNotification()` and `sendEventFromAvailabilityNotification()` now accept `startTime`/`endTime` (raw Date/string) instead of pre-formatted `dateTime`, plus `timezone` on each recipient.
- Each function formats the time per-recipient inside its loop, matching the reminder pattern: `formatEventTime(startTime, endTime, recipient.timezone ?? undefined)`.

### Route Fixes
- **`events.$eventId.tsx`**: Moved `formatEventTime()` inside the per-user loop, passing `member.timezone ?? undefined`.
- **`events.new.tsx`**: Removed global `dateTime` computation. Passes `event.startTime`/`event.endTime` and `timezone` per recipient to the updated email functions.

## Testing
- All 337 tests pass
- Updated assignment notification test to verify timezone-aware formatting (America/Los_Angeles)
- Updated `email-notification-filtering.test.ts` for new function signature
- TypeScript strict mode passes
- Biome lint clean
- Production build succeeds