### PR TITLE
feat: Add per-group Discord webhook notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ app/
 │   ├── groups.$groupId.events.$eventId.tsx      # Event detail: cast list, confirm/decline
 │   ├── groups.$groupId.events.$eventId.edit.tsx # Edit/delete event (admin)
 │   ├── groups.$groupId.notifications.tsx # Per-group notification preferences
-│   ├── groups.$groupId.settings.tsx      # Group settings: edit name, permissions, regenerate invite code, delete group
+│   ├── groups.$groupId.settings.tsx      # Group settings: edit name, permissions, Discord webhook, regenerate invite code, delete group
 │   └── settings.tsx              # User settings: timezone preference
 ├── services/                   # Server-side business logic (*.server.ts)
 │   ├── account.server.ts       # Account deletion (soft-delete, reactivation, sole-admin handling)
@@ -74,7 +74,8 @@ app/
 │   ├── rate-limit.server.ts    # In-memory sliding window rate limiter for auth routes
 │   ├── reminder.server.ts      # Event reminder cron job (advisory lock, 24h before)
 │   ├── session.server.ts       # Cookie session storage, getUserId(), createUserSession()
-│   └── telemetry.server.ts     # Application Insights SDK init + getTelemetryClient() helper
+│   ├── telemetry.server.ts     # Application Insights SDK init + getTelemetryClient() helper
+│   └── webhook.server.ts      # Discord webhook notifications (fire-and-forget)
 └── components/                 # Reusable React components
     ├── availability-grid.tsx   # Date × status grid for submitting availability
     ├── csrf-input.tsx          # Hidden CSRF token input (reads from root loader data)
@@ -305,7 +306,7 @@ export async function action({ request }: ActionFunctionArgs) {
 | Table | Key Columns | Notes |
 |-------|-------------|-------|
 | `users` | id, email (unique), passwordHash, name, googleId (unique), emailVerified, timezone, profileImage, deletedAt | Supports email/password + Google OAuth. `passwordHash` is null for Google-only users. `timezone` is IANA timezone string, auto-detected on first visit. `deletedAt` enables soft-delete (30-day reactivation). `profileImage` from Google OAuth. |
-| `groups` | id, name, description, inviteCode (unique, 8 chars), createdById → users, membersCanCreateRequests, membersCanCreateEvents | Invite code uses chars `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (no ambiguous I/O/0/1). Permission booleans default to `false` (admin-only). |
+| `groups` | id, name, description, inviteCode (unique, 8 chars), createdById → users, membersCanCreateRequests, membersCanCreateEvents, webhookUrl | Invite code uses chars `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (no ambiguous I/O/0/1). Permission booleans default to `false` (admin-only). `webhookUrl` is nullable varchar(500) for Discord webhook integration. |
 | `group_memberships` | id, groupId → groups, userId → users, role (admin/member), notificationPreferences (JSONB) | Unique on (groupId, userId). Creator gets admin role. Per-group notification preferences. |
 | `availability_requests` | id, groupId → groups, title, requestedDates (JSONB `string[]`), status (open/closed), expiresAt, requestedStartTime, requestedEndTime, dateRangeStart, dateRangeEnd | `requestedDates` is a JSON array of ISO date strings. `requestedStartTime`/`requestedEndTime` are nullable "HH:MM" strings for time range (null = all day). `dateRangeStart`/`dateRangeEnd` are timestamps. |
 | `availability_responses` | id, requestId → availability_requests, userId → users, responses (JSONB) | `responses` is `Record<string, "available" | "maybe" | "not_available">`. Upsert on (requestId, userId) |

--- a/app/routes/groups.$groupId.availability.new.tsx
+++ b/app/routes/groups.$groupId.availability.new.tsx
@@ -21,6 +21,7 @@ import {
 	getGroupMembersWithPreferences,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { sendAvailabilityRequestWebhook } from "~/services/webhook.server";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "New Availability Request — My Call Time" }];
@@ -147,6 +148,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				requestUrl: `${appUrl}/groups/${groupId}/availability/${req.id}`,
 				preferencesUrl,
 			});
+
+			// Fire-and-forget Discord webhook
+			if (group.webhookUrl) {
+				sendAvailabilityRequestWebhook(group.webhookUrl, {
+					groupName: group.name,
+					title: req.title,
+					createdByName: user.name,
+					dateRange: dateRangeDisplay,
+					requestUrl: `${appUrl}/groups/${groupId}/availability/${req.id}`,
+				});
+			}
 		},
 	);
 

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -12,7 +12,7 @@ import { ArrowLeft, Clock, Users } from "lucide-react";
 import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { InlineTimezoneSelector } from "~/components/timezone-selector";
-import { localTimeToUTC } from "~/lib/date-utils";
+import { formatEventTime, localTimeToUTC } from "~/lib/date-utils";
 import { getAvailabilityRequest } from "~/services/availability.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import {
@@ -29,6 +29,7 @@ import {
 	getGroupWithMembers,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { sendEventCreatedWebhook } from "~/services/webhook.server";
 import type { NotificationPreferences } from "../../src/db/schema.js";
 
 export const meta: MetaFunction = () => {
@@ -249,6 +250,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				recipients,
 				eventUrl,
 				preferencesUrl,
+			});
+		}
+
+		// Fire-and-forget Discord webhook
+		if (groupData.group.webhookUrl) {
+			sendEventCreatedWebhook(groupData.group.webhookUrl, {
+				groupName: groupData.group.name,
+				eventTitle: event.title,
+				eventType: event.eventType,
+				dateTime: formatEventTime(event.startTime, event.endTime),
+				location: event.location ?? undefined,
+				eventUrl,
 			});
 		}
 	})();

--- a/app/routes/groups.$groupId.settings.tsx
+++ b/app/routes/groups.$groupId.settings.tsx
@@ -13,13 +13,21 @@ import {
 	updateGroupPermissions,
 } from "~/services/groups.server";
 import { logger } from "~/services/logger.server";
+import { isValidWebhookUrl, sendTestWebhook } from "~/services/webhook.server";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	await requireGroupAdmin(request, groupId);
 	const group = await getGroupById(groupId);
 	if (!group) throw new Response("Not Found", { status: 404 });
-	return { group };
+	return {
+		group: {
+			...group,
+			// Mask the webhook URL — the token is secret and should not be sent to the client
+			webhookUrl: undefined,
+			hasWebhook: !!group.webhookUrl,
+		},
+	};
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -86,6 +94,59 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				"Failed to update permissions",
 			);
 			return { error: "Failed to update permissions.", success: false };
+		}
+	}
+
+	if (intent === "update-webhook") {
+		const webhookUrl = formData.get("webhookUrl");
+		const url = typeof webhookUrl === "string" ? webhookUrl.trim() : "";
+
+		if (url && !isValidWebhookUrl(url)) {
+			return {
+				error:
+					"Invalid webhook URL. Must be a Discord webhook URL (https://discord.com/api/webhooks/...).",
+				success: false,
+			};
+		}
+
+		try {
+			await updateGroup(groupId, { webhookUrl: url || null });
+			return { success: true, message: url ? "Webhook URL saved." : "Webhook URL removed." };
+		} catch (error) {
+			logger.error(
+				{ err: error, route: "groups.$groupId.settings", intent: "update-webhook" },
+				"Failed to update webhook URL",
+			);
+			return { error: "Failed to update webhook URL.", success: false };
+		}
+	}
+
+	if (intent === "test-webhook") {
+		const group = await getGroupById(groupId);
+		if (!group?.webhookUrl) {
+			return { error: "No webhook URL configured.", success: false };
+		}
+
+		const success = await sendTestWebhook(group.webhookUrl, group.name);
+		if (success) {
+			return { success: true, message: "Test message sent! Check your Discord channel." };
+		}
+		return {
+			error: "Failed to send test message. Please verify the webhook URL is correct.",
+			success: false,
+		};
+	}
+
+	if (intent === "remove-webhook") {
+		try {
+			await updateGroup(groupId, { webhookUrl: null });
+			return { success: true, message: "Webhook URL removed." };
+		} catch (error) {
+			logger.error(
+				{ err: error, route: "groups.$groupId.settings", intent: "remove-webhook" },
+				"Failed to remove webhook URL",
+			);
+			return { error: "Failed to remove webhook URL.", success: false };
 		}
 	}
 
@@ -274,6 +335,78 @@ export default function GroupSettings() {
 						{isSubmitting ? "Saving…" : "Save Permissions"}
 					</button>
 				</Form>
+			</div>
+
+			{/* Discord Webhook */}
+			<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+				<div className="border-b border-slate-100 px-6 py-4">
+					<h2 className="text-lg font-semibold text-slate-900">Discord Webhook</h2>
+					<p className="mt-1 text-sm text-slate-500">
+						Paste a Discord channel webhook URL to receive notifications in Discord
+					</p>
+				</div>
+				<div className="space-y-4 p-6">
+					<Form method="post" className="space-y-4">
+						<CsrfInput />
+						<input type="hidden" name="intent" value="update-webhook" />
+						<div>
+							<label htmlFor="webhookUrl" className="block text-sm font-medium text-slate-700">
+								Webhook URL
+							</label>
+							<input
+								id="webhookUrl"
+								name="webhookUrl"
+								type="url"
+								placeholder={
+									group.hasWebhook
+										? "Enter a new URL to replace the current one"
+										: "https://discord.com/api/webhooks/..."
+								}
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							/>
+							{group.hasWebhook && (
+								<p className="mt-1 text-xs text-emerald-600">✓ A webhook is currently configured</p>
+							)}
+							<p className="mt-1 text-xs text-slate-500">
+								In Discord: Server Settings → Integrations → Webhooks → New Webhook → Copy Webhook
+								URL
+							</p>
+						</div>
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:ring-offset-2 disabled:opacity-50"
+						>
+							{isSubmitting ? "Saving…" : "Save Webhook"}
+						</button>
+					</Form>
+					{group.hasWebhook && (
+						<div className="flex items-center gap-2 border-t border-slate-100 pt-4">
+							<Form method="post">
+								<CsrfInput />
+								<input type="hidden" name="intent" value="test-webhook" />
+								<button
+									type="submit"
+									disabled={isSubmitting}
+									className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+								>
+									{isSubmitting ? "Sending…" : "Send Test Message"}
+								</button>
+							</Form>
+							<Form method="post">
+								<CsrfInput />
+								<input type="hidden" name="intent" value="remove-webhook" />
+								<button
+									type="submit"
+									disabled={isSubmitting}
+									className="rounded-lg border border-red-300 px-3 py-2 text-sm text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50"
+								>
+									{isSubmitting ? "Removing…" : "Remove Webhook"}
+								</button>
+							</Form>
+						</div>
+					)}
+				</div>
 			</div>
 
 			{/* Danger Zone */}

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -78,6 +78,7 @@ export async function getUserGroups(
 			createdById: groups.createdById,
 			membersCanCreateRequests: groups.membersCanCreateRequests,
 			membersCanCreateEvents: groups.membersCanCreateEvents,
+			webhookUrl: groups.webhookUrl,
 			createdAt: groups.createdAt,
 			updatedAt: groups.updatedAt,
 			role: groupMemberships.role,
@@ -224,13 +225,14 @@ export async function deleteGroup(groupId: string): Promise<void> {
 
 export async function updateGroup(
 	groupId: string,
-	data: { name?: string; description?: string },
+	data: { name?: string; description?: string; webhookUrl?: string | null },
 ): Promise<Group> {
 	const [updated] = await db
 		.update(groups)
 		.set({
 			...(data.name !== undefined ? { name: data.name.trim() } : {}),
 			...(data.description !== undefined ? { description: data.description.trim() || null } : {}),
+			...(data.webhookUrl !== undefined ? { webhookUrl: data.webhookUrl } : {}),
 			updatedAt: new Date(),
 		})
 		.where(eq(groups.id, groupId))

--- a/app/services/reminder.server.ts
+++ b/app/services/reminder.server.ts
@@ -9,6 +9,7 @@ import {
 } from "./email.server.js";
 import { logger } from "./logger.server.js";
 import { trackEvent } from "./telemetry.server.js";
+import { sendEventReminderWebhook } from "./webhook.server.js";
 
 /**
  * Start a cron job that sends reminder emails for upcoming events.
@@ -83,6 +84,7 @@ export async function processReminders(): Promise<void> {
 				location: events.location,
 				callTime: events.callTime,
 				groupName: groups.name,
+				webhookUrl: groups.webhookUrl,
 			})
 			.from(events)
 			.innerJoin(groups, eq(events.groupId, groups.id))
@@ -156,6 +158,18 @@ export async function processReminders(): Promise<void> {
 
 			// Mark reminder as sent
 			await tx.update(events).set({ reminderSentAt: new Date() }).where(eq(events.id, event.id));
+
+			// Fire-and-forget Discord webhook (one message per event, not per attendee)
+			if (event.webhookUrl) {
+				const webhookDateTime = formatEventTime(event.startTime, event.endTime);
+				sendEventReminderWebhook(event.webhookUrl, {
+					groupName: event.groupName,
+					eventTitle: event.title,
+					dateTime: webhookDateTime,
+					location: event.location,
+					eventUrl,
+				});
+			}
 
 			logger.info(
 				{ eventId: event.id, attendeeCount: attendees.length },

--- a/app/services/webhook.server.test.ts
+++ b/app/services/webhook.server.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before importing the module
+vi.mock("./logger.server.js", () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+vi.mock("./telemetry.server.js", () => ({
+	trackEvent: vi.fn(),
+}));
+
+import { logger } from "./logger.server.js";
+import { trackEvent } from "./telemetry.server.js";
+import {
+	isValidWebhookUrl,
+	sendAvailabilityRequestWebhook,
+	sendEventCreatedWebhook,
+	sendEventReminderWebhook,
+	sendTestWebhook,
+	sendWebhook,
+} from "./webhook.server";
+
+describe("webhook.server", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		globalThis.fetch = vi.fn();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	// --- URL Validation ---
+
+	describe("isValidWebhookUrl", () => {
+		it("accepts discord.com webhook URLs", () => {
+			expect(isValidWebhookUrl("https://discord.com/api/webhooks/123/abc")).toBe(true);
+		});
+
+		it("accepts discordapp.com webhook URLs", () => {
+			expect(isValidWebhookUrl("https://discordapp.com/api/webhooks/123/abc")).toBe(true);
+		});
+
+		it("rejects non-Discord URLs", () => {
+			expect(isValidWebhookUrl("https://example.com/webhook")).toBe(false);
+		});
+
+		it("rejects empty strings", () => {
+			expect(isValidWebhookUrl("")).toBe(false);
+		});
+
+		it("rejects URLs that look similar but aren't Discord webhooks", () => {
+			expect(isValidWebhookUrl("https://discord.com/channels/123")).toBe(false);
+			expect(isValidWebhookUrl("https://notdiscord.com/api/webhooks/123")).toBe(false);
+		});
+	});
+
+	// --- sendWebhook ---
+
+	describe("sendWebhook", () => {
+		it("sends correct Discord embed payload", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			const result = await sendWebhook(
+				"https://discord.com/api/webhooks/123/abc",
+				{ title: "Test", description: "Hello" },
+				{ groupId: "g1", type: "test" },
+			);
+
+			expect(result).toBe(true);
+			expect(globalThis.fetch).toHaveBeenCalledWith("https://discord.com/api/webhooks/123/abc", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					embeds: [{ color: 0x57f287, title: "Test", description: "Hello" }],
+				}),
+			});
+		});
+
+		it("tracks event on success", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			await sendWebhook(
+				"https://discord.com/api/webhooks/123/abc",
+				{ title: "Test" },
+				{ groupId: "g1", type: "test" },
+			);
+
+			expect(trackEvent).toHaveBeenCalledWith("WebhookSent", {
+				groupId: "g1",
+				type: "test",
+			});
+		});
+
+		it("returns false and logs warning on non-OK response", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response("error", { status: 400 }));
+
+			const result = await sendWebhook(
+				"https://discord.com/api/webhooks/123/abc",
+				{ title: "Test" },
+				{ groupId: "g1", type: "test" },
+			);
+
+			expect(result).toBe(false);
+			expect(logger.warn).toHaveBeenCalled();
+			expect(trackEvent).not.toHaveBeenCalled();
+		});
+
+		it("returns false and logs error on network failure", async () => {
+			vi.mocked(globalThis.fetch).mockRejectedValue(new Error("Network error"));
+
+			const result = await sendWebhook(
+				"https://discord.com/api/webhooks/123/abc",
+				{ title: "Test" },
+				{ groupId: "g1", type: "test" },
+			);
+
+			expect(result).toBe(false);
+			expect(logger.error).toHaveBeenCalled();
+			expect(trackEvent).not.toHaveBeenCalled();
+		});
+
+		it("never throws even on unexpected errors", async () => {
+			vi.mocked(globalThis.fetch).mockRejectedValue(new TypeError("Invalid URL"));
+
+			const result = await sendWebhook("bad-url", { title: "Test" });
+
+			expect(result).toBe(false);
+		});
+	});
+
+	// --- Notification Helpers ---
+
+	describe("sendAvailabilityRequestWebhook", () => {
+		it("sends Discord embed with availability request details", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			sendAvailabilityRequestWebhook("https://discord.com/api/webhooks/123/abc", {
+				groupName: "Comedy Club",
+				title: "March Rehearsal Availability",
+				createdByName: "Alice",
+				dateRange: "Mar 1 – Mar 15",
+				requestUrl: "https://mycalltime.app/groups/g1/availability/r1",
+			});
+
+			// Wait for fire-and-forget
+			await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+			const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body as string);
+			const embed = body.embeds[0];
+
+			expect(embed.title).toBe("📋 New Availability Request");
+			expect(embed.description).toBe("**March Rehearsal Availability**");
+			expect(embed.url).toBe("https://mycalltime.app/groups/g1/availability/r1");
+			expect(embed.fields).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "Group", value: "Comedy Club" }),
+					expect.objectContaining({ name: "Date Range", value: "Mar 1 – Mar 15" }),
+					expect.objectContaining({ name: "Created By", value: "Alice" }),
+				]),
+			);
+		});
+	});
+
+	describe("sendEventCreatedWebhook", () => {
+		it("sends Discord embed with event details", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			sendEventCreatedWebhook("https://discord.com/api/webhooks/123/abc", {
+				groupName: "Troupe",
+				eventTitle: "Friday Show",
+				eventType: "show",
+				dateTime: "Fri, Mar 7 · 8:00 PM – 10:00 PM",
+				location: "Main Stage",
+				eventUrl: "https://mycalltime.app/groups/g1/events/e1",
+			});
+
+			await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+			const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body as string);
+			const embed = body.embeds[0];
+
+			expect(embed.title).toBe("🎭 New Show: Friday Show");
+			expect(embed.fields).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "Where", value: "Main Stage" }),
+					expect.objectContaining({
+						name: "When",
+						value: "Fri, Mar 7 · 8:00 PM – 10:00 PM",
+					}),
+				]),
+			);
+		});
+
+		it("omits location field when not provided", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			sendEventCreatedWebhook("https://discord.com/api/webhooks/123/abc", {
+				groupName: "Troupe",
+				eventTitle: "Rehearsal",
+				eventType: "rehearsal",
+				dateTime: "Mon, Mar 3 · 7:00 PM – 9:00 PM",
+				eventUrl: "https://mycalltime.app/groups/g1/events/e1",
+			});
+
+			await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+			const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body as string);
+			const embed = body.embeds[0];
+
+			expect(embed.fields.find((f: { name: string }) => f.name === "Where")).toBeUndefined();
+		});
+	});
+
+	describe("sendEventReminderWebhook", () => {
+		it("sends Discord embed with reminder details", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			sendEventReminderWebhook("https://discord.com/api/webhooks/123/abc", {
+				groupName: "Troupe",
+				eventTitle: "Saturday Show",
+				dateTime: "Sat, Mar 8 · 8:00 PM – 10:00 PM",
+				location: "Theater",
+				eventUrl: "https://mycalltime.app/groups/g1/events/e1",
+			});
+
+			await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+			const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body as string);
+			const embed = body.embeds[0];
+
+			expect(embed.title).toBe("⏰ Reminder: Saturday Show");
+			expect(embed.description).toContain("less than 24 hours");
+		});
+	});
+
+	describe("sendTestWebhook", () => {
+		it("awaits and returns true on success", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+			const result = await sendTestWebhook("https://discord.com/api/webhooks/123/abc", "My Group");
+
+			expect(result).toBe(true);
+			const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body as string);
+			expect(body.embeds[0].title).toBe("✅ Webhook Connected!");
+			expect(body.embeds[0].description).toContain("My Group");
+		});
+
+		it("returns false on failure", async () => {
+			vi.mocked(globalThis.fetch).mockRejectedValue(new Error("fail"));
+
+			const result = await sendTestWebhook("https://discord.com/api/webhooks/123/abc", "My Group");
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/app/services/webhook.server.ts
+++ b/app/services/webhook.server.ts
@@ -1,0 +1,185 @@
+import { logger } from "./logger.server.js";
+import { trackEvent } from "./telemetry.server.js";
+
+// Discord embed color — emerald green (0x57F287) matching the app's brand
+const EMBED_COLOR = 0x57f287;
+
+interface DiscordField {
+	name: string;
+	value: string;
+	inline?: boolean;
+}
+
+interface DiscordEmbed {
+	title: string;
+	description?: string;
+	color?: number;
+	url?: string;
+	fields?: DiscordField[];
+	footer?: { text: string };
+}
+
+const DISCORD_WEBHOOK_PREFIXES = [
+	"https://discord.com/api/webhooks/",
+	"https://discordapp.com/api/webhooks/",
+];
+
+/** Validate that a URL is a Discord webhook URL. */
+export function isValidWebhookUrl(url: string): boolean {
+	return DISCORD_WEBHOOK_PREFIXES.some((prefix) => url.startsWith(prefix));
+}
+
+/**
+ * Send a Discord webhook with embeds. Fire-and-forget — never throws.
+ * Returns true on success, false on failure.
+ */
+export async function sendWebhook(
+	webhookUrl: string,
+	embed: DiscordEmbed,
+	meta?: { groupId?: string; type?: string },
+): Promise<boolean> {
+	try {
+		const response = await fetch(webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				embeds: [{ color: EMBED_COLOR, ...embed }],
+			}),
+		});
+
+		if (!response.ok) {
+			logger.warn(
+				{ status: response.status, groupId: meta?.groupId, type: meta?.type },
+				"Discord webhook returned non-OK status",
+			);
+			return false;
+		}
+
+		trackEvent("WebhookSent", {
+			groupId: meta?.groupId ?? "unknown",
+			type: meta?.type ?? "unknown",
+		});
+		return true;
+	} catch (error) {
+		logger.error(
+			{ err: error, groupId: meta?.groupId, type: meta?.type },
+			"Failed to send Discord webhook",
+		);
+		return false;
+	}
+}
+
+// --- Notification-specific helpers ---
+
+export function sendAvailabilityRequestWebhook(
+	webhookUrl: string,
+	params: {
+		groupName: string;
+		title: string;
+		createdByName: string;
+		dateRange: string;
+		requestUrl: string;
+	},
+): void {
+	void sendWebhook(
+		webhookUrl,
+		{
+			title: "📋 New Availability Request",
+			description: `**${params.title}**`,
+			url: params.requestUrl,
+			fields: [
+				{ name: "Group", value: params.groupName, inline: true },
+				{ name: "Date Range", value: params.dateRange, inline: true },
+				{ name: "Created By", value: params.createdByName },
+			],
+			footer: { text: "Submit your availability on My Call Time" },
+		},
+		{ groupId: params.groupName, type: "availability_request" },
+	);
+}
+
+export function sendEventCreatedWebhook(
+	webhookUrl: string,
+	params: {
+		groupName: string;
+		eventTitle: string;
+		eventType: string;
+		dateTime: string;
+		location?: string;
+		eventUrl: string;
+	},
+): void {
+	const typeLabel = params.eventType.charAt(0).toUpperCase() + params.eventType.slice(1);
+	const fields: DiscordField[] = [
+		{ name: "Group", value: params.groupName, inline: true },
+		{ name: "Type", value: typeLabel, inline: true },
+		{ name: "When", value: params.dateTime },
+	];
+	if (params.location) {
+		fields.push({ name: "Where", value: params.location });
+	}
+
+	void sendWebhook(
+		webhookUrl,
+		{
+			title: `🎭 New ${typeLabel}: ${params.eventTitle}`,
+			url: params.eventUrl,
+			fields,
+			footer: { text: "View details on My Call Time" },
+		},
+		{ groupId: params.groupName, type: "event_created" },
+	);
+}
+
+export function sendEventReminderWebhook(
+	webhookUrl: string,
+	params: {
+		groupName: string;
+		eventTitle: string;
+		dateTime: string;
+		location?: string | null;
+		eventUrl: string;
+	},
+): void {
+	const fields: DiscordField[] = [
+		{ name: "Group", value: params.groupName, inline: true },
+		{ name: "When", value: params.dateTime },
+	];
+	if (params.location) {
+		fields.push({ name: "Where", value: params.location });
+	}
+
+	void sendWebhook(
+		webhookUrl,
+		{
+			title: `⏰ Reminder: ${params.eventTitle}`,
+			description: "This event is coming up in less than 24 hours!",
+			url: params.eventUrl,
+			fields,
+			footer: { text: "View details on My Call Time" },
+		},
+		{ groupId: params.groupName, type: "event_reminder" },
+	);
+}
+
+/**
+ * Send a test webhook message to verify the URL works.
+ * Unlike other helpers, this awaits and returns the result.
+ */
+export async function sendTestWebhook(webhookUrl: string, groupName: string): Promise<boolean> {
+	return sendWebhook(
+		webhookUrl,
+		{
+			title: "✅ Webhook Connected!",
+			description: `This Discord channel will now receive notifications for **${groupName}**.`,
+			fields: [
+				{
+					name: "What you'll receive",
+					value: "• New availability requests\n• New events\n• Event reminders",
+				},
+			],
+			footer: { text: "My Call Time" },
+		},
+		{ groupId: groupName, type: "test" },
+	);
+}

--- a/drizzle/0010_cultured_zombie.sql
+++ b/drizzle/0010_cultured_zombie.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "groups" ADD COLUMN "webhook_url" varchar(500);

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,979 @@
+{
+  "id": "4fc69457-368b-406d-932a-b587262ab0a2",
+  "prevId": "25c667f6-c618-40bf-b0fc-9aed50860793",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_requests": {
+      "name": "availability_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_dates": {
+          "name": "requested_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_start_time": {
+          "name": "requested_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_end_time": {
+          "name": "requested_end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "availability_requests_group_id_idx": {
+          "name": "availability_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_requests_group_id_groups_id_fk": {
+          "name": "availability_requests_group_id_groups_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_requests_created_by_id_users_id_fk": {
+          "name": "availability_requests_created_by_id_users_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_responses": {
+      "name": "availability_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_responses_request_user_idx": {
+          "name": "availability_responses_request_user_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_responses_request_id_availability_requests_id_fk": {
+          "name": "availability_responses_request_id_availability_requests_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_responses_user_id_users_id_fk": {
+          "name": "availability_responses_user_id_users_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_assignments": {
+      "name": "event_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_assignments_event_user_idx": {
+          "name": "event_assignments_event_user_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_assignments_user_id_idx": {
+          "name": "event_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_assignments_event_id_events_id_fk": {
+          "name": "event_assignments_event_id_events_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_assignments_user_id_users_id_fk": {
+          "name": "event_assignments_user_id_users_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_request_id": {
+          "name": "created_from_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_time": {
+          "name": "call_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_reminder_sent_at": {
+          "name": "confirmation_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_group_start_time_idx": {
+          "name": "events_group_start_time_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_group_id_groups_id_fk": {
+          "name": "events_group_id_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_id_users_id_fk": {
+          "name": "events_created_by_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_created_from_request_id_availability_requests_id_fk": {
+          "name": "events_created_from_request_id_availability_requests_id_fk",
+          "tableFrom": "events",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "created_from_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"availabilityRequests\":{\"email\":true},\"eventNotifications\":{\"email\":true},\"showReminders\":{\"email\":true}}'::jsonb"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_user_idx": {
+          "name": "group_memberships_group_user_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_can_create_requests": {
+          "name": "members_can_create_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "members_can_create_events": {
+          "name": "members_can_create_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_invite_code_idx": {
+          "name": "groups_invite_code_idx",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_id_users_id_fk": {
+          "name": "groups_created_by_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_invite_code_unique": {
+          "name": "groups_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_expiry": {
+          "name": "email_verification_expiry",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_google_id_idx": {
+          "name": "users_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verification_token_idx": {
+          "name": "users_email_verification_token_idx",
+          "columns": [
+            {
+              "expression": "email_verification_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "declined"
+      ]
+    },
+    "public.availability_response_value": {
+      "name": "availability_response_value",
+      "schema": "public",
+      "values": [
+        "available",
+        "maybe",
+        "not_available"
+      ]
+    },
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "rehearsal",
+        "show",
+        "other"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772513384008,
       "tag": "0009_fantastic_forgotten_one",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1772514464300,
+      "tag": "0010_cultured_zombie",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -62,6 +62,7 @@ export const groups = pgTable(
 		createdById: uuid("created_by_id").references(() => users.id, { onDelete: "set null" }),
 		membersCanCreateRequests: boolean("members_can_create_requests").default(false).notNull(),
 		membersCanCreateEvents: boolean("members_can_create_events").default(false).notNull(),
+		webhookUrl: varchar("webhook_url", { length: 500 }),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 	},


### PR DESCRIPTION
## Summary

Adds per-group Discord webhook support for notifications. When configured by a group admin, key notifications are also sent to a Discord channel via webhook alongside the existing email notifications.

## What's New

### Discord Webhook Integration
- **Schema**: Added nullable `webhookUrl` (varchar 500) column to `groups` table with Drizzle migration
- **Webhook Service** (`app/services/webhook.server.ts`): Fire-and-forget Discord embed delivery with:
  - `sendAvailabilityRequestWebhook()` — Rich embed for new availability requests
  - `sendEventCreatedWebhook()` — Rich embed for new events
  - `sendEventReminderWebhook()` — Rich embed for 24h reminders
  - `sendTestWebhook()` — Verify webhook URL works
  - `isValidWebhookUrl()` — Only accepts Discord webhook URLs
  - Application Insights telemetry tracking (`WebhookSent` events)

### Notification Flow Integration
Webhooks are sent alongside existing emails in three flows:
1. **Availability request created** — `groups.$groupId.availability.new.tsx`
2. **Event created** — `groups.$groupId.events.new.tsx` (both standard and from-availability)
3. **24-hour reminder** — `reminder.server.ts` (one webhook per event, not per attendee)

### Admin Settings UI
New "Discord Webhook" section in group settings with:
- URL input field with validation (Discord URLs only)
- "Save Webhook" button
- "Send Test Message" button (sends a verification embed)
- "Remove Webhook" button
- Status indicator when webhook is configured

## Security
- **Webhook URL is never sent to the client** — The loader returns `hasWebhook: boolean` instead of the actual URL (which contains a secret token)
- **URL validation**: Only accepts `https://discord.com/api/webhooks/` and `https://discordapp.com/api/webhooks/` prefixes
- **Fire-and-forget**: Webhook failures are logged but never block email delivery or user requests
- **Admin-only**: Only group admins can configure webhooks (enforced by `requireGroupAdmin()`)

## Tests
16 new tests covering:
- URL validation (valid/invalid Discord URLs)
- Correct Discord embed payload format for all notification types
- Error handling (non-OK responses, network failures)
- Fire-and-forget behavior (never throws)
- Test webhook functionality

## Quality Gates
- ✅ TypeScript strict mode (`pnpm run typecheck`)
- ✅ Biome lint (`pnpm run lint`)
- ✅ Production build (`pnpm run build`)
- ✅ All 368 tests pass (`pnpm test`)
