### PR TITLE
fix: make assignment notification test timezone-independent

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -394,6 +394,7 @@ describe("event detail action — assignment notifications", () => {
 				id: "user-2",
 				name: "New Performer",
 				email: "new@example.com",
+				timezone: "UTC",
 				notificationPreferences: {},
 			},
 		]);
@@ -423,7 +424,7 @@ describe("event detail action — assignment notifications", () => {
 				expect.objectContaining({
 					eventTitle: "Friday Show",
 					eventType: "show",
-					dateTime: "Sun, Mar 15 · 12:00 PM – 2:00 PM",
+					dateTime: "Sun, Mar 15 · 7:00 PM – 9:00 PM",
 					groupName: "Test Group",
 					recipient: expect.objectContaining({
 						email: "new@example.com",


### PR DESCRIPTION
## Problem

CI has been failing on master since the webhook notifications PR (#103) was merged. The test `sends notification to newly assigned users` in `groups.$groupId.events.$eventId.test.ts` hardcoded an expected `dateTime` of `"Sun, Mar 15 · 12:00 PM – 2:00 PM"` — which is correct in Pacific time, but CI runs in UTC where it produces `"Sun, Mar 15 · 7:00 PM – 9:00 PM"`.

## Fix

Added `timezone: "UTC"` to the mock member data in `getGroupMembersWithPreferences`, so `formatEventTime` produces deterministic output regardless of runtime timezone. Updated the expected `dateTime` to match UTC formatting.

## Testing

- All 368 tests pass locally (both native timezone and `TZ=UTC`)
- Typecheck clean
- Lint clean