### PR TITLE
fix: return proper 404/405 from catch-all route

### DIFF
--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,9 +1,17 @@
-import type { MetaFunction } from "@remix-run/node";
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { Link } from "@remix-run/react";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "Page Not Found — My Call Time" }];
 };
+
+export function loader(_args: LoaderFunctionArgs) {
+	throw new Response("Not Found", { status: 404, statusText: "Not Found" });
+}
+
+export function action(_args: ActionFunctionArgs) {
+	throw new Response("Method Not Allowed", { status: 405, statusText: "Method Not Allowed" });
+}
 
 export default function CatchAll() {
 	return (


### PR DESCRIPTION
## Problem

Bot scanners (probing for WordPress/PHP admin panels) hit `app/routes/$.tsx` with POST requests, causing unhandled Remix errors → 500s in production. Additionally, GET requests to non-existent paths returned 200 instead of 404.

## Fix

Added `loader` and `action` exports to the catch-all route:
- **`loader`** — throws a 404 Response so GET requests properly return 404
- **`action`** — throws a 405 Response (Method Not Allowed) so POST/PUT/DELETE requests return 405 instead of 500

The existing error boundary / 404 page component is unchanged.

## Testing

- All 371 tests pass
- Typecheck clean
- Lint clean (0 warnings)