### PR TITLE
docs: update availability alert config in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,11 +487,11 @@ Production telemetry is powered by Azure Application Insights, initialized in `a
 | `mycalltime-exception-spike` | Scheduled Query | >5 exceptions in 5 min | Sev 1 | 5 min |
 | `mycalltime-slow-response` | Metric | Avg response time >5s | Sev 2 | 5 min |
 | `mycalltime-high-error-rate` | Metric | >5 failed requests in 5 min (5xx only) | Sev 2 | 5 min |
-| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 1 | 3 min |
+| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 2 | 5 min |
 
 All alerts notify the `mycalltime-alerts` action group (tylerl0706@gmail.com).
 
-The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 5 locations (US East, US West, UK, Netherlands, Hong Kong). It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
+The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 5 locations (US East, US West, North Central US, UK, Netherlands). It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
 
 ```bash
 # List alert rules


### PR DESCRIPTION
Reflects infra changes already applied via Azure CLI:
- Availability alert downgraded from Sev 1 to Sev 2
- Window changed from 3min to 5min  
- Test locations updated (added UK + Netherlands, 5 total)

The actual Azure infra changes (alert rule + web test locations) were applied directly. This PR just updates the docs to match.