### PR TITLE
docs: fix alert infrastructure — correct 403 root cause, restore Sev 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,11 +487,12 @@ Production telemetry is powered by Azure Application Insights, initialized in `a
 | `mycalltime-exception-spike` | Scheduled Query | >5 exceptions in 5 min | Sev 1 | 5 min |
 | `mycalltime-slow-response` | Metric | Avg response time >5s | Sev 2 | 5 min |
 | `mycalltime-high-error-rate` | Metric | >5 failed requests in 5 min (5xx only) | Sev 2 | 5 min |
-| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 2 | 5 min |
+| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 1 | 5 min |
+| `mycalltime-app-unhealthy` | Metric | Availability <95% | Sev 2 | 5 min |
 
 All alerts notify the `mycalltime-alerts` action group (tylerl0706@gmail.com).
 
-The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 5 locations (US East, US West, North Central US, UK, Netherlands). It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
+The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 3 US locations (East US, West US, North Central US). EU locations were removed because Cloudflare's WAF/geo-blocking rules return 403 to non-US IPs (the Container Apps ingress itself has no IP restrictions). It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
 
 ```bash
 # List alert rules


### PR DESCRIPTION
## What changed

### Infrastructure (already applied via Azure CLI)
- **Upgraded `mycalltime-availability-alert` back to Sev 1.** With only 3 test locations, 2 failures = 67% outage — this is a confirmed outage signal, not noise. It was incorrectly downgraded to Sev 2.

### Documentation (this PR)
Three corrections to AGENTS.md:

1. **Corrected the 403 root cause.** The EU test locations return 403 because **Cloudflare's WAF/geo-blocking rules** reject non-US IPs, NOT because of Container Apps IP restrictions (`ipSecurityRestrictions: null`). Evidence:
   - `mycalltime.app` DNS resolves to Cloudflare IPs (104.21.x.x, 172.67.x.x)
   - Response headers include `server: cloudflare`, `cf-ray`
   - Direct Container App FQDN (greenroom.victoriousmoss-d75cef02.centralus.azurecontainerapps.io) returns 200

2. **Fixed availability-alert severity** from Sev 2 → Sev 1 in the docs table (matches the Azure CLI change).

3. **Added the missing `mycalltime-app-unhealthy` alert** to the docs table.

## Review of prior changes

| Change | Verdict | Reasoning |
|--------|---------|-----------|
| Remove EU test locations | ✅ Correct | Cloudflare blocks EU IPs → tests produce false failures |
| Downgrade availability-alert to Sev 2 | ❌ Incorrect (reverted) | 2/3 US locations failing = real outage → should be Sev 1 |
| Downgrade app-unhealthy to Sev 2 | ✅ Correct | Any single failure (1/3 = 33%) triggers it → too sensitive for Sev 1, good as early warning |
| Claim alerts are redundant | ❌ Incorrect | They serve different purposes: early warning (Sev 2) vs confirmed outage (Sev 1) |

## Recommended severity model

| Alert | Severity | Role |
|-------|----------|------|
| `mycalltime-exception-spike` | Sev 1 | App errors — critical |
| `mycalltime-availability-alert` | **Sev 1** | Confirmed outage (2/3 locations fail) |
| `mycalltime-app-unhealthy` | Sev 2 | Early warning (any single failure) |
| `mycalltime-slow-response` | Sev 2 | Performance degradation |
| `mycalltime-high-error-rate` | Sev 2 | Elevated 5xx errors |

## Follow-up recommendation
The Cloudflare geo-blocking may be unintentional — the product vision (`docs/vision.md`) targets global improv groups, not US-only. Consider reviewing Cloudflare WAF rules to determine if EU blocking is desired.