### PR TITLE
docs: restore availability alert to Sev 1, correct 403 root cause

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,12 +487,12 @@ Production telemetry is powered by Azure Application Insights, initialized in `a
 | `mycalltime-exception-spike` | Scheduled Query | >5 exceptions in 5 min | Sev 1 | 5 min |
 | `mycalltime-slow-response` | Metric | Avg response time >5s | Sev 2 | 5 min |
 | `mycalltime-high-error-rate` | Metric | >5 failed requests in 5 min (5xx only) | Sev 2 | 5 min |
-| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 2 | 5 min |
+| `mycalltime-availability-alert` | Webtest Availability | ≥2 locations fail | Sev 1 | 5 min |
 | `mycalltime-app-unhealthy` | Metric | Availability <95% | Sev 2 | 5 min |
 
 All alerts notify the `mycalltime-alerts` action group (tylerl0706@gmail.com).
 
-The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 3 US locations (East US, West US, North Central US). EU locations were removed because the Container Apps environment returns 403 to non-US IPs. It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
+The **availability test** (`mycalltime-health-ping`) pings `https://mycalltime.app/api/health` every 5 minutes from 3 US locations (East US, West US, North Central US). EU locations were removed because Cloudflare's WAF/geo-blocking rules return 403 to non-US IPs (the Container Apps ingress itself has no IP restrictions). It validates HTTP 200 and SSL certificate validity (7-day expiry warning).
 
 ```bash
 # List alert rules


### PR DESCRIPTION
Team review of alert changes found two corrections needed:
1. `mycalltime-availability-alert` restored to **Sev 1** — it's the primary uptime alert
2. 403 root cause corrected: it's **Cloudflare WAF** geo-blocking, not Container Apps ingress

Closes #115 (superseded)