### PR TITLE
fix: Discord webhook shows times in UTC instead of correct timezone

### DIFF
--- a/app/lib/date-utils.test.ts
+++ b/app/lib/date-utils.test.ts
@@ -10,6 +10,7 @@ import {
 	formatEventTime,
 	formatTime,
 	formatTimeRange,
+	getTimezoneAbbreviation,
 	isValidTimezone,
 	localTimeToUTC,
 	sanitizeTimezone,
@@ -350,6 +351,47 @@ describe("date-utils", () => {
 			const withUndefined = formatEventTime(start, end, undefined);
 			// Both should produce the same result since "PST" gets sanitized to undefined
 			expect(withPST).toBe(withUndefined);
+		});
+	});
+
+	describe("getTimezoneAbbreviation", () => {
+		it("returns timezone abbreviation for a valid timezone", () => {
+			const result = getTimezoneAbbreviation(testDate, "America/Los_Angeles");
+			// March 4 in LA is PST (standard time, before spring DST)
+			expect(result).toBe("PST");
+		});
+
+		it("returns UTC abbreviation", () => {
+			const result = getTimezoneAbbreviation(testDate, "UTC");
+			expect(result).toBe("UTC");
+		});
+
+		it("returns correct abbreviation for Eastern timezone", () => {
+			const result = getTimezoneAbbreviation(testDate, "America/New_York");
+			expect(result).toBe("EST");
+		});
+
+		it("returns empty string when no timezone is provided", () => {
+			expect(getTimezoneAbbreviation(testDate)).toBe("");
+			expect(getTimezoneAbbreviation(testDate, undefined)).toBe("");
+			expect(getTimezoneAbbreviation(testDate, null)).toBe("");
+		});
+
+		it("returns empty string for invalid timezone abbreviations", () => {
+			expect(getTimezoneAbbreviation(testDate, "PST")).toBe("");
+			expect(getTimezoneAbbreviation(testDate, "EST")).toBe("");
+		});
+
+		it("accepts string date input", () => {
+			const result = getTimezoneAbbreviation("2026-03-04T19:00:00Z", "America/Chicago");
+			expect(result).toBe("CST");
+		});
+
+		it("reflects DST changes", () => {
+			// March 15 is after spring DST in the US (second Sunday of March)
+			const dstDate = new Date("2026-03-15T19:00:00Z");
+			const result = getTimezoneAbbreviation(dstDate, "America/Los_Angeles");
+			expect(result).toBe("PDT");
 		});
 	});
 });

--- a/app/lib/date-utils.ts
+++ b/app/lib/date-utils.ts
@@ -42,6 +42,21 @@ export function sanitizeTimezone(timezone?: string | null): string | undefined {
 }
 
 /**
+ * Get the short timezone abbreviation (e.g., "PDT", "EST") for a date in a specific timezone.
+ * Returns an empty string if no valid timezone is provided.
+ */
+export function getTimezoneAbbreviation(date: string | Date, timezone?: string | null): string {
+	const tz = sanitizeTimezone(timezone);
+	if (!tz) return "";
+	const d = typeof date === "string" ? new Date(date) : date;
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZoneName: "short",
+		timeZone: tz,
+	}).formatToParts(d);
+	return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+}
+
+/**
  * Format a date as "Wed, Mar 4, 2026"
  */
 export function formatDate(date: string | Date, timezone?: string): string {

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -12,7 +12,7 @@ import { ArrowLeft, Clock, Users } from "lucide-react";
 import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { InlineTimezoneSelector } from "~/components/timezone-selector";
-import { formatEventTime, localTimeToUTC } from "~/lib/date-utils";
+import { formatEventTime, getTimezoneAbbreviation, localTimeToUTC } from "~/lib/date-utils";
 import { getAvailabilityRequest } from "~/services/availability.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import {
@@ -255,11 +255,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 		// Fire-and-forget Discord webhook
 		if (groupData.group.webhookUrl) {
+			const tz = user.timezone ?? undefined;
+			const webhookDateTime = formatEventTime(event.startTime, event.endTime, tz);
+			const tzAbbrev = getTimezoneAbbreviation(event.startTime, tz);
 			sendEventCreatedWebhook(groupData.group.webhookUrl, {
 				groupName: groupData.group.name,
 				eventTitle: event.title,
 				eventType: event.eventType,
-				dateTime: formatEventTime(event.startTime, event.endTime),
+				dateTime: tzAbbrev ? `${webhookDateTime} (${tzAbbrev})` : webhookDateTime,
 				location: event.location ?? undefined,
 				eventUrl,
 			});

--- a/app/services/reminder.server.test.ts
+++ b/app/services/reminder.server.test.ts
@@ -28,6 +28,11 @@ vi.mock("./email.server.js", () => ({
 	sendConfirmationReminderNotification: mockSendConfirmationReminderNotification,
 }));
 
+const mockSendEventReminderWebhook = vi.fn();
+vi.mock("./webhook.server.js", () => ({
+	sendEventReminderWebhook: mockSendEventReminderWebhook,
+}));
+
 vi.mock("./logger.server.js", () => ({
 	logger: {
 		info: vi.fn(),
@@ -45,6 +50,7 @@ vi.mock("./telemetry.server.js", () => ({
 vi.mock("../lib/date-utils.js", () => ({
 	formatEventTime: vi.fn(() => "Sun, Mar 1 · 7:00 PM – 9:00 PM"),
 	formatTime: vi.fn(() => "6:00 PM"),
+	getTimezoneAbbreviation: vi.fn(() => "PST"),
 }));
 
 const { processReminders, processConfirmationReminders, startReminderJob } = await import(
@@ -66,6 +72,8 @@ const mockUpcomingEvent = {
 	location: "Theater",
 	callTime: new Date("2026-03-02T01:00:00Z"),
 	groupName: "Comedy Team",
+	creatorTimezone: "America/Los_Angeles",
+	webhookUrl: "https://discord.com/api/webhooks/123/abc",
 };
 
 const mockAttendees = [
@@ -289,6 +297,114 @@ describe("reminder.server", () => {
 
 			// Should still mark as sent even with no attendees (to avoid retrying)
 			expect(mockSendEventReminderNotification).not.toHaveBeenCalled();
+		});
+
+		it("sends Discord webhook with creator's timezone", async () => {
+			const { formatEventTime, getTimezoneAbbreviation } = await import("../lib/date-utils.js");
+
+			mockTransaction.mockImplementation(async (fn) => {
+				const eventChain = txChainMock(null);
+				eventChain.where = vi.fn().mockResolvedValue([mockUpcomingEvent]);
+				eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
+				eventChain.from = vi.fn().mockReturnValue(eventChain);
+
+				const attendeeChain = txChainMock(null);
+				attendeeChain.where = vi.fn().mockResolvedValue(mockAttendees);
+				attendeeChain.innerJoin = vi.fn().mockReturnValue(attendeeChain);
+				attendeeChain.from = vi.fn().mockReturnValue(attendeeChain);
+
+				let selectCallCount = 0;
+				const tx = {
+					execute: vi.fn().mockResolvedValue({
+						rows: [{ pg_try_advisory_xact_lock: true }],
+					}),
+					select: vi.fn().mockImplementation(() => {
+						selectCallCount++;
+						return selectCallCount === 1 ? eventChain : attendeeChain;
+					}),
+					update: vi.fn().mockReturnValue({
+						set: vi.fn().mockReturnValue({
+							where: vi.fn().mockResolvedValue(undefined),
+						}),
+					}),
+				};
+				return fn(tx);
+			});
+
+			await processReminders();
+
+			// Verify webhook was called with timezone-formatted dateTime
+			expect(mockSendEventReminderWebhook).toHaveBeenCalledWith(
+				"https://discord.com/api/webhooks/123/abc",
+				expect.objectContaining({
+					groupName: "Comedy Team",
+					eventTitle: "Show Night",
+					dateTime: expect.stringContaining("PST"),
+				}),
+			);
+
+			// Verify formatEventTime was called with the creator's timezone
+			expect(formatEventTime).toHaveBeenCalledWith(
+				mockUpcomingEvent.startTime,
+				mockUpcomingEvent.endTime,
+				"America/Los_Angeles",
+			);
+
+			// Verify getTimezoneAbbreviation was called with the creator's timezone
+			expect(getTimezoneAbbreviation).toHaveBeenCalledWith(
+				mockUpcomingEvent.startTime,
+				"America/Los_Angeles",
+			);
+		});
+
+		it("falls back to first attendee's timezone when creator is deleted", async () => {
+			const { formatEventTime } = await import("../lib/date-utils.js");
+			const eventWithoutCreator = {
+				...mockUpcomingEvent,
+				creatorTimezone: null,
+			};
+			const attendeesWithTimezone = [
+				{ ...mockAttendees[0], timezone: "America/New_York" },
+				{ ...mockAttendees[1], timezone: "America/Chicago" },
+			];
+
+			mockTransaction.mockImplementation(async (fn) => {
+				const eventChain = txChainMock(null);
+				eventChain.where = vi.fn().mockResolvedValue([eventWithoutCreator]);
+				eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
+				eventChain.from = vi.fn().mockReturnValue(eventChain);
+
+				const attendeeChain = txChainMock(null);
+				attendeeChain.where = vi.fn().mockResolvedValue(attendeesWithTimezone);
+				attendeeChain.innerJoin = vi.fn().mockReturnValue(attendeeChain);
+				attendeeChain.from = vi.fn().mockReturnValue(attendeeChain);
+
+				let selectCallCount = 0;
+				const tx = {
+					execute: vi.fn().mockResolvedValue({
+						rows: [{ pg_try_advisory_xact_lock: true }],
+					}),
+					select: vi.fn().mockImplementation(() => {
+						selectCallCount++;
+						return selectCallCount === 1 ? eventChain : attendeeChain;
+					}),
+					update: vi.fn().mockReturnValue({
+						set: vi.fn().mockReturnValue({
+							where: vi.fn().mockResolvedValue(undefined),
+						}),
+					}),
+				};
+				return fn(tx);
+			});
+
+			await processReminders();
+
+			// Should fall back to first attendee's timezone
+			expect(formatEventTime).toHaveBeenCalledWith(
+				eventWithoutCreator.startTime,
+				eventWithoutCreator.endTime,
+				"America/New_York",
+			);
 		});
 	});
 

--- a/app/services/reminder.server.ts
+++ b/app/services/reminder.server.ts
@@ -2,7 +2,7 @@ import { CronJob } from "cron";
 import { and, eq, gte, isNull, lte, sql } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import { eventAssignments, events, groupMemberships, groups, users } from "../../src/db/schema.js";
-import { formatEventTime, formatTime } from "../lib/date-utils.js";
+import { formatEventTime, formatTime, getTimezoneAbbreviation } from "../lib/date-utils.js";
 import {
 	sendConfirmationReminderNotification,
 	sendEventReminderNotification,
@@ -85,9 +85,11 @@ export async function processReminders(): Promise<void> {
 				callTime: events.callTime,
 				groupName: groups.name,
 				webhookUrl: groups.webhookUrl,
+				creatorTimezone: users.timezone,
 			})
 			.from(events)
 			.innerJoin(groups, eq(events.groupId, groups.id))
+			.leftJoin(users, eq(events.createdById, users.id))
 			.where(
 				and(
 					isNull(events.reminderSentAt),
@@ -161,11 +163,14 @@ export async function processReminders(): Promise<void> {
 
 			// Fire-and-forget Discord webhook (one message per event, not per attendee)
 			if (event.webhookUrl) {
-				const webhookDateTime = formatEventTime(event.startTime, event.endTime);
+				// Use event creator's timezone, falling back to first attendee's timezone
+				const webhookTz = event.creatorTimezone ?? attendees[0]?.timezone ?? undefined;
+				const webhookDateTime = formatEventTime(event.startTime, event.endTime, webhookTz);
+				const tzAbbrev = getTimezoneAbbreviation(event.startTime, webhookTz);
 				sendEventReminderWebhook(event.webhookUrl, {
 					groupName: event.groupName,
 					eventTitle: event.title,
-					dateTime: webhookDateTime,
+					dateTime: tzAbbrev ? `${webhookDateTime} (${tzAbbrev})` : webhookDateTime,
 					location: event.location,
 					eventUrl,
 				});


### PR DESCRIPTION
## Problem

Discord webhook notifications showed event times in UTC instead of the event creator's timezone. For example, an event at **7:00 PM Pacific** was displayed as **2:00 AM** in the webhook message — a 7-hour offset matching the UTC-to-Pacific difference.

The personal email notification for the same event showed the correct time, confirming the timezone data existed but wasn't being applied in the Discord webhook code path.

## Root Cause

`formatEventTime()` was called **without a timezone parameter** in two places:

1. **Event creation webhook** (`groups.$groupId.events.new.tsx`): `formatEventTime(event.startTime, event.endTime)` — no timezone
2. **Event reminder webhook** (`reminder.server.ts`): `formatEventTime(event.startTime, event.endTime)` — no timezone

When no timezone is provided, `Intl.DateTimeFormat` defaults to UTC on the server, producing UTC-formatted times.

Meanwhile, the **email code paths** correctly pass per-recipient timezone: `formatEventTime(startTime, endTime, recipient.timezone)`.

## Fix

### New helper: `getTimezoneAbbreviation()`
Added to `app/lib/date-utils.ts` — returns the short timezone name (e.g., "PDT", "EST") for a given date and timezone. Used to append a timezone label to Discord messages since they go to a shared channel with potentially mixed-timezone members.

### Event creation webhook
Pass the event creator's `user.timezone` to `formatEventTime()` and append the timezone abbreviation:
```
Thu, Mar 12 · 7:00 PM – 10:00 PM (PDT)
```

### Event reminder webhook
- Added `leftJoin(users)` on `events.createdById` to fetch the creator's timezone
- Falls back to the first attendee's timezone if the creator was deleted (createdById is nullable with ON DELETE SET NULL)
- Appends timezone abbreviation to the formatted time

## Tests Added
- **`date-utils.test.ts`**: 7 new tests for `getTimezoneAbbreviation()` — valid timezones, UTC, empty/invalid input, DST transitions
- **`reminder.server.test.ts`**: 2 new tests — webhook called with creator's timezone, fallback to attendee timezone when creator is deleted

## Verification
- ✅ TypeScript strict mode: `pnpm run typecheck` passes
- ✅ Lint: `pnpm run lint` clean (only pre-existing warning)
- ✅ Build: `pnpm run build` succeeds
- ✅ Tests: All 381 tests pass