### PR TITLE
feat: store timezone on events instead of inferring from creator

### DIFF
--- a/app/components/timezone-selector.tsx
+++ b/app/components/timezone-selector.tsx
@@ -51,7 +51,13 @@ export function getTimezoneLabel(tz: string): string {
  * Inline timezone indicator with dropdown to change.
  * Saves to user profile via /settings action using useFetcher.
  */
-export function InlineTimezoneSelector({ timezone }: { timezone: string | null }) {
+export function InlineTimezoneSelector({
+	timezone,
+	onChange,
+}: {
+	timezone: string | null;
+	onChange?: (tz: string) => void;
+}) {
 	const fetcher = useFetcher();
 	const [isEditing, setIsEditing] = useState(false);
 	const selectRef = useRef<HTMLSelectElement>(null);
@@ -70,6 +76,7 @@ export function InlineTimezoneSelector({ timezone }: { timezone: string | null }
 			{ method: "post", action: "/settings" },
 		);
 		setIsEditing(false);
+		onChange?.(newTimezone);
 	};
 
 	return (

--- a/app/routes/groups.$groupId.events.$eventId.edit.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.edit.tsx
@@ -11,6 +11,7 @@ import {
 import { ArrowLeft, Clock, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
+import { InlineTimezoneSelector } from "~/components/timezone-selector";
 import { localTimeToUTC, utcToLocalParts } from "~/lib/date-utils";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { deleteEvent, getEventWithAssignments, updateEvent } from "~/services/events.server";
@@ -30,15 +31,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		throw new Response("Not Found", { status: 404 });
 	}
 
-	const startParts = utcToLocalParts(new Date(data.event.startTime), user.timezone);
-	const endParts = utcToLocalParts(new Date(data.event.endTime), user.timezone);
+	const eventTimezone = data.event.timezone ?? user.timezone;
+	const startParts = utcToLocalParts(new Date(data.event.startTime), eventTimezone);
+	const endParts = utcToLocalParts(new Date(data.event.endTime), eventTimezone);
 	const ctParts = data.event.callTime
-		? utcToLocalParts(new Date(data.event.callTime), user.timezone)
+		? utcToLocalParts(new Date(data.event.callTime), eventTimezone)
 		: null;
 
 	return {
 		event: data.event,
-		userTimezone: user.timezone,
+		eventTimezone,
 		prefill: {
 			date: startParts.date,
 			startTime: startParts.time,
@@ -76,6 +78,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const location = formData.get("location");
 	const description = formData.get("description");
 	const callTime = formData.get("callTime");
+	const formTimezone = formData.get("timezone");
+	const timezone =
+		typeof formTimezone === "string" && formTimezone ? formTimezone : (user.timezone ?? undefined);
 
 	if (typeof title !== "string" || !title.trim()) {
 		return { error: "Title is required." };
@@ -116,14 +121,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		title: title.trim(),
 		description: typeof description === "string" ? description : undefined,
 		eventType,
-		startTime: localTimeToUTC(date, startTime, user.timezone),
-		endTime: localTimeToUTC(date, endTime, user.timezone),
+		startTime: localTimeToUTC(date, startTime, timezone),
+		endTime: localTimeToUTC(date, endTime, timezone),
 		location: typeof location === "string" ? location : undefined,
 		callTime: hasCallTime
-			? localTimeToUTC(date, callTime.trim(), user.timezone)
+			? localTimeToUTC(date, callTime.trim(), timezone)
 			: eventType === "show"
 				? undefined
 				: null,
+		timezone,
 	});
 
 	return redirect(`/groups/${groupId}/events/${eventId}`);
@@ -136,6 +142,7 @@ export default function EditEvent() {
 	const navigation = useNavigation();
 	const isSubmitting = navigation.state === "submitting";
 	const [eventType, setEventType] = useState(event.eventType);
+	const [timezone, setTimezone] = useState(() => event.timezone ?? "America/Los_Angeles");
 	const isShow = eventType === "show";
 
 	return (
@@ -225,6 +232,10 @@ export default function EditEvent() {
 				{/* Date & Time */}
 				<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
 					<h3 className="mb-4 text-sm font-semibold text-slate-900">Date & Time</h3>
+					<div className="mb-4">
+						<InlineTimezoneSelector timezone={timezone} onChange={setTimezone} />
+						<input type="hidden" name="timezone" value={timezone} />
+					</div>
 					<div className="grid gap-4 sm:grid-cols-3">
 						<div>
 							<label htmlFor="date" className="block text-sm font-medium text-slate-700">

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -78,6 +78,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const fromRequestId = formData.get("fromRequestId");
 	const callTime = formData.get("callTime");
 	const performerIds = formData.getAll("performerIds");
+	const formTimezone = formData.get("timezone");
+	const timezone =
+		typeof formTimezone === "string" && formTimezone ? formTimezone : (user.timezone ?? undefined);
 
 	if (typeof title !== "string" || !title.trim()) {
 		return { error: "Title is required." };
@@ -119,13 +122,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		title: title.trim(),
 		description: typeof description === "string" ? description.trim() || undefined : undefined,
 		eventType: eventType as "rehearsal" | "show" | "other",
-		startTime: localTimeToUTC(date, startTime, user.timezone),
-		endTime: localTimeToUTC(date, endTime, user.timezone),
+		startTime: localTimeToUTC(date, startTime, timezone),
+		endTime: localTimeToUTC(date, endTime, timezone),
 		location: typeof location === "string" ? location.trim() || undefined : undefined,
 		createdById: user.id,
 		createdFromRequestId:
 			typeof fromRequestId === "string" && fromRequestId ? fromRequestId : undefined,
-		callTime: hasCallTime ? localTimeToUTC(date, callTime.trim(), user.timezone) : undefined,
+		callTime: hasCallTime ? localTimeToUTC(date, callTime.trim(), timezone) : undefined,
+		timezone,
 	});
 
 	// Assign performers for show events
@@ -255,7 +259,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 		// Fire-and-forget Discord webhook
 		if (groupData.group.webhookUrl) {
-			const tz = user.timezone ?? undefined;
+			const tz = event.timezone ?? undefined;
 			const webhookDateTime = formatEventTime(event.startTime, event.endTime, tz);
 			const tzAbbrev = getTimezoneAbbreviation(event.startTime, tz);
 			sendEventCreatedWebhook(groupData.group.webhookUrl, {
@@ -281,6 +285,9 @@ export default function NewEvent() {
 	const isSubmitting = navigation.state === "submitting";
 
 	const [eventType, setEventType] = useState("rehearsal");
+	const [timezone, setTimezone] = useState(
+		() => userTimezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+	);
 	const [selectedPerformers, setSelectedPerformers] = useState<Set<string>>(() => {
 		// Pre-select available members when creating from availability
 		if (availabilityData.length > 0) {
@@ -411,7 +418,8 @@ export default function NewEvent() {
 				<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
 					<h3 className="mb-4 text-sm font-semibold text-slate-900">Date & Time</h3>
 					<div className="mb-4">
-						<InlineTimezoneSelector timezone={userTimezone} />
+						<InlineTimezoneSelector timezone={timezone} onChange={setTimezone} />
+						<input type="hidden" name="timezone" value={timezone} />
 					</div>
 					<div className="grid gap-4 sm:grid-cols-3">
 						<div>

--- a/app/services/events.server.test.ts
+++ b/app/services/events.server.test.ts
@@ -79,6 +79,7 @@ const mockEvent = {
 	createdById: "user-1",
 	createdFromRequestId: null,
 	callTime: null,
+	timezone: "America/Los_Angeles",
 	reminderSentAt: null,
 	confirmationReminderSentAt: null,
 	createdAt: now,
@@ -135,6 +136,7 @@ describe("events.server", () => {
 					location: null,
 					createdFromRequestId: null,
 					callTime: null,
+					timezone: "America/Los_Angeles",
 				}),
 			);
 			expect(result).toEqual(mockEvent);

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -27,6 +27,7 @@ export async function createEvent(data: {
 	createdById: string;
 	createdFromRequestId?: string;
 	callTime?: Date;
+	timezone?: string;
 }): Promise<Event> {
 	const [event] = await db
 		.insert(events)
@@ -41,6 +42,7 @@ export async function createEvent(data: {
 			createdById: data.createdById,
 			createdFromRequestId: data.createdFromRequestId ?? null,
 			callTime: data.callTime ?? null,
+			timezone: data.timezone ?? "America/Los_Angeles",
 		})
 		.returning();
 	if (!event) throw new Error("Failed to create event.");
@@ -74,6 +76,7 @@ export async function createEventsFromAvailability(data: {
 			location: data.location,
 			createdById: data.createdById,
 			createdFromRequestId: data.requestId,
+			timezone: data.timezone ?? undefined,
 		});
 
 		if (data.autoAssignAvailable) {
@@ -131,6 +134,7 @@ export async function getGroupEvents(
 			createdById: events.createdById,
 			createdFromRequestId: events.createdFromRequestId,
 			callTime: events.callTime,
+			timezone: events.timezone,
 			reminderSentAt: events.reminderSentAt,
 			confirmationReminderSentAt: events.confirmationReminderSentAt,
 			createdAt: events.createdAt,
@@ -210,6 +214,7 @@ export async function getEventWithAssignments(eventId: string): Promise<{
 			createdById: events.createdById,
 			createdFromRequestId: events.createdFromRequestId,
 			callTime: events.callTime,
+			timezone: events.timezone,
 			reminderSentAt: events.reminderSentAt,
 			confirmationReminderSentAt: events.confirmationReminderSentAt,
 			createdAt: events.createdAt,
@@ -261,6 +266,7 @@ export async function updateEvent(
 		endTime: Date;
 		location: string;
 		callTime: Date | null;
+		timezone: string;
 	}>,
 ): Promise<Event> {
 	const [updated] = await db
@@ -275,6 +281,7 @@ export async function updateEvent(
 			...(data.endTime !== undefined ? { endTime: data.endTime } : {}),
 			...(data.location !== undefined ? { location: data.location.trim() || null } : {}),
 			...(data.callTime !== undefined ? { callTime: data.callTime } : {}),
+			...(data.timezone !== undefined ? { timezone: data.timezone } : {}),
 			// Reset reminders when event is rescheduled so new reminders are sent
 			...(data.startTime !== undefined
 				? { reminderSentAt: null, confirmationReminderSentAt: null }
@@ -362,6 +369,7 @@ export async function getUserUpcomingEvents(
 			createdById: events.createdById,
 			createdFromRequestId: events.createdFromRequestId,
 			callTime: events.callTime,
+			timezone: events.timezone,
 			reminderSentAt: events.reminderSentAt,
 			confirmationReminderSentAt: events.confirmationReminderSentAt,
 			createdAt: events.createdAt,

--- a/app/services/reminder.server.test.ts
+++ b/app/services/reminder.server.test.ts
@@ -71,8 +71,8 @@ const mockUpcomingEvent = {
 	endTime: eventEnd,
 	location: "Theater",
 	callTime: new Date("2026-03-02T01:00:00Z"),
+	timezone: "America/Los_Angeles",
 	groupName: "Comedy Team",
-	creatorTimezone: "America/Los_Angeles",
 	webhookUrl: "https://discord.com/api/webhooks/123/abc",
 };
 
@@ -299,7 +299,7 @@ describe("reminder.server", () => {
 			expect(mockSendEventReminderNotification).not.toHaveBeenCalled();
 		});
 
-		it("sends Discord webhook with creator's timezone", async () => {
+		it("sends Discord webhook with event timezone", async () => {
 			const { formatEventTime, getTimezoneAbbreviation } = await import("../lib/date-utils.js");
 
 			mockTransaction.mockImplementation(async (fn) => {
@@ -343,67 +343,17 @@ describe("reminder.server", () => {
 				}),
 			);
 
-			// Verify formatEventTime was called with the creator's timezone
+			// Verify formatEventTime was called with the event's timezone
 			expect(formatEventTime).toHaveBeenCalledWith(
 				mockUpcomingEvent.startTime,
 				mockUpcomingEvent.endTime,
 				"America/Los_Angeles",
 			);
 
-			// Verify getTimezoneAbbreviation was called with the creator's timezone
+			// Verify getTimezoneAbbreviation was called with the event's timezone
 			expect(getTimezoneAbbreviation).toHaveBeenCalledWith(
 				mockUpcomingEvent.startTime,
 				"America/Los_Angeles",
-			);
-		});
-
-		it("falls back to first attendee's timezone when creator is deleted", async () => {
-			const { formatEventTime } = await import("../lib/date-utils.js");
-			const eventWithoutCreator = {
-				...mockUpcomingEvent,
-				creatorTimezone: null,
-			};
-			const attendeesWithTimezone = [
-				{ ...mockAttendees[0], timezone: "America/New_York" },
-				{ ...mockAttendees[1], timezone: "America/Chicago" },
-			];
-
-			mockTransaction.mockImplementation(async (fn) => {
-				const eventChain = txChainMock(null);
-				eventChain.where = vi.fn().mockResolvedValue([eventWithoutCreator]);
-				eventChain.innerJoin = vi.fn().mockReturnValue(eventChain);
-				eventChain.from = vi.fn().mockReturnValue(eventChain);
-
-				const attendeeChain = txChainMock(null);
-				attendeeChain.where = vi.fn().mockResolvedValue(attendeesWithTimezone);
-				attendeeChain.innerJoin = vi.fn().mockReturnValue(attendeeChain);
-				attendeeChain.from = vi.fn().mockReturnValue(attendeeChain);
-
-				let selectCallCount = 0;
-				const tx = {
-					execute: vi.fn().mockResolvedValue({
-						rows: [{ pg_try_advisory_xact_lock: true }],
-					}),
-					select: vi.fn().mockImplementation(() => {
-						selectCallCount++;
-						return selectCallCount === 1 ? eventChain : attendeeChain;
-					}),
-					update: vi.fn().mockReturnValue({
-						set: vi.fn().mockReturnValue({
-							where: vi.fn().mockResolvedValue(undefined),
-						}),
-					}),
-				};
-				return fn(tx);
-			});
-
-			await processReminders();
-
-			// Should fall back to first attendee's timezone
-			expect(formatEventTime).toHaveBeenCalledWith(
-				eventWithoutCreator.startTime,
-				eventWithoutCreator.endTime,
-				"America/New_York",
 			);
 		});
 	});

--- a/app/services/reminder.server.ts
+++ b/app/services/reminder.server.ts
@@ -83,13 +83,12 @@ export async function processReminders(): Promise<void> {
 				endTime: events.endTime,
 				location: events.location,
 				callTime: events.callTime,
+				timezone: events.timezone,
 				groupName: groups.name,
 				webhookUrl: groups.webhookUrl,
-				creatorTimezone: users.timezone,
 			})
 			.from(events)
 			.innerJoin(groups, eq(events.groupId, groups.id))
-			.leftJoin(users, eq(events.createdById, users.id))
 			.where(
 				and(
 					isNull(events.reminderSentAt),
@@ -163,8 +162,7 @@ export async function processReminders(): Promise<void> {
 
 			// Fire-and-forget Discord webhook (one message per event, not per attendee)
 			if (event.webhookUrl) {
-				// Use event creator's timezone, falling back to first attendee's timezone
-				const webhookTz = event.creatorTimezone ?? attendees[0]?.timezone ?? undefined;
+				const webhookTz = event.timezone ?? undefined;
 				const webhookDateTime = formatEventTime(event.startTime, event.endTime, webhookTz);
 				const tzAbbrev = getTimezoneAbbreviation(event.startTime, webhookTz);
 				sendEventReminderWebhook(event.webhookUrl, {

--- a/drizzle/0011_brave_jackal.sql
+++ b/drizzle/0011_brave_jackal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "timezone" varchar(100) DEFAULT 'America/Los_Angeles' NOT NULL;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,986 @@
+{
+  "id": "15630689-c3a4-4f14-ad88-577bcf704256",
+  "prevId": "4fc69457-368b-406d-932a-b587262ab0a2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_requests": {
+      "name": "availability_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_dates": {
+          "name": "requested_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_start_time": {
+          "name": "requested_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_end_time": {
+          "name": "requested_end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "availability_requests_group_id_idx": {
+          "name": "availability_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_requests_group_id_groups_id_fk": {
+          "name": "availability_requests_group_id_groups_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_requests_created_by_id_users_id_fk": {
+          "name": "availability_requests_created_by_id_users_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_responses": {
+      "name": "availability_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_responses_request_user_idx": {
+          "name": "availability_responses_request_user_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_responses_request_id_availability_requests_id_fk": {
+          "name": "availability_responses_request_id_availability_requests_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_responses_user_id_users_id_fk": {
+          "name": "availability_responses_user_id_users_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_assignments": {
+      "name": "event_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_assignments_event_user_idx": {
+          "name": "event_assignments_event_user_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_assignments_user_id_idx": {
+          "name": "event_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_assignments_event_id_events_id_fk": {
+          "name": "event_assignments_event_id_events_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_assignments_user_id_users_id_fk": {
+          "name": "event_assignments_user_id_users_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_request_id": {
+          "name": "created_from_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_time": {
+          "name": "call_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_reminder_sent_at": {
+          "name": "confirmation_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_group_start_time_idx": {
+          "name": "events_group_start_time_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_group_id_groups_id_fk": {
+          "name": "events_group_id_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_id_users_id_fk": {
+          "name": "events_created_by_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_created_from_request_id_availability_requests_id_fk": {
+          "name": "events_created_from_request_id_availability_requests_id_fk",
+          "tableFrom": "events",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "created_from_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"availabilityRequests\":{\"email\":true},\"eventNotifications\":{\"email\":true},\"showReminders\":{\"email\":true}}'::jsonb"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_user_idx": {
+          "name": "group_memberships_group_user_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_can_create_requests": {
+          "name": "members_can_create_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "members_can_create_events": {
+          "name": "members_can_create_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_invite_code_idx": {
+          "name": "groups_invite_code_idx",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_id_users_id_fk": {
+          "name": "groups_created_by_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_invite_code_unique": {
+          "name": "groups_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_expiry": {
+          "name": "email_verification_expiry",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_google_id_idx": {
+          "name": "users_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verification_token_idx": {
+          "name": "users_email_verification_token_idx",
+          "columns": [
+            {
+              "expression": "email_verification_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "declined"
+      ]
+    },
+    "public.availability_response_value": {
+      "name": "availability_response_value",
+      "schema": "public",
+      "values": [
+        "available",
+        "maybe",
+        "not_available"
+      ]
+    },
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "rehearsal",
+        "show",
+        "other"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772514464300,
       "tag": "0010_cultured_zombie",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773326473946,
+      "tag": "0011_brave_jackal",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -176,6 +176,7 @@ export const events = pgTable(
 		createdById: uuid("created_by_id").references(() => users.id, { onDelete: "set null" }),
 		createdFromRequestId: uuid("created_from_request_id").references(() => availabilityRequests.id),
 		callTime: timestamp("call_time", { withTimezone: true }),
+		timezone: varchar("timezone", { length: 100 }).default("America/Los_Angeles").notNull(),
 		reminderSentAt: timestamp("reminder_sent_at", { withTimezone: true }),
 		confirmationReminderSentAt: timestamp("confirmation_reminder_sent_at", {
 			withTimezone: true,


### PR DESCRIPTION
## Summary

Events now persist their timezone at creation time rather than looking up the creator's profile timezone via a JOIN. This fixes the approach from PR #119 which was fragile.

## Problem

PR #119 fixed Discord webhook timezone display by joining the event creator's profile timezone. That approach is wrong because:
- The creator might change their profile timezone (e.g., travel)
- The creator might be deleted (was falling back to first attendee's timezone)
- The creator might not even attend the event

## Solution

### 1. New `timezone` column on events table
- `varchar(100)`, NOT NULL, default `'America/Los_Angeles'`
- Migration backfills all existing events with the default (only current creator is in Pacific time)

### 2. Timezone saved at event creation/edit
- The form's `InlineTimezoneSelector` now submits via hidden input (`name="timezone"`)
- `createEvent()` and `updateEvent()` accept and persist the timezone
- Edit route uses event's stored timezone for time conversion (not the editing user's profile)

### 3. Webhook uses event.timezone directly
- Removed `leftJoin` on users table in `reminder.server.ts` (the `creatorTimezone` join from PR #119)
- `event.timezone` is used directly for Discord webhook formatting
- Same fix applied in event creation route's webhook

### 4. Email notifications unchanged
- Email notifications still format per-recipient timezone — that's correct for personal emails

## Files Changed
| File | Change |
|------|--------|
| `src/db/schema.ts` | Added `timezone` column to events table |
| `drizzle/0011_brave_jackal.sql` | Migration: ALTER TABLE ADD COLUMN |
| `app/services/events.server.ts` | `createEvent`/`updateEvent` accept timezone; all selects include it |
| `app/services/reminder.server.ts` | Removed users leftJoin, use `event.timezone` for webhooks |
| `app/routes/groups.$groupId.events.new.tsx` | Submit timezone from form, use for webhook |
| `app/routes/groups.$groupId.events.$eventId.edit.tsx` | Added timezone selector, submit timezone |
| `app/components/timezone-selector.tsx` | Added `onChange` callback prop |
| `app/services/events.server.test.ts` | Added timezone to mock event |
| `app/services/reminder.server.test.ts` | Updated to use `event.timezone`, removed creator fallback test |

## Quality Gates
- ✅ `pnpm run typecheck` — no errors
- ✅ `pnpm run lint` — clean (pre-existing warning only)
- ✅ `pnpm test` — 380/380 tests pass
- ✅ `pnpm run build` — production build succeeds
- ✅ No remaining `creatorTimezone` references in codebase