### PR TITLE
feat: add copy feedback animation to invite code buttons

### DIFF
--- a/app/components/copy-button.tsx
+++ b/app/components/copy-button.tsx
@@ -1,0 +1,95 @@
+import { Check, Copy } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+function useCopyState(value: string) {
+	const [copied, setCopied] = useState(false);
+	const [animating, setAnimating] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			setAnimating(true);
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+			timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// Clipboard API unavailable in this context
+		}
+	}, [value]);
+
+	const handleAnimationEnd = useCallback(() => {
+		setAnimating(false);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	return { copied, animating, handleCopy, handleAnimationEnd };
+}
+
+/**
+ * Small icon-only copy button (e.g., next to an invite code).
+ * Shows a clipboard icon that swaps to a checkmark on success.
+ */
+export function CopyIconButton({ value, title = "Copy" }: { value: string; title?: string }) {
+	const { copied, animating, handleCopy, handleAnimationEnd } = useCopyState(value);
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			onAnimationEnd={handleAnimationEnd}
+			className={`rounded-lg border p-2 transition-all duration-200 ${
+				copied
+					? "border-emerald-300 bg-emerald-50 text-emerald-600"
+					: "border-slate-300 text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+			} ${animating ? "animate-copy-success" : ""}`}
+			title={copied ? "Copied!" : title}
+			aria-label={copied ? "Copied!" : title}
+		>
+			{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+		</button>
+	);
+}
+
+/**
+ * Text copy button with a label that swaps to "Copied!" on success.
+ * Pass additional layout classes (e.g., `w-full`, `mt-3`) via `className`.
+ */
+export function CopyButton({
+	value,
+	children,
+	className = "",
+}: {
+	value: string;
+	children: ReactNode;
+	className?: string;
+}) {
+	const { copied, animating, handleCopy, handleAnimationEnd } = useCopyState(value);
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			onAnimationEnd={handleAnimationEnd}
+			className={`rounded-lg border transition-all duration-200 ${
+				copied
+					? "border-emerald-300 bg-emerald-50 text-emerald-600"
+					: "border-slate-300 text-slate-600 hover:bg-slate-50 hover:text-slate-700"
+			} ${animating ? "animate-copy-success" : ""} ${className}`}
+		>
+			{copied ? (
+				<span className="inline-flex items-center justify-center gap-1.5">
+					<Check className="h-3.5 w-3.5" />
+					Copied!
+				</span>
+			) : (
+				children
+			)}
+		</button>
+	);
+}

--- a/app/routes/groups.$groupId._index.tsx
+++ b/app/routes/groups.$groupId._index.tsx
@@ -1,6 +1,7 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Form, Link, useLoaderData, useRouteLoaderData } from "@remix-run/react";
 import { CalendarDays } from "lucide-react";
+import { CopyButton, CopyIconButton } from "~/components/copy-button";
 import { CsrfInput } from "~/components/csrf-input";
 import { EventCard } from "~/components/event-card";
 import { getOpenAvailabilityRequestCount } from "~/services/availability.server";
@@ -193,37 +194,11 @@ export default function GroupOverview() {
 							<code className="flex-1 rounded-lg bg-slate-100 px-3 py-2 text-center font-mono text-lg tracking-widest text-slate-900">
 								{group.inviteCode}
 							</code>
-							<button
-								type="button"
-								onClick={() => navigator.clipboard.writeText(group.inviteCode)}
-								className="rounded-lg border border-slate-300 p-2 text-slate-500 transition-colors hover:bg-slate-50 hover:text-slate-700"
-								title="Copy invite code"
-							>
-								<svg
-									className="h-4 w-4"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth={1.5}
-									stroke="currentColor"
-								>
-									<title>Copy</title>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
-									/>
-								</svg>
-							</button>
+							<CopyIconButton value={group.inviteCode} title="Copy invite code" />
 						</div>
-						<button
-							type="button"
-							onClick={() => {
-								navigator.clipboard.writeText(inviteLink);
-							}}
-							className="mt-3 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
-						>
+						<CopyButton value={inviteLink} className="mt-3 w-full px-3 py-2 text-sm font-medium">
 							📋 Copy Invite Link
-						</button>
+						</CopyButton>
 					</div>
 				)}
 			</div>

--- a/app/routes/groups.$groupId.settings.tsx
+++ b/app/routes/groups.$groupId.settings.tsx
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { Form, useActionData, useLoaderData, useNavigation } from "@remix-run/react";
 import { useState } from "react";
+import { CopyButton } from "~/components/copy-button";
 import { CsrfInput } from "~/components/csrf-input";
 import { validateCsrfToken } from "~/services/csrf.server";
 import {
@@ -252,13 +253,9 @@ export default function GroupSettings() {
 						<code className="flex-1 rounded-lg bg-slate-100 px-4 py-3 text-center font-mono text-xl tracking-widest text-slate-900">
 							{group.inviteCode}
 						</code>
-						<button
-							type="button"
-							onClick={() => navigator.clipboard.writeText(group.inviteCode)}
-							className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-50"
-						>
+						<CopyButton value={group.inviteCode} className="px-3 py-2 text-sm">
 							Copy
-						</button>
+						</CopyButton>
 					</div>
 					<Form method="post" className="mt-4">
 						<CsrfInput />

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,1 +1,20 @@
 @import "tailwindcss";
+
+@theme {
+	--animate-copy-success: copy-success 0.35s ease-out;
+}
+
+@keyframes copy-success {
+	0% {
+		transform: scale(1);
+	}
+	25% {
+		transform: scale(0.92);
+	}
+	65% {
+		transform: scale(1.07);
+	}
+	100% {
+		transform: scale(1);
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,11 @@
 			"semicolons": "always"
 		}
 	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		}
+	},
 	"files": {
 		"includes": ["**/*.ts", "**/*.tsx", "**/*.json", "**/*.css", "!drizzle"]
 	},


### PR DESCRIPTION
## Summary

Adds satisfying visual feedback when clicking copy buttons for invite codes. Previously, the buttons had no indication that the copy succeeded.

## Changes

- **New `CopyButton` and `CopyIconButton` components** (`app/components/copy-button.tsx`): Reusable copy-to-clipboard buttons with built-in feedback animation
- **Group overview page** (`groups.$groupId._index.tsx`): Replaced inline SVG clipboard button and plain text button with the new components
- **Group settings page** (`groups.$groupId.settings.tsx`): Replaced plain "Copy" button with the new component
- **Animation** (`app/tailwind.css`): Added `copy-success` keyframe animation (scale bounce: 1 → 0.92 → 1.07 → 1)
- **Biome config**: Enabled `tailwindDirectives` in CSS parser to support `@theme` blocks

## Behavior

When a copy button is clicked:
1. Clipboard write executes
2. Icon swaps from 📋 to ✓ (lucide-react `Copy` → `Check`)
4. Border/background transitions to emerald (green) with `transition-all duration-200`
5. A subtle scale bounce animation plays (0.35s ease-out)
6. After 2 seconds, smoothly reverts to the original state

## Technical notes

- `useCopyState` hook manages copied/animating state with proper cleanup (timeout refs cleared on unmount)
- `onAnimationEnd` callback ensures the bounce animation fires once per click, even on rapid re-clicks
- Error handling for clipboard API failures (silently catches — no broken state)

## Quality gates

- ✅ TypeScript strict mode (`pnpm run typecheck`)
- ✅ Biome lint (only pre-existing `isNaN` warning in telemetry.server.ts)
- ✅ Production build (`pnpm run build`)
- ✅ All 380 tests pass (`pnpm test`)