### PR TITLE
fix: add call time field for shows and fix mobile layout in batch form

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
@@ -470,3 +470,132 @@ describe("batch action with default times (fast path)", () => {
 		);
 	});
 });
+
+describe("batch action call time (show events)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(getAvailabilityRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			title: "March Schedule",
+			status: "open",
+			requestedDates: ["2026-03-15", "2026-03-16"],
+		});
+		(createEventsFromAvailability as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{
+				id: "ev-1",
+				groupId: "g1",
+				title: "Big Show",
+				eventType: "show",
+				startTime: new Date("2026-03-15T19:00:00Z"),
+				endTime: new Date("2026-03-15T21:00:00Z"),
+				location: null,
+				description: null,
+			},
+		]);
+	});
+
+	it("returns error when call time is after start time", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "show",
+			callTime: "20:00",
+		});
+		const result = await action(actionArgs(formData));
+
+		expect(result).toEqual({ error: "Call time must be before start time." });
+	});
+
+	it("returns error when call time equals start time", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "show",
+			callTime: "19:00",
+		});
+		const result = await action(actionArgs(formData));
+
+		expect(result).toEqual({ error: "Call time must be before start time." });
+	});
+
+	it("accepts call time before start time for shows", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "show",
+			callTime: "18:00",
+		});
+
+		let response: Response | undefined;
+		try {
+			const result = await action(actionArgs(formData));
+			if (result instanceof Response) response = result;
+		} catch (thrown) {
+			if (thrown instanceof Response) response = thrown;
+		}
+
+		expect(response).toBeInstanceOf(Response);
+		expect(response?.status).toBe(302);
+	});
+
+	it("passes call time to createEventsFromAvailability for shows", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "show",
+			callTime: "18:00",
+		});
+
+		try {
+			await action(actionArgs(formData));
+		} catch {
+			// redirect expected
+		}
+
+		expect(createEventsFromAvailability).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "show",
+				callTime: "18:00",
+			}),
+		);
+	});
+
+	it("ignores call time for non-show event types", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "rehearsal",
+			callTime: "18:00",
+		});
+
+		try {
+			await action(actionArgs(formData));
+		} catch {
+			// redirect expected
+		}
+
+		expect(createEventsFromAvailability).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "rehearsal",
+				callTime: undefined,
+			}),
+		);
+	});
+
+	it("does not pass call time when empty string for shows", async () => {
+		const formData = createFormData({
+			...validFormData,
+			eventType: "show",
+			callTime: "",
+		});
+
+		try {
+			await action(actionArgs(formData));
+		} catch {
+			// redirect expected
+		}
+
+		expect(createEventsFromAvailability).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "show",
+				callTime: undefined,
+			}),
+		);
+	});
+});

--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -7,7 +7,7 @@ import {
 	useLoaderData,
 	useNavigation,
 } from "@remix-run/react";
-import { ArrowLeft, Calendar, Check, MapPin, Plus } from "lucide-react";
+import { ArrowLeft, Calendar, Check, Clock, MapPin, Plus } from "lucide-react";
 import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { InlineTimezoneSelector } from "~/components/timezone-selector";
@@ -78,6 +78,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const description = formData.get("description");
 	const startTime = formData.get("startTime");
 	const endTime = formData.get("endTime");
+	const callTime = formData.get("callTime");
 	const dates = formData.get("dates");
 	const formTimezone = formData.get("timezone");
 	const timezone =
@@ -110,6 +111,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	if (startTime >= endTime) {
 		return { error: "End time must be after start time." };
 	}
+
+	const hasCallTime =
+		eventType === "show" && typeof callTime === "string" && callTime.trim() !== "";
+	if (hasCallTime && callTime.trim() >= startTime) {
+		return { error: "Call time must be before start time." };
+	}
+
 	if (typeof dates !== "string" || !dates) {
 		return { error: "No dates selected." };
 	}
@@ -141,6 +149,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		eventType: eventType as "rehearsal" | "show" | "other",
 		createdById: user.id,
 		timezone,
+		callTime: hasCallTime ? callTime.trim() : undefined,
 	});
 
 	// Fire-and-forget notifications
@@ -289,6 +298,7 @@ export default function BatchCreateEvents() {
 	const [description, setDescription] = useState("");
 	const [startTime, setStartTime] = useState(availRequest.requestedStartTime ?? DEFAULT_START_TIME);
 	const [endTime, setEndTime] = useState(availRequest.requestedEndTime ?? DEFAULT_END_TIME);
+	const [callTime, setCallTime] = useState("18:00");
 	const [timezone, setTimezone] = useState<string | null>(userTimezone ?? null);
 	const [locations, setLocations] = useState<Record<string, string>>({});
 	const [applyAllLocation, setApplyAllLocation] = useState("");
@@ -369,6 +379,8 @@ export default function BatchCreateEvents() {
 					onStartTimeChange={setStartTime}
 					endTime={endTime}
 					onEndTimeChange={setEndTime}
+					callTime={callTime}
+					onCallTimeChange={setCallTime}
 					timezone={timezone}
 					onTimezoneChange={setTimezone}
 					selectedDates={selectedDates}
@@ -401,6 +413,7 @@ export default function BatchCreateEvents() {
 					description={description}
 					startTime={startTime}
 					endTime={endTime}
+					callTime={callTime}
 					timezone={timezone}
 					selectedDates={selectedDates}
 					locations={locations}
@@ -424,6 +437,8 @@ function ConfigureStep({
 	onStartTimeChange,
 	endTime,
 	onEndTimeChange,
+	callTime,
+	onCallTimeChange,
 	timezone,
 	onTimezoneChange,
 	selectedDates,
@@ -450,6 +465,8 @@ function ConfigureStep({
 	onStartTimeChange: (v: string) => void;
 	endTime: string;
 	onEndTimeChange: (v: string) => void;
+	callTime: string;
+	onCallTimeChange: (v: string) => void;
 	timezone: string | null;
 	onTimezoneChange: (v: string) => void;
 	selectedDates: string[];
@@ -551,7 +568,7 @@ function ConfigureStep({
 					)}
 
 					{/* Time Inputs */}
-					<div className="grid grid-cols-2 gap-4">
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
 						<div>
 							<label htmlFor="startTime" className="block text-sm font-medium text-slate-700">
 								Start Time <span className="text-red-500">*</span>
@@ -577,6 +594,26 @@ function ConfigureStep({
 							/>
 						</div>
 					</div>
+
+					{/* Call Time — show only */}
+					{eventType === "show" && (
+						<div>
+							<label htmlFor="callTime" className="block text-sm font-medium text-slate-700">
+								<Clock className="mr-1 inline h-4 w-4 text-purple-500" />
+								Call Time
+								<span className="ml-1 text-xs font-normal text-slate-500">
+									(when performers need to arrive)
+								</span>
+							</label>
+							<input
+								id="callTime"
+								type="time"
+								value={callTime}
+								onChange={(e) => onCallTimeChange(e.target.value)}
+								className="mt-1 block w-full max-w-[200px] rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+							/>
+						</div>
+					)}
 
 					{/* Timezone */}
 					<div>
@@ -681,6 +718,7 @@ function ReviewStep({
 	description,
 	startTime,
 	endTime,
+	callTime,
 	timezone,
 	selectedDates,
 	locations,
@@ -693,6 +731,7 @@ function ReviewStep({
 	description: string;
 	startTime: string;
 	endTime: string;
+	callTime: string;
 	timezone: string | null;
 	selectedDates: string[];
 	locations: Record<string, string>;
@@ -702,6 +741,13 @@ function ReviewStep({
 }) {
 	const typeLabel = EVENT_TYPE_OPTIONS.find((o) => o.value === eventType)?.label ?? eventType;
 	const timeDisplay = formatTimeRange(startTime, endTime);
+	const showCallTime = eventType === "show" && callTime;
+	const formatHHMM = (t: string) => {
+		const [h, m] = t.split(":").map(Number);
+		const period = h >= 12 ? "PM" : "AM";
+		const hour12 = h % 12 || 12;
+		return `${hour12}:${String(m).padStart(2, "0")} ${period}`;
+	};
 
 	return (
 		<div className="space-y-6">
@@ -743,6 +789,12 @@ function ReviewStep({
 										<span>·</span>
 										<span>{timeDisplay}</span>
 									</div>
+									{showCallTime && (
+										<div className="mt-1 flex items-center gap-1 text-sm text-purple-600">
+											<Clock className="h-3.5 w-3.5" />
+											Call Time: {formatHHMM(callTime)}
+										</div>
+									)}
 									{location && (
 										<div className="mt-1 flex items-center gap-1 text-sm text-slate-500">
 											<MapPin className="h-3.5 w-3.5" />
@@ -764,6 +816,7 @@ function ReviewStep({
 				{description && <input type="hidden" name="description" value={description} />}
 				<input type="hidden" name="startTime" value={startTime} />
 				<input type="hidden" name="endTime" value={endTime} />
+				{showCallTime && <input type="hidden" name="callTime" value={callTime} />}
 				<input type="hidden" name="timezone" value={timezone ?? ""} />
 				<input type="hidden" name="dates" value={selectedDates.join(",")} />
 				{selectedDates.map((date) =>

--- a/app/services/batch-events.test.ts
+++ b/app/services/batch-events.test.ts
@@ -194,4 +194,51 @@ describe("batch events — createEventsFromAvailability per-date features", () =
 
 		expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ location: null }));
 	});
+
+	it("passes callTime to each created event when provided", async () => {
+		mockReturning
+			.mockResolvedValueOnce([
+				{ ...mockEvent, id: "ev-1", callTime: new Date("2026-03-15T18:00:00Z") },
+			])
+			.mockResolvedValueOnce([
+				{ ...mockEvent, id: "ev-2", callTime: new Date("2026-03-16T18:00:00Z") },
+			]);
+
+		await createEventsFromAvailability({
+			groupId: "group-1",
+			requestId: "req-1",
+			dates: [
+				{ date: "2026-03-15", startTime: "19:00", endTime: "21:00" },
+				{ date: "2026-03-16", startTime: "19:00", endTime: "21:00" },
+			],
+			title: "Big Show",
+			eventType: "show",
+			createdById: "user-1",
+			callTime: "18:00",
+		});
+
+		const calls = mockValues.mock.calls;
+		// Each event should have callTime converted via localTimeToUTC
+		expect(calls[0][0]).toEqual(
+			expect.objectContaining({ callTime: new Date("2026-03-15T18:00:00Z") }),
+		);
+		expect(calls[1][0]).toEqual(
+			expect.objectContaining({ callTime: new Date("2026-03-16T18:00:00Z") }),
+		);
+	});
+
+	it("defaults callTime to null when not provided", async () => {
+		mockReturning.mockResolvedValueOnce([mockEvent]);
+
+		await createEventsFromAvailability({
+			groupId: "group-1",
+			requestId: "req-1",
+			dates: [{ date: "2026-03-15", startTime: "19:00", endTime: "21:00" }],
+			title: "Rehearsal",
+			eventType: "rehearsal",
+			createdById: "user-1",
+		});
+
+		expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ callTime: null }));
+	});
 });

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -61,6 +61,7 @@ export async function createEventsFromAvailability(data: {
 	createdById: string;
 	autoAssignAvailable?: boolean;
 	timezone?: string | null;
+	callTime?: string;
 }): Promise<Event[]> {
 	const createdEvents: Event[] = [];
 
@@ -79,6 +80,9 @@ export async function createEventsFromAvailability(data: {
 			createdById: data.createdById,
 			createdFromRequestId: data.requestId,
 			timezone: data.timezone ?? undefined,
+			callTime: data.callTime
+				? localTimeToUTC(dateInfo.date, data.callTime, data.timezone)
+				: undefined,
 		});
 
 		if (data.autoAssignAvailable) {


### PR DESCRIPTION
## Summary

Fixes two bugs in the batch event creation form reported by the CEO.

### Bug 1: Missing "Call Time" option when Show is selected

When selecting "Show" as the event type in the batch form, there was no Call Time field — unlike the single event creation form which shows it. This meant batch-created show events always had `callTime: null`, so performers wouldn't know when to arrive.

**Fix:** Added a conditional Call Time input that appears when event type is "Show", matching the single event form's pattern:
- Purple Clock icon with "(when performers need to arrive)" helper text
- Default value of 18:00 (6 PM), same as the single event form
- Validation: call time must be before start time
- Displayed in the review step before submission
- Passed through `createEventsFromAvailability` → `createEvent` for each date

### Bug 2: Start & End time pickers scrunched on mobile

The time pickers used `grid grid-cols-2 gap-4` with no responsive breakpoint, causing them to be crammed together on mobile screens.

**Fix:** Changed to `grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4` — stacks vertically on phones, side-by-side on larger screens.

## Changes

| File | Change |
|------|--------|
| `app/services/events.server.ts` | Added `callTime?: string` param to `createEventsFromAvailability`, passes it to `createEvent` via `localTimeToUTC` |
| `app/routes/groups.$groupId.availability.$requestId_.batch.tsx` | Added call time UI, state, validation in action, hidden input in review form, fixed mobile grid |
| `app/routes/groups.$groupId.availability.$requestId_.batch.test.ts` | +6 tests: validation (after/equal/before start time), passing to service, ignored for non-shows, empty string handling |
| `app/services/batch-events.test.ts` | +2 tests: callTime propagation to createEvent, default null when omitted |

## Testing

- **39 tests pass** (31 existing + 8 new) across both test files
- **Typecheck** passes (no new errors)
- **Lint** passes clean
- **Build** succeeds
