### PR TITLE
fix: make Call Time input full-width on mobile for consistency

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -610,7 +610,7 @@ function ConfigureStep({
 								type="time"
 								value={callTime}
 								onChange={(e) => onCallTimeChange(e.target.value)}
-								className="mt-1 block w-full max-w-[200px] rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
 							/>
 						</div>
 					)}

--- a/app/routes/groups.$groupId.events.$eventId.edit.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.edit.tsx
@@ -461,7 +461,7 @@ export default function EditEvent() {
 								name="callTime"
 								type="time"
 								defaultValue={prefill.callTime}
-								className="mt-1 block w-full max-w-[200px] rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
 							/>
 						</div>
 					)}

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -478,7 +478,7 @@ export default function NewEvent() {
 								name="callTime"
 								type="time"
 								defaultValue="18:00"
-								className="mt-1 block w-full max-w-[200px] rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
 							/>
 						</div>
 					)}


### PR DESCRIPTION
## Problem

The batch event creation form has inconsistent input widths on mobile. The Call Time input is constrained to `max-w-[200px]`, making it noticeably narrower than Title, Description, Start Time, and End Time inputs which are all full-width.

The same issue exists in the single event creation and event edit forms.

## Fix

Changed `max-w-[200px]` → `sm:max-w-[200px]` on the Call Time `<input type="time">` in all three event forms:

- `groups.$groupId.availability.$requestId_.batch.tsx` (batch creation)
- `groups.$groupId.events.new.tsx` (single event creation)
- `groups.$groupId.events.$eventId.edit.tsx` (event edit)

### Before (mobile)
Call Time input is 200px wide while all other inputs are full-width → visual inconsistency.

### After (mobile)
All inputs including Call Time are full-width (`w-full`), creating a cohesive form layout.

### Desktop behavior
No change — `sm:max-w-[200px]` preserves the 200px constraint at ≥640px where full-width time pickers look oversized.

## Verification

- [x] Build passes
- [x] All pre-existing typecheck/lint/test failures are unchanged (wt-* prototype dirs only)
- [x] CSS-only change — no logic changes
- [x] Consistent across all three event forms