### PR TITLE
fix: add appearance-none to form inputs for consistent iOS Safari widths

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -504,7 +504,7 @@ function ConfigureStep({
 							value={title}
 							onChange={(e) => onTitleChange(e.target.value)}
 							maxLength={200}
-							className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							placeholder="e.g. Weekly Rehearsal"
 						/>
 					</div>
@@ -561,7 +561,7 @@ function ConfigureStep({
 								onChange={(e) => onDescriptionChange(e.target.value)}
 								maxLength={2000}
 								rows={3}
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 								placeholder="Add any notes or details..."
 							/>
 						</div>
@@ -578,7 +578,7 @@ function ConfigureStep({
 								type="time"
 								value={startTime}
 								onChange={(e) => onStartTimeChange(e.target.value)}
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -590,7 +590,7 @@ function ConfigureStep({
 								type="time"
 								value={endTime}
 								onChange={(e) => onEndTimeChange(e.target.value)}
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 					</div>
@@ -610,7 +610,7 @@ function ConfigureStep({
 								type="time"
 								value={callTime}
 								onChange={(e) => onCallTimeChange(e.target.value)}
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
 							/>
 						</div>
 					)}
@@ -660,7 +660,7 @@ function ConfigureStep({
 							value={applyAllLocation}
 							onChange={(e) => onApplyAllLocationChange(e.target.value)}
 							maxLength={200}
-							className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							className="flex-1 appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							placeholder="Same location for all dates"
 						/>
 						<button
@@ -687,7 +687,7 @@ function ConfigureStep({
 										value={locations[date] ?? ""}
 										onChange={(e) => onLocationChange(date, e.target.value)}
 										maxLength={200}
-										className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+										className="flex-1 appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 										placeholder="Location"
 									/>
 								</div>

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -365,7 +365,7 @@ export default function NewEvent() {
 								required
 								maxLength={200}
 								placeholder="e.g., Friday Night Show"
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -432,7 +432,7 @@ export default function NewEvent() {
 								type="date"
 								required
 								defaultValue={prefillDate ?? ""}
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -445,7 +445,7 @@ export default function NewEvent() {
 								type="time"
 								required
 								defaultValue="19:00"
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -458,7 +458,7 @@ export default function NewEvent() {
 								type="time"
 								required
 								defaultValue="21:00"
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 					</div>
@@ -478,7 +478,7 @@ export default function NewEvent() {
 								name="callTime"
 								type="time"
 								defaultValue="18:00"
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors sm:max-w-[200px] focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
 							/>
 						</div>
 					)}
@@ -645,7 +645,7 @@ export default function NewEvent() {
 								type="text"
 								maxLength={200}
 								placeholder="e.g., Studio A, Main Theater"
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -658,7 +658,7 @@ export default function NewEvent() {
 								rows={3}
 								maxLength={2000}
 								placeholder="Any additional details..."
-								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
## Problem

On the batch event creation form, the Title `<input type="text">` is visibly narrower than Start Time, End Time, and Call Time `<input type="time">` inputs on iPhone/iOS Safari.

Previous attempts changed `text-sm` to `text-slate-900` and made `max-w-[200px]` responsive — neither fixed the root cause.

## Root Cause

iOS Safari renders `type="time"` inputs with native browser appearance chrome (`-webkit-appearance: menulist-button`) that affects width calculation differently from `type="text"` inputs. Even when both have `w-full` (CSS `width: 100%`), the native chrome on time inputs makes them render wider than text inputs.

## Fix

Added Tailwind's `appearance-none` utility (`appearance: none; -webkit-appearance: none`) to **all form inputs** in both event creation forms. This strips the native browser chrome and gives CSS full control over sizing.

**Why this works:**
- All inputs already have complete custom styling (borders, padding, rounded corners, shadows)
- `appearance-none` simply completes the CSS override that was already 90% there
- The time picker still functions on mobile (triggered by tap/focus, not by the appearance property)
- Standard CSS normalization practice for custom-styled form controls

## Files Changed

- `app/routes/groups.$groupId.availability.$requestId_.batch.tsx` — 7 inputs (title, description, start time, end time, call time, apply-all location, per-date locations)
- `app/routes/groups.$groupId.events.new.tsx` — 7 inputs (title, date, start time, end time, call time, location, description)

## Verification

Playwright screenshot with iPhone 14 Pro viewport (393×852, 3x scale, WebKit engine) confirms all inputs render at identical width (279px each):

```
title:     width=279px  left=57  right=336
startTime: width=279px  left=57  right=336
endTime:   width=279px  left=57  right=336
callTime:  width=279px  left=57  right=336
✅ All input widths match!
```

## Quality Gates

- ✅ Biome lint (changed files) — 0 issues
- ✅ Production build — passes
- ✅ Tests — 234 files, 2957 tests pass (failures are pre-existing in wt-* prototype dirs)
