### PR TITLE
fix: scope appearance-none to only type=time inputs

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -504,7 +504,7 @@ function ConfigureStep({
 							value={title}
 							onChange={(e) => onTitleChange(e.target.value)}
 							maxLength={200}
-							className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							placeholder="e.g. Weekly Rehearsal"
 						/>
 					</div>
@@ -561,7 +561,7 @@ function ConfigureStep({
 								onChange={(e) => onDescriptionChange(e.target.value)}
 								maxLength={2000}
 								rows={3}
-								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 								placeholder="Add any notes or details..."
 							/>
 						</div>
@@ -660,7 +660,7 @@ function ConfigureStep({
 							value={applyAllLocation}
 							onChange={(e) => onApplyAllLocationChange(e.target.value)}
 							maxLength={200}
-							className="flex-1 appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							placeholder="Same location for all dates"
 						/>
 						<button
@@ -687,7 +687,7 @@ function ConfigureStep({
 										value={locations[date] ?? ""}
 										onChange={(e) => onLocationChange(date, e.target.value)}
 										maxLength={200}
-										className="flex-1 appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+										className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 										placeholder="Location"
 									/>
 								</div>

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -365,7 +365,7 @@ export default function NewEvent() {
 								required
 								maxLength={200}
 								placeholder="e.g., Friday Night Show"
-								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -432,7 +432,7 @@ export default function NewEvent() {
 								type="date"
 								required
 								defaultValue={prefillDate ?? ""}
-								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -645,7 +645,7 @@ export default function NewEvent() {
 								type="text"
 								maxLength={200}
 								placeholder="e.g., Studio A, Main Theater"
-								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 						<div>
@@ -658,7 +658,7 @@ export default function NewEvent() {
 								rows={3}
 								maxLength={2000}
 								placeholder="Any additional details..."
-								className="mt-1 block w-full appearance-none rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
## What

Fixes regression from PR #131 where `appearance-none` was applied too broadly to all form inputs in the batch event form and single event form.

## Why

`appearance-none` is only needed on `type="time"` inputs to fix iOS Safari's native chrome causing width inconsistency. Text inputs, textareas, and date inputs don't have this problem and lost proper styling when it was applied to them.

## Changes

**Removed `appearance-none` from (both files):**
- Title inputs (`type="text"`)
- Description textareas
- Location inputs (`type="text"`, both "Apply to All" and per-date)
- Date input (`type="date"`, events.new only)

**Kept `appearance-none` on (both files):**
- `startTime` (`type="time"`)
- `endTime` (`type="time"`)
- `callTime` (`type="time"`)

## Files Changed
- `app/routes/groups.$groupId.availability.$requestId_.batch.tsx` — 4 className changes
- `app/routes/groups.$groupId.events.new.tsx` — 4 className changes

## Verification

- [x] Lint passes (biome check on changed files)
- [x] Build passes (`pnpm run build`)
- [x] Visual verification via Playwright WebKit screenshots at iPhone 14 Pro viewport (393×852, 3x scale)
- [x] All form elements have visible borders, rounded corners, and consistent widths
- [x] Code review confirms all 8 removals are correct and all 6 time inputs retain `appearance-none`

## Screenshot

Visual test confirms all inputs render correctly in WebKit/iOS Safari viewport — borders, rounding, and widths are consistent across all form element types.