### PR TITLE
fix: per-date location inputs overflow card on mobile

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -660,7 +660,7 @@ function ConfigureStep({
 							value={applyAllLocation}
 							onChange={(e) => onApplyAllLocationChange(e.target.value)}
 							maxLength={200}
-							className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							className="min-w-0 flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 							placeholder="Same location for all dates"
 						/>
 						<button
@@ -687,7 +687,7 @@ function ConfigureStep({
 										value={locations[date] ?? ""}
 										onChange={(e) => onLocationChange(date, e.target.value)}
 										maxLength={200}
-										className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+										className="min-w-0 flex-1 rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
 										placeholder="Location"
 									/>
 								</div>


### PR DESCRIPTION
## Problem

On the batch event creation form, the per-date location inputs and the "Apply to All" input overflow the card container on mobile (especially iOS Safari). The inputs extend past the right edge of the card.

## Root Cause

Flex items default to `min-width: auto`, which means the input's intrinsic minimum width prevents it from shrinking below its content size. On a narrow mobile viewport, the `w-28` date label + `gap-3` + the input exceeds the card width.

## Fix

Added `min-w-0` to both location inputs (`flex-1` → `min-w-0 flex-1`), allowing them to shrink properly within the flex container. This is the standard CSS fix for flex item overflow.

**Changed inputs:**
- "Same location for all dates" input (Apply to All row)
- Per-date location inputs

## Visual Verification

Tested with Playwright WebKit on iPhone SE viewport (375×667). Screenshot shows before/after:

- **Before:** Inputs and "Apply to All" button overflow past card boundary
- **After:** Everything properly contained within the card

Screenshot: `test-results/mobile-overflow-fix.png`

## Quality Gates

- ✅ Build passes
- ✅ Typecheck: pre-existing errors only in `wt-cart/`, `wt-heatmap/`, `wt-wizard/` prototype dirs (no new errors)
- ✅ Visual verification with Playwright WebKit mobile viewport