### PR TITLE
fix: collapse same-date ranges in formatDateRange to single date

### DIFF
--- a/app/lib/date-utils.test.ts
+++ b/app/lib/date-utils.test.ts
@@ -90,7 +90,7 @@ describe("date-utils", () => {
 			// This is the core off-by-one bug: midnight UTC formatted in PDT shows previous day
 			const start = new Date("2026-04-12T00:00:00Z");
 			const end = new Date("2026-04-12T00:00:00Z");
-			expect(formatDateRange(start, end, "America/Los_Angeles")).toBe("Apr 12 – Apr 12, 2026");
+			expect(formatDateRange(start, end, "America/Los_Angeles")).toBe("Apr 12, 2026");
 		});
 
 		it("does not shift dates for midnight-UTC timestamps in multiple timezones", () => {
@@ -104,8 +104,17 @@ describe("date-utils", () => {
 
 		it("handles YYYY-MM-DD string input without time component", () => {
 			expect(formatDateRange("2026-04-12", "2026-04-12", "America/Los_Angeles")).toBe(
-				"Apr 12 – Apr 12, 2026",
+				"Apr 12, 2026",
 			);
+		});
+
+		it("collapses same-date range to a single date", () => {
+			expect(formatDateRange("2026-04-12", "2026-04-12", "UTC")).toBe("Apr 12, 2026");
+			expect(formatDateRange("2026-01-01", "2026-01-01", "America/New_York")).toBe("Jan 1, 2026");
+			// Different time components but same calendar date should still collapse
+			expect(
+				formatDateRange(new Date("2026-06-15T03:00:00Z"), new Date("2026-06-15T20:00:00Z"), "UTC"),
+			).toBe("Jun 15, 2026");
 		});
 	});
 

--- a/app/lib/date-utils.ts
+++ b/app/lib/date-utils.ts
@@ -127,10 +127,17 @@ export function formatDateRange(
 	const sYear = s.toLocaleDateString("en-US", { year: "numeric", timeZone: tz });
 	const eYear = e.toLocaleDateString("en-US", { year: "numeric", timeZone: tz });
 
+	const sFormatted = s.toLocaleDateString("en-US", opts);
+	const eFormatted = e.toLocaleDateString("en-US", opts);
+	const eFormattedWithYear = e.toLocaleDateString("en-US", yearOpts);
+
 	if (sYear === eYear) {
-		return `${s.toLocaleDateString("en-US", opts)} – ${e.toLocaleDateString("en-US", yearOpts)}`;
+		if (sFormatted === eFormatted) {
+			return eFormattedWithYear;
+		}
+		return `${sFormatted} – ${eFormattedWithYear}`;
 	}
-	return `${s.toLocaleDateString("en-US", yearOpts)} – ${e.toLocaleDateString("en-US", yearOpts)}`;
+	return `${s.toLocaleDateString("en-US", yearOpts)} – ${eFormattedWithYear}`;
 }
 
 /**


### PR DESCRIPTION
## Problem
When an availability request has the same start and end date (e.g., April 12), `formatDateRange` displays **"Apr 12 – Apr 12, 2026"** instead of just **"Apr 12, 2026"**.

## Fix
After formatting both dates, compare the formatted month+day strings. If they match (same calendar date), return a single date with year instead of the range format.

## Tests
- Added explicit `collapses same-date range to a single date` test covering UTC, Eastern timezone, and different time components on the same calendar day
- Updated two existing assertions that expected the old redundant range format
- All 65 existing date-utils tests pass

## Quality Gates
- ✅ `pnpm test` — all tests pass
- ✅ `pnpm run typecheck` — no errors
- ✅ `pnpm run lint` — clean