### PR TITLE
fix: selected cast members get Performer role when creating event from availability

### DIFF
--- a/app/routes/groups.$groupId.events.new.test.ts
+++ b/app/routes/groups.$groupId.events.new.test.ts
@@ -50,8 +50,10 @@ vi.mock("~/services/csrf.server", () => ({
 import { action } from "~/routes/groups.$groupId.events.new";
 import {
 	autoAssignFromAvailability,
+	bulkAssignToEvent,
 	getAvailabilityRequestGroupId,
 } from "~/services/events.server";
+import { getGroupWithMembers } from "~/services/groups.server";
 
 function makeRequest(fields: Record<string, string | string[]>) {
 	const formData = new FormData();
@@ -263,6 +265,91 @@ describe("events.new validation", () => {
 		});
 		expect(result).toBeInstanceOf(Response);
 		expect((result as Response).status).toBe(302);
+		expect(autoAssignFromAvailability).not.toHaveBeenCalled();
+	});
+
+	it("assigns selected performers with Performer role before auto-assign when creating show from availability", async () => {
+		// Track call order to verify performers are assigned before auto-assign
+		const callOrder: string[] = [];
+		vi.mocked(bulkAssignToEvent).mockImplementation(async () => {
+			callOrder.push("bulkAssignToEvent");
+		});
+		vi.mocked(autoAssignFromAvailability).mockImplementation(async () => {
+			callOrder.push("autoAssignFromAvailability");
+			return [];
+		});
+		vi.mocked(getAvailabilityRequestGroupId).mockResolvedValue("g1");
+
+		// Mock group with all the performers as members
+		vi.mocked(getGroupWithMembers).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" } as never,
+			members: [
+				{ id: "user-1", name: "Admin", email: "admin@test.com" },
+				{ id: "user-2", name: "Jessica", email: "jessica@test.com" },
+				{ id: "user-3", name: "Larry", email: "larry@test.com" },
+				{ id: "user-4", name: "Meagan", email: "meagan@test.com" },
+			] as never[],
+		});
+
+		const result = await action({
+			request: makeRequest({
+				...validEvent,
+				eventType: "show",
+				callTime: "18:00",
+				fromRequestId: "req-1",
+				performerIds: ["user-1", "user-2", "user-3", "user-4"],
+			}),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(302);
+
+		// Verify bulkAssignToEvent was called with all selected performers and "Performer" role
+		expect(bulkAssignToEvent).toHaveBeenCalledWith(
+			"event-1",
+			["user-1", "user-2", "user-3", "user-4"],
+			"Performer",
+		);
+
+		// Verify auto-assign was also called
+		expect(autoAssignFromAvailability).toHaveBeenCalledWith(
+			"event-1",
+			"req-1",
+			"2099-06-15",
+			"user-1",
+		);
+
+		// Critical: performer assignment must happen BEFORE auto-assign
+		// so that onConflictDoNothing in auto-assign skips already-assigned performers
+		expect(callOrder).toEqual(["bulkAssignToEvent", "autoAssignFromAvailability"]);
+	});
+
+	it("assigns selected performers with Performer role even without availability request", async () => {
+		vi.mocked(getGroupWithMembers).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" } as never,
+			members: [
+				{ id: "user-1", name: "Admin", email: "admin@test.com" },
+				{ id: "user-2", name: "Jessica", email: "jessica@test.com" },
+			] as never[],
+		});
+
+		const result = await action({
+			request: makeRequest({
+				...validEvent,
+				eventType: "show",
+				callTime: "18:00",
+				performerIds: ["user-1", "user-2"],
+			}),
+			params: { groupId: "g1" },
+			context: {},
+		});
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(302);
+
+		expect(bulkAssignToEvent).toHaveBeenCalledWith("event-1", ["user-1", "user-2"], "Performer");
 		expect(autoAssignFromAvailability).not.toHaveBeenCalled();
 	});
 });

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -141,18 +141,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		timezone,
 	});
 
-	// Auto-assign available/maybe members when creating from an availability request
-	const validFromRequestIdForAssign =
-		typeof fromRequestId === "string" && fromRequestId ? fromRequestId : null;
-	if (validFromRequestIdForAssign && typeof date === "string") {
-		// Validate the availability request belongs to this group (IDOR prevention)
-		const requestGroupId = await getAvailabilityRequestGroupId(validFromRequestIdForAssign);
-		if (requestGroupId === groupId) {
-			await autoAssignFromAvailability(event.id, validFromRequestIdForAssign, date, user.id);
-		}
-	}
-
-	// Assign performers for show events (onConflictDoNothing handles overlap with auto-assign)
+	// Assign performers for show events BEFORE auto-assign so they get the
+	// "Performer" role.  Auto-assign's onConflictDoNothing will then skip them.
 	if (eventType === "show") {
 		const validPerformerIds = performerIds.filter(
 			(id): id is string => typeof id === "string" && id.length > 0,
@@ -165,6 +155,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			if (verifiedIds.length > 0) {
 				await bulkAssignToEvent(event.id, verifiedIds, "Performer");
 			}
+		}
+	}
+
+	// Auto-assign available/maybe members when creating from an availability request
+	// (onConflictDoNothing skips members already assigned as Performers above)
+	const validFromRequestIdForAssign =
+		typeof fromRequestId === "string" && fromRequestId ? fromRequestId : null;
+	if (validFromRequestIdForAssign && typeof date === "string") {
+		// Validate the availability request belongs to this group (IDOR prevention)
+		const requestGroupId = await getAvailabilityRequestGroupId(validFromRequestIdForAssign);
+		if (requestGroupId === groupId) {
+			await autoAssignFromAvailability(event.id, validFromRequestIdForAssign, date, user.id);
 		}
 	}
 


### PR DESCRIPTION
## Problem

When creating a show event from an availability request, the admin selects cast members. After creation, only the admin appeared in **Cast** as a Performer. All other selected members ended up in **Other Roles** with a null role.

## Root Cause

In the `events.new` action, `autoAssignFromAvailability()` ran **before** `bulkAssignToEvent()`. Auto-assign inserted members with `role=null`, then the explicit performer assignment's `onConflictDoNothing()` silently skipped them — leaving selected performers with a null role.

The event creator was unaffected because `autoAssignFromAvailability` excludes `excludeUserId` (the creator), so their Performer insert was never conflicted.

## Fix

Swap the execution order: assign performers with `role='Performer'` **first**, then run auto-assign. The auto-assign's `onConflictDoNothing()` now correctly skips already-assigned performers.

## Tests

Added 2 regression tests:
1. **With availability request**: Verifies all selected performers get `Performer` role AND that performer assignment runs before auto-assign (call order assertion)
2. **Without availability request**: Verifies performers get `Performer` role in the standalone show creation flow

All 631 tests pass. Typecheck, lint, and build are green.