### PR TITLE
feat: Inline role selector on event detail page

### DIFF
--- a/app/components/role-selector.tsx
+++ b/app/components/role-selector.tsx
@@ -32,7 +32,11 @@ export function RoleSelector({
 	const roleInputRef = useRef<HTMLInputElement>(null);
 
 	const pendingRole = fetcher.formData?.get("newRole") as string | undefined;
-	const displayRole = pendingRole ?? currentRole;
+	const fetcherError =
+		fetcher.data && typeof fetcher.data === "object" && "error" in fetcher.data
+			? (fetcher.data as { error: string }).error
+			: null;
+	const displayRole = fetcherError ? currentRole : (pendingRole ?? currentRole);
 	const isUpdating = fetcher.state !== "idle";
 
 	// Click outside to close
@@ -62,6 +66,7 @@ export function RoleSelector({
 			setShowCustomInput(false);
 			return;
 		}
+		if (trimmed.length > 100) return;
 		if (roleInputRef.current && formRef.current) {
 			roleInputRef.current.value = trimmed;
 			fetcher.submit(formRef.current);
@@ -105,6 +110,9 @@ export function RoleSelector({
 				{displayRole ?? "Set role"}
 				<ChevronDown className="h-3 w-3" />
 			</button>
+
+			{/* Server error feedback */}
+			{fetcherError && <p className="mt-1 text-xs text-red-600">{fetcherError}</p>}
 
 			{/* Dropdown */}
 			{isOpen && (

--- a/app/components/role-selector.tsx
+++ b/app/components/role-selector.tsx
@@ -1,0 +1,188 @@
+import { useFetcher } from "@remix-run/react";
+import { ChevronDown, Pencil } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { CsrfInput } from "~/components/csrf-input";
+
+interface RoleSelectorProps {
+	userId: string;
+	currentRole: string | null;
+	isShow: boolean;
+	notifyOnRoleChange: boolean;
+}
+
+const ROLE_BADGE_STYLES: Record<string, string> = {
+	Performer: "border-purple-300 bg-purple-50 text-purple-700 hover:bg-purple-100",
+	Viewer: "border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100",
+};
+
+const DEFAULT_BADGE_STYLE = "border-slate-300 bg-slate-50 text-slate-700 hover:bg-slate-100";
+
+export function RoleSelector({
+	userId,
+	currentRole,
+	isShow,
+	notifyOnRoleChange,
+}: RoleSelectorProps) {
+	const fetcher = useFetcher();
+	const [isOpen, setIsOpen] = useState(false);
+	const [showCustomInput, setShowCustomInput] = useState(false);
+	const dropdownRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const formRef = useRef<HTMLFormElement>(null);
+	const roleInputRef = useRef<HTMLInputElement>(null);
+
+	const pendingRole = fetcher.formData?.get("newRole") as string | undefined;
+	const displayRole = pendingRole ?? currentRole;
+	const isUpdating = fetcher.state !== "idle";
+
+	// Click outside to close
+	useEffect(() => {
+		if (!isOpen) return;
+		const handler = (e: MouseEvent) => {
+			if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+				setIsOpen(false);
+				setShowCustomInput(false);
+			}
+		};
+		document.addEventListener("mousedown", handler);
+		return () => document.removeEventListener("mousedown", handler);
+	}, [isOpen]);
+
+	// Auto-focus custom input when shown
+	useEffect(() => {
+		if (showCustomInput) {
+			inputRef.current?.focus();
+		}
+	}, [showCustomInput]);
+
+	const submitRole = (role: string) => {
+		const trimmed = role.trim();
+		if (!trimmed || trimmed === currentRole) {
+			setIsOpen(false);
+			setShowCustomInput(false);
+			return;
+		}
+		if (roleInputRef.current && formRef.current) {
+			roleInputRef.current.value = trimmed;
+			fetcher.submit(formRef.current);
+		}
+		setIsOpen(false);
+		setShowCustomInput(false);
+	};
+
+	const handleBadgeClick = () => {
+		if (isUpdating) return;
+		if (!isShow) {
+			// Non-show events: open custom input directly
+			setShowCustomInput(true);
+			setIsOpen(true);
+		} else {
+			setIsOpen(!isOpen);
+			setShowCustomInput(false);
+		}
+	};
+
+	const badgeStyle = ROLE_BADGE_STYLES[displayRole ?? ""] ?? DEFAULT_BADGE_STYLE;
+
+	return (
+		<div ref={dropdownRef} className="relative">
+			{/* Hidden form for CSRF-safe submission */}
+			<fetcher.Form method="post" ref={formRef} className="hidden">
+				<CsrfInput />
+				<input type="hidden" name="intent" value="change-role" />
+				<input type="hidden" name="userId" value={userId} />
+				<input type="hidden" name="newRole" ref={roleInputRef} value="" />
+				{notifyOnRoleChange && <input type="hidden" name="sendNotification" value="on" />}
+			</fetcher.Form>
+
+			{/* Role badge button */}
+			<button
+				type="button"
+				onClick={handleBadgeClick}
+				disabled={isUpdating}
+				className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-50 ${badgeStyle}`}
+			>
+				{displayRole ?? "Set role"}
+				<ChevronDown className="h-3 w-3" />
+			</button>
+
+			{/* Dropdown */}
+			{isOpen && (
+				<div className="absolute right-0 z-20 mt-1 w-48 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg">
+					{isShow && !showCustomInput && (
+						<>
+							<button
+								type="button"
+								onClick={() => submitRole("Performer")}
+								className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-purple-50 ${
+									displayRole === "Performer" ? "font-medium text-purple-700" : "text-slate-700"
+								}`}
+							>
+								🎭 Performer
+								{displayRole === "Performer" && <span className="ml-auto text-purple-500">✓</span>}
+							</button>
+							<button
+								type="button"
+								onClick={() => submitRole("Viewer")}
+								className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-amber-50 ${
+									displayRole === "Viewer" ? "font-medium text-amber-700" : "text-slate-700"
+								}`}
+							>
+								👀 Viewer
+								{displayRole === "Viewer" && <span className="ml-auto text-amber-500">✓</span>}
+							</button>
+							<div className="border-t border-slate-100" />
+							<button
+								type="button"
+								onClick={() => setShowCustomInput(true)}
+								className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-600 transition-colors hover:bg-slate-50"
+							>
+								<Pencil className="h-3.5 w-3.5" /> Custom role…
+							</button>
+						</>
+					)}
+					{showCustomInput && (
+						<div className="p-2">
+							<input
+								ref={inputRef}
+								type="text"
+								placeholder="Type role name…"
+								maxLength={100}
+								defaultValue={
+									displayRole && displayRole !== "Performer" && displayRole !== "Viewer"
+										? displayRole
+										: ""
+								}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										submitRole(e.currentTarget.value);
+									}
+									if (e.key === "Escape") {
+										setIsOpen(false);
+										setShowCustomInput(false);
+									}
+								}}
+								className="w-full rounded-md border border-slate-300 px-2.5 py-1.5 text-sm text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+							/>
+							<p className="mt-1 text-xs text-slate-400">Press Enter to save, Esc to cancel</p>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+/** Read-only role badge for non-admin users */
+export function RoleBadge({ role }: { role: string | null }) {
+	if (!role) return null;
+	const style = ROLE_BADGE_STYLES[role] ?? DEFAULT_BADGE_STYLE;
+	return (
+		<span
+			className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${style}`}
+		>
+			{role}
+		</span>
+	);
+}

--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -689,7 +689,7 @@ describe("event detail action — change role", () => {
 		expect(updateAssignmentRole).not.toHaveBeenCalled();
 	});
 
-	it("returns error for invalid role", async () => {
+	it("accepts custom role names", async () => {
 		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
 			event: mockShowEvent,
 			assignments: [
@@ -698,12 +698,174 @@ describe("event detail action — change role", () => {
 		});
 
 		const result = await action({
-			request: makeChangeRoleRequest({ userId: "user-2", newRole: "InvalidRole" }),
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: "Stage Manager" }),
 			params: { groupId: "g1", eventId: "event-1" },
 			context: {},
 		});
 
-		expect(result).toEqual({ error: "Invalid role." });
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", "Stage Manager");
+	});
+
+	it("trims whitespace from role names", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: "  Director  " }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", "Director");
+	});
+
+	it("rejects empty role", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: "" }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Role cannot be empty." });
 		expect(updateAssignmentRole).not.toHaveBeenCalled();
+	});
+
+	it("rejects whitespace-only role", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: "   " }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Role cannot be empty." });
+		expect(updateAssignmentRole).not.toHaveBeenCalled();
+	});
+
+	it("rejects role exceeding 100 characters", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const longRole = "A".repeat(101);
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: longRole }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Role must be 100 characters or less." });
+		expect(updateAssignmentRole).not.toHaveBeenCalled();
+	});
+
+	it("accepts role at exactly 100 characters", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const maxRole = "A".repeat(100);
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: maxRole }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", maxRole);
+	});
+
+	it("changes role on non-show event", async () => {
+		const mockRehearsalEvent = {
+			id: "event-1",
+			groupId: "g1",
+			title: "Monday Rehearsal",
+			eventType: "rehearsal",
+			startTime: "2026-03-15T19:00:00.000Z",
+			endTime: "2026-03-15T21:00:00.000Z",
+		};
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockRehearsalEvent,
+			assignments: [{ userId: "user-2", userName: "Some User", role: null, status: "confirmed" }],
+		});
+
+		const result = await action({
+			request: makeChangeRoleRequest({ userId: "user-2", newRole: "Director" }),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", "Director");
+	});
+
+	it("sends notification with custom role name", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "Some User", role: "Performer", status: "confirmed" },
+			],
+		});
+		(getGroupMembersWithPreferences as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{
+				id: "user-2",
+				name: "Some User",
+				email: "user@example.com",
+				timezone: "UTC",
+				notificationPreferences: {},
+			},
+		]);
+		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" },
+			members: [],
+		});
+
+		const result = await action({
+			request: makeChangeRoleRequest({
+				userId: "user-2",
+				newRole: "Stage Manager",
+				sendNotification: "on",
+			}),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", "Stage Manager");
+
+		await vi.waitFor(() => {
+			expect(sendRoleChangeNotification).toHaveBeenCalledWith(
+				expect.objectContaining({
+					newRole: "Stage Manager",
+					recipient: expect.objectContaining({
+						email: "user@example.com",
+					}),
+				}),
+			);
+		});
 	});
 });

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -11,7 +11,6 @@ import {
 } from "@remix-run/react";
 import {
 	ArrowLeft,
-	ArrowUpDown,
 	Calendar,
 	CalendarDays,
 	Check,
@@ -30,6 +29,7 @@ import { ActivityFeed } from "~/components/activity-feed";
 import { CsrfInput } from "~/components/csrf-input";
 import { DangerZone } from "~/components/danger-zone";
 import { EventDateCarousel } from "~/components/event-date-carousel";
+import { RoleBadge, RoleSelector } from "~/components/role-selector";
 import { UserChipSelector } from "~/components/user-chip-selector";
 import { formatDateLong, formatEventTime, formatTime, utcToLocalParts } from "~/lib/date-utils";
 import { validateCsrfToken } from "~/services/csrf.server";
@@ -251,15 +251,19 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		if (typeof targetUserId !== "string" || typeof newRole !== "string") {
 			return { error: "Invalid parameters." };
 		}
-		if (newRole !== "Performer" && newRole !== "Viewer") {
-			return { error: "Invalid role." };
+		const trimmedRole = newRole.trim();
+		if (!trimmedRole) {
+			return { error: "Role cannot be empty." };
+		}
+		if (trimmedRole.length > 100) {
+			return { error: "Role must be 100 characters or less." };
 		}
 		// Verify the target user is actually assigned to this event
 		const existingAssignment = eventData.assignments.find((a) => a.userId === targetUserId);
 		if (!existingAssignment) {
 			return { error: "User is not assigned to this event." };
 		}
-		await updateAssignmentRole(eventId, targetUserId, newRole);
+		await updateAssignmentRole(eventId, targetUserId, trimmedRole);
 
 		if (sendNotification) {
 			void (async () => {
@@ -283,7 +287,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 					eventType: event.eventType,
 					dateTime,
 					groupName,
-					newRole: newRole as "Performer" | "Viewer",
+					newRole: trimmedRole,
 					recipient: {
 						email: member.email,
 						name: member.name,
@@ -531,9 +535,18 @@ export default function EventDetail() {
 										const statusCfg = STATUS_CONFIG[a.status] ?? STATUS_CONFIG.pending;
 										return (
 											<li key={a.userId} className="flex items-center justify-between px-6 py-3">
-												<div>
+												<div className="flex items-center gap-2">
 													<span className="text-sm font-medium text-slate-900">{a.userName}</span>
-													<span className="ml-2 text-xs text-purple-500">Performer</span>
+													{isAdmin ? (
+														<RoleSelector
+															userId={a.userId}
+															currentRole={a.role}
+															isShow={isShow}
+															notifyOnRoleChange={notifyOnRoleChange}
+														/>
+													) : (
+														<RoleBadge role={a.role} />
+													)}
 												</div>
 												<div className="flex items-center gap-2">
 													<span
@@ -541,25 +554,6 @@ export default function EventDetail() {
 													>
 														{statusCfg.label}
 													</span>
-													{isAdmin && (
-														<Form method="post" className="flex items-center">
-															<CsrfInput />
-															<input type="hidden" name="intent" value="change-role" />
-															<input type="hidden" name="userId" value={a.userId} />
-															<input type="hidden" name="newRole" value="Viewer" />
-															{notifyOnRoleChange && (
-																<input type="hidden" name="sendNotification" value="on" />
-															)}
-															<button
-																type="submit"
-																disabled={isSubmitting}
-																className="text-slate-400 transition-colors hover:text-amber-500 disabled:opacity-50"
-																title="Move to watching"
-															>
-																<ArrowUpDown className="h-4 w-4" />
-															</button>
-														</Form>
-													)}
 													{isAdmin && (
 														<Form method="post">
 															<CsrfInput />
@@ -680,8 +674,8 @@ export default function EventDetail() {
 						</div>
 					)}
 
-					{/* Notify on role change toggle (admin only, shows only) */}
-					{isShow && isAdmin && (performers.length > 0 || viewers.length > 0) && (
+					{/* Notify on role change toggle (admin only) */}
+					{isAdmin && assignments.length > 0 && (
 						<label className="flex items-center gap-2 text-xs text-slate-500">
 							<input
 								type="checkbox"
@@ -714,32 +708,27 @@ export default function EventDetail() {
 														key={a.userId}
 														className="flex items-center justify-between px-6 py-3"
 													>
-														<span className="text-sm font-medium text-slate-900">{a.userName}</span>
+														<div className="flex items-center gap-2">
+															<span className="text-sm font-medium text-slate-900">
+																{a.userName}
+															</span>
+															{isAdmin ? (
+																<RoleSelector
+																	userId={a.userId}
+																	currentRole={a.role}
+																	isShow={isShow}
+																	notifyOnRoleChange={notifyOnRoleChange}
+																/>
+															) : (
+																<RoleBadge role={a.role} />
+															)}
+														</div>
 														<div className="flex items-center gap-2">
 															<span
 																className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusCfg.badgeClass}`}
 															>
 																{statusCfg.label}
 															</span>
-															{isAdmin && (
-																<Form method="post" className="flex items-center">
-																	<CsrfInput />
-																	<input type="hidden" name="intent" value="change-role" />
-																	<input type="hidden" name="userId" value={a.userId} />
-																	<input type="hidden" name="newRole" value="Performer" />
-																	{notifyOnRoleChange && (
-																		<input type="hidden" name="sendNotification" value="on" />
-																	)}
-																	<button
-																		type="submit"
-																		disabled={isSubmitting}
-																		className="text-slate-400 transition-colors hover:text-purple-500 disabled:opacity-50"
-																		title="Move to cast"
-																	>
-																		<ArrowUpDown className="h-4 w-4" />
-																	</button>
-																</Form>
-															)}
 															{isAdmin && (
 																<Form method="post">
 																	<CsrfInput />
@@ -831,9 +820,18 @@ export default function EventDetail() {
 										const statusCfg = STATUS_CONFIG[a.status] ?? STATUS_CONFIG.pending;
 										return (
 											<li key={a.userId} className="flex items-center justify-between px-6 py-3">
-												<div>
+												<div className="flex items-center gap-2">
 													<span className="text-sm font-medium text-slate-900">{a.userName}</span>
-													{a.role && <span className="ml-2 text-xs text-slate-500">{a.role}</span>}
+													{isAdmin ? (
+														<RoleSelector
+															userId={a.userId}
+															currentRole={a.role}
+															isShow={isShow}
+															notifyOnRoleChange={notifyOnRoleChange}
+														/>
+													) : (
+														<RoleBadge role={a.role} />
+													)}
 												</div>
 												<div className="flex items-center gap-2">
 													<span
@@ -992,9 +990,18 @@ export default function EventDetail() {
 									const statusCfg = STATUS_CONFIG[a.status] ?? STATUS_CONFIG.pending;
 									return (
 										<li key={a.userId} className="flex items-center justify-between px-6 py-3">
-											<div>
+											<div className="flex items-center gap-2">
 												<span className="text-sm font-medium text-slate-900">{a.userName}</span>
-												{a.role && <span className="ml-2 text-xs text-slate-500">{a.role}</span>}
+												{isAdmin ? (
+													<RoleSelector
+														userId={a.userId}
+														currentRole={a.role}
+														isShow={isShow}
+														notifyOnRoleChange={notifyOnRoleChange}
+													/>
+												) : (
+													<RoleBadge role={a.role} />
+												)}
 											</div>
 											<div className="flex items-center gap-2">
 												<span

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -363,7 +363,7 @@ export async function sendRoleChangeNotification(options: {
 	eventType: string;
 	dateTime: string;
 	groupName: string;
-	newRole: "Performer" | "Viewer";
+	newRole: string;
 	recipient: { email: string; name: string; notificationPreferences?: NotificationPreferences };
 	eventUrl: string;
 	preferencesUrl?: string;
@@ -375,15 +375,22 @@ export async function sendRoleChangeNotification(options: {
 		options.eventType === "show" ? "🎭" : options.eventType === "rehearsal" ? "🎯" : "📅";
 
 	const isPromotedToCast = options.newRole === "Performer";
+	const isMovedToWatching = options.newRole === "Viewer";
 	const heading = isPromotedToCast
 		? "You've Been Added to the Cast"
-		: "You've Been Moved to Watching";
+		: isMovedToWatching
+			? "You've Been Moved to Watching"
+			: `Your Role Has Been Changed to ${escapeHtml(options.newRole)}`;
 	const message = isPromotedToCast
 		? `you've been added to the cast for an upcoming event.`
-		: `you've been moved to watching for an upcoming event.`;
+		: isMovedToWatching
+			? `you've been moved to watching for an upcoming event.`
+			: `your role has been changed to <strong>${escapeHtml(options.newRole)}</strong> for an upcoming event.`;
 	const subject = isPromotedToCast
 		? `${typeEmoji} You're in the cast for "${escapeHtml(options.eventTitle)}"`
-		: `${typeEmoji} You've been moved to watching for "${escapeHtml(options.eventTitle)}"`;
+		: isMovedToWatching
+			? `${typeEmoji} You've been moved to watching for "${escapeHtml(options.eventTitle)}"`
+			: `${typeEmoji} Your role changed for "${escapeHtml(options.eventTitle)}"`;
 
 	const html = emailLayout(
 		`
@@ -399,7 +406,9 @@ ${ctaButton(options.eventUrl, "View Event Details")}`,
 
 	const textMessage = isPromotedToCast
 		? `you've been added to the cast`
-		: `you've been moved to watching`;
+		: isMovedToWatching
+			? `you've been moved to watching`
+			: `your role has been changed to ${options.newRole}`;
 	const text = `Hi ${options.recipient.name},\n\n${textMessage} for an event.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${options.dateTime}\n\nView event: ${options.eventUrl}`;
 
 	void sendEmail({


### PR DESCRIPTION
## Summary

Replaces the limited Performer↔Viewer toggle buttons on the event detail page with a proper inline role selector that supports custom roles.

### Problem
- Shows: Only a simple toggle between Performer and Viewer (ArrowUpDown button)
- "Other Roles" section had **no role editing** at all
- Non-show events displayed roles as text labels but couldn't edit them
- Server action rejected any role that wasn't "Performer" or "Viewer"

### Solution
**Option A from George's direction**: Inline role selector per person — a tappable role badge that opens a dropdown to change the role.

### What Changed

| File | Why |
|------|-----|
| `app/components/role-selector.tsx` (NEW) | Reusable inline role selector with dropdown (Performer/Viewer/Custom for shows, direct text input for non-shows). Uses `useFetcher` for smooth inline updates with optimistic UI. Includes read-only `RoleBadge` for non-admins. |
| `app/routes/groups.$groupId.events.$eventId.tsx` | **Action**: Removed Performer/Viewer-only restriction. Now accepts any trimmed, non-empty string ≤100 chars. **UI**: Replaced ArrowUpDown forms in Cast, Attending, Other Roles, and non-show Cast sections with `RoleSelector`. Extended notification toggle to non-show events. |
| `app/services/email.server.ts` | Widened `newRole` type from `"Performer" \| "Viewer"` to `string`. Email template now handles 3 cases: Performer (cast), Viewer (watching), custom ("Your role has been changed to {role}"). |
| `app/routes/groups.$groupId.events.$eventId.test.ts` | Replaced "invalid role" test (custom roles are now valid). Added 8 new tests: custom role success, whitespace trimming, empty/whitespace-only/too-long rejection, non-show events, notifications with custom roles. |

### UX Details
- **Shows**: Badge click opens dropdown with 🎭 Performer, 👀 Viewer, ✏️ Custom role… options
- **Non-shows**: Badge click opens text input directly (no presets)
- **Optimistic UI**: Role badge updates immediately while submission is in flight
- **Click-outside**: Closes dropdown naturally
- **Non-admins**: See a read-only role badge (no dropdown)

### Quality Gates
- ✅ TypeScript: 0 errors
- ✅ Biome lint: Clean
- ✅ Build: Production build succeeds
- ✅ Tests: 638/638 pass (53 files)