### PR TITLE
feat: Add per-day notes to availability responses

### DIFF
--- a/app/components/availability-grid.fixture.tsx
+++ b/app/components/availability-grid.fixture.tsx
@@ -104,4 +104,80 @@ export default defineFixtureGroup({
 			return { dispose: () => root.unmount() };
 		},
 	}),
+	"With Notes": defineFixture({
+		description: "Grid with notes on some days — note inputs auto-expanded",
+		render: (container) => {
+			const responses: Record<string, AvailabilityStatus> = {
+				"2026-03-23": "available",
+				"2026-03-24": "maybe",
+				"2026-03-25": "not_available",
+				"2026-03-26": "available",
+			};
+			const notes: Record<string, string> = {
+				"2026-03-23": "Can arrive a bit late, around 7:15",
+				"2026-03-25": "Out of town for a wedding",
+			};
+			const root = createRoot(container);
+			root.render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={responses}
+					onChange={(r) => console.log("Responses changed:", r)}
+					notes={notes}
+					onNotesChange={(n) => console.log("Notes changed:", n)}
+					timezone="America/New_York"
+				/>,
+			);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"No Notes": defineFixture({
+		description: "Grid with note buttons visible but no notes entered",
+		render: (container) => {
+			const responses: Record<string, AvailabilityStatus> = {
+				"2026-03-23": "available",
+				"2026-03-25": "maybe",
+			};
+			const root = createRoot(container);
+			root.render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={responses}
+					onChange={(r) => console.log("Responses changed:", r)}
+					notes={{}}
+					onNotesChange={(n) => console.log("Notes changed:", n)}
+					timezone="America/New_York"
+				/>,
+			);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"Long Notes": defineFixture({
+		description: "Grid with notes at or near the 200-character limit",
+		render: (container) => {
+			const responses: Record<string, AvailabilityStatus> = {
+				"2026-03-23": "available",
+				"2026-03-24": "maybe",
+				"2026-03-25": "available",
+			};
+			const notes: Record<string, string> = {
+				"2026-03-23":
+					"I can make it but I'll need to leave by 8:30pm because I have another commitment across town and traffic can be really unpredictable at that hour so I want to make sure I leave enough time to get there",
+				"2026-03-24":
+					"Not 100% sure yet — waiting to hear back from my day job about whether I need to cover someone's shift. Should know by Wednesday at the latest. Will update as soon as I find out!",
+			};
+			const root = createRoot(container);
+			root.render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={responses}
+					onChange={(r) => console.log("Responses changed:", r)}
+					notes={notes}
+					onNotesChange={(n) => console.log("Notes changed:", n)}
+					timezone="America/New_York"
+				/>,
+			);
+			return { dispose: () => root.unmount() };
+		},
+	}),
 });

--- a/app/components/availability-grid.test.tsx
+++ b/app/components/availability-grid.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AvailabilityGrid } from "~/components/availability-grid";
+
+vi.mock("~/lib/date-utils", () => ({
+	formatDateDisplay: vi.fn((date: string) => ({
+		dayOfWeek: "Sat",
+		display: date,
+	})),
+}));
+
+const sampleDates = ["2025-03-15", "2025-03-16", "2025-03-17"];
+
+function getDesktopTable(container: HTMLElement) {
+	const el = container.querySelector(".hidden.sm\\:block") as HTMLElement;
+	if (!el) throw new Error("Desktop table wrapper not found");
+	return { ...within(el), el };
+}
+
+function getMobileCards(container: HTMLElement) {
+	const el = container.querySelector(".sm\\:hidden") as HTMLElement;
+	if (!el) throw new Error("Mobile cards wrapper not found");
+	return { ...within(el), el };
+}
+
+describe("AvailabilityGrid notes", () => {
+	describe("desktop table", () => {
+		it("shows add note button when onNotesChange is provided", () => {
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{}}
+					onNotesChange={vi.fn()}
+				/>,
+			);
+			const desktop = getDesktopTable(container);
+			const noteButtons = desktop.el.querySelectorAll('button[title="Add note"]');
+			expect(noteButtons.length).toBe(3);
+		});
+
+		it("does not show add note button when onNotesChange is not provided", () => {
+			const { container } = render(
+				<AvailabilityGrid dates={sampleDates} responses={{}} onChange={vi.fn()} />,
+			);
+			const desktop = getDesktopTable(container);
+			const noteButtons = desktop.el.querySelectorAll('button[title="Add note"]');
+			expect(noteButtons.length).toBe(0);
+		});
+
+		it("expands note input when add note button is clicked", async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{}}
+					onNotesChange={vi.fn()}
+				/>,
+			);
+			const desktop = getDesktopTable(container);
+			const noteButtons = desktop.el.querySelectorAll('button[title="Add note"]');
+			await user.click(noteButtons[0]);
+
+			const input = desktop.el.querySelector('input[placeholder="Add a note..."]');
+			expect(input).not.toBeNull();
+		});
+
+		it("calls onNotesChange when a note is typed", async () => {
+			const user = userEvent.setup();
+			const onNotesChange = vi.fn();
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{}}
+					onNotesChange={onNotesChange}
+				/>,
+			);
+			const desktop = getDesktopTable(container);
+			const noteButtons = desktop.el.querySelectorAll('button[title="Add note"]');
+			await user.click(noteButtons[0]);
+
+			const input = desktop.el.querySelector(
+				'input[placeholder="Add a note..."]',
+			) as HTMLInputElement;
+			await user.type(input, "L");
+
+			expect(onNotesChange).toHaveBeenCalledWith({ "2025-03-15": "L" });
+		});
+
+		it("auto-expands dates that already have notes", () => {
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{ "2025-03-15": "Existing note" }}
+					onNotesChange={vi.fn()}
+				/>,
+			);
+			const desktop = getDesktopTable(container);
+			const input = desktop.el.querySelector(
+				'input[placeholder="Add a note..."]',
+			) as HTMLInputElement;
+			expect(input).not.toBeNull();
+			expect(input.value).toBe("Existing note");
+		});
+
+		it("does not show note UI when disabled", () => {
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{ "2025-03-15": "Read-only note" }}
+					onNotesChange={vi.fn()}
+					disabled
+				/>,
+			);
+			const desktop = getDesktopTable(container);
+			// Should not show the input when disabled
+			const input = desktop.el.querySelector('input[placeholder="Add a note..."]');
+			expect(input).toBeNull();
+			// But should show the note text
+			expect(desktop.getByText("Read-only note")).toBeDefined();
+		});
+	});
+
+	describe("mobile cards", () => {
+		it("shows add note button on mobile", () => {
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{}}
+					onNotesChange={vi.fn()}
+				/>,
+			);
+			const mobile = getMobileCards(container);
+			const noteButtons = mobile.el.querySelectorAll("button");
+			const addNoteButtons = Array.from(noteButtons).filter((b) =>
+				b.textContent?.includes("Add note"),
+			);
+			expect(addNoteButtons.length).toBe(3);
+		});
+
+		it("expands note input when add note is clicked on mobile", async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<AvailabilityGrid
+					dates={sampleDates}
+					responses={{}}
+					onChange={vi.fn()}
+					notes={{}}
+					onNotesChange={vi.fn()}
+				/>,
+			);
+			const mobile = getMobileCards(container);
+			const noteButtons = Array.from(mobile.el.querySelectorAll("button")).filter((b) =>
+				b.textContent?.includes("Add note"),
+			);
+			await user.click(noteButtons[0]);
+
+			const input = mobile.el.querySelector('input[placeholder="Add a note..."]');
+			expect(input).not.toBeNull();
+		});
+	});
+});

--- a/app/components/availability-grid.tsx
+++ b/app/components/availability-grid.tsx
@@ -1,5 +1,5 @@
-import { Check, HelpCircle, X } from "lucide-react";
-import { useCallback } from "react";
+import { Check, HelpCircle, MessageSquarePlus, X } from "lucide-react";
+import { useCallback, useState } from "react";
 import { formatDateDisplay } from "~/lib/date-utils";
 
 type AvailabilityStatus = "available" | "maybe" | "not_available";
@@ -8,6 +8,8 @@ interface AvailabilityGridProps {
 	dates: string[];
 	responses: Record<string, AvailabilityStatus>;
 	onChange: (responses: Record<string, AvailabilityStatus>) => void;
+	notes?: Record<string, string>;
+	onNotesChange?: (notes: Record<string, string>) => void;
 	disabled?: boolean;
 	timeRange?: string | null;
 	timezone?: string | null;
@@ -38,10 +40,17 @@ export function AvailabilityGrid({
 	dates,
 	responses,
 	onChange,
+	notes = {},
+	onNotesChange,
 	disabled,
 	timeRange,
 	timezone,
 }: AvailabilityGridProps) {
+	const [expandedNotes, setExpandedNotes] = useState<Set<string>>(() => {
+		// Auto-expand dates that already have notes
+		return new Set(Object.keys(notes).filter((k) => notes[k]));
+	});
+
 	const setStatus = useCallback(
 		(date: string, status: AvailabilityStatus) => {
 			onChange({ ...responses, [date]: status });
@@ -63,6 +72,30 @@ export function AvailabilityGrid({
 	const clearAll = useCallback(() => {
 		onChange({});
 	}, [onChange]);
+
+	const toggleNoteExpanded = useCallback((date: string) => {
+		setExpandedNotes((prev) => {
+			const next = new Set(prev);
+			if (next.has(date)) {
+				next.delete(date);
+			} else {
+				next.add(date);
+			}
+			return next;
+		});
+	}, []);
+
+	const updateNote = useCallback(
+		(date: string, value: string) => {
+			if (!onNotesChange) return;
+			const updated = { ...notes, [date]: value };
+			if (!value) {
+				delete updated[date];
+			}
+			onNotesChange(updated);
+		},
+		[notes, onNotesChange],
+	);
 
 	return (
 		<div className="space-y-4">
@@ -140,7 +173,37 @@ export function AvailabilityGrid({
 														</button>
 													);
 												})}
+												{!disabled && onNotesChange && (
+													<button
+														type="button"
+														onClick={() => toggleNoteExpanded(date)}
+														className={`ml-1 inline-flex items-center rounded-lg p-1.5 text-xs transition-colors ${
+															expandedNotes.has(date) || notes[date]
+																? "text-emerald-600 hover:bg-emerald-50"
+																: "text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+														}`}
+														title={expandedNotes.has(date) ? "Hide note" : "Add note"}
+													>
+														<MessageSquarePlus className="h-3.5 w-3.5" />
+													</button>
+												)}
 											</div>
+											{(expandedNotes.has(date) || notes[date]) && !disabled && onNotesChange && (
+												<div className="mt-1.5">
+													<input
+														type="text"
+														value={notes[date] ?? ""}
+														onChange={(e) => updateNote(date, e.target.value)}
+														maxLength={200}
+														placeholder="Add a note..."
+														aria-label={`Note for ${display}`}
+														className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs text-slate-700 placeholder:text-slate-400 focus:border-emerald-300 focus:outline-none focus:ring-1 focus:ring-emerald-300"
+													/>
+												</div>
+											)}
+											{notes[date] && disabled && (
+												<p className="mt-1 text-xs text-slate-500 italic">{notes[date]}</p>
+											)}
 										</td>
 									</tr>
 								);
@@ -184,6 +247,36 @@ export function AvailabilityGrid({
 									);
 								})}
 							</div>
+							{!disabled && onNotesChange && (
+								<div className="mt-2">
+									<button
+										type="button"
+										onClick={() => toggleNoteExpanded(date)}
+										className={`inline-flex items-center gap-1 text-xs transition-colors ${
+											expandedNotes.has(date) || notes[date]
+												? "text-emerald-600"
+												: "text-slate-400 hover:text-slate-600"
+										}`}
+									>
+										<MessageSquarePlus className="h-3.5 w-3.5" />
+										{notes[date] ? "Edit note" : "Add note"}
+									</button>
+									{(expandedNotes.has(date) || notes[date]) && (
+										<input
+											type="text"
+											value={notes[date] ?? ""}
+											onChange={(e) => updateNote(date, e.target.value)}
+											maxLength={200}
+											placeholder="Add a note..."
+											aria-label={`Note for ${display}`}
+											className="mt-1.5 w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs text-slate-700 placeholder:text-slate-400 focus:border-emerald-300 focus:outline-none focus:ring-1 focus:ring-emerald-300"
+										/>
+									)}
+								</div>
+							)}
+							{notes[date] && disabled && (
+								<p className="mt-2 text-xs text-slate-500 italic">{notes[date]}</p>
+							)}
 						</div>
 					);
 				})}

--- a/app/components/results-heatmap.fixture.tsx
+++ b/app/components/results-heatmap.fixture.tsx
@@ -11,7 +11,7 @@ interface DateResult {
 	noResponse: number;
 	total: number;
 	score: number;
-	respondents: Array<{ name: string; status: string }>;
+	respondents: Array<{ name: string; status: string; note?: string }>;
 }
 
 function makeDateResult(
@@ -20,7 +20,7 @@ function makeDateResult(
 	maybe: number,
 	notAvailable: number,
 	total: number,
-	respondents: Array<{ name: string; status: string }>,
+	respondents: Array<{ name: string; status: string; note?: string }>,
 ): DateResult {
 	return {
 		date,
@@ -357,6 +357,54 @@ export default defineFixtureGroup({
 						groupId="fixture-group-1"
 						requestId="fixture-request-5"
 						timeRange="7:00 PM - 9:00 PM"
+						timezone="America/New_York"
+					/>
+				</div>,
+			);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"With Respondent Notes": defineFixture({
+		description: "Respondents with per-day notes shown inline",
+		render: (container) => {
+			const datesWithNotes: DateResult[] = [
+				makeDateResult("2026-03-23", 5, 1, 1, 8, [
+					{ name: "Alex", status: "available", note: "Can arrive by 6:45" },
+					{ name: "Jordan", status: "available", note: "Bringing a friend to watch" },
+					{ name: "Casey", status: "available" },
+					{ name: "Morgan", status: "not_available", note: "Out of town for a wedding" },
+					{ name: "Riley", status: "available" },
+					{ name: "Taylor", status: "available" },
+					{ name: "Sam", status: "maybe", note: "Depends on work schedule" },
+				]),
+				makeDateResult("2026-03-24", 3, 2, 2, 8, [
+					{ name: "Alex", status: "available" },
+					{ name: "Jordan", status: "maybe", note: "Might have a conflict with another show" },
+					{ name: "Casey", status: "not_available" },
+					{ name: "Morgan", status: "not_available" },
+					{ name: "Riley", status: "available" },
+					{ name: "Taylor", status: "available" },
+					{ name: "Sam", status: "maybe" },
+				]),
+				makeDateResult("2026-03-25", 6, 0, 1, 8, [
+					{ name: "Alex", status: "available", note: "This is my preferred date!" },
+					{ name: "Jordan", status: "available" },
+					{ name: "Casey", status: "available" },
+					{ name: "Morgan", status: "not_available" },
+					{ name: "Riley", status: "available" },
+					{ name: "Taylor", status: "available" },
+					{ name: "Sam", status: "available" },
+				]),
+			];
+			const root = createRoot(container);
+			root.render(
+				<div className="max-w-4xl p-4">
+					<ResultsHeatmap
+						dates={datesWithNotes}
+						totalMembers={8}
+						totalResponded={7}
+						groupId="fixture-group-1"
+						requestId="fixture-request-notes"
 						timezone="America/New_York"
 					/>
 				</div>,

--- a/app/components/results-heatmap.test.tsx
+++ b/app/components/results-heatmap.test.tsx
@@ -19,7 +19,7 @@ interface DateResult {
 	noResponse: number;
 	total: number;
 	score: number;
-	respondents: Array<{ name: string; status: string }>;
+	respondents: Array<{ name: string; status: string; note?: string }>;
 }
 
 function makeDateResult(overrides: Partial<DateResult> = {}): DateResult {
@@ -549,6 +549,77 @@ describe("ResultsHeatmap", () => {
 			render(<ResultsHeatmap dates={dates} {...defaultProps} />);
 			expect(screen.queryByText("Respondents:")).toBeNull();
 			expect(screen.queryByText("Response")).toBeNull();
+		});
+	});
+
+	describe("respondent notes", () => {
+		it("displays notes inline under respondent name when present", async () => {
+			const user = userEvent.setup();
+			const dates = [
+				makeDateResult({
+					date: "2025-03-15",
+					respondents: [
+						{ name: "Alice", status: "available", note: "Leaving at 9pm" },
+						{ name: "Bob", status: "maybe" },
+					],
+				}),
+			];
+			const { container } = render(<ResultsHeatmap dates={dates} {...defaultProps} />);
+			const desktop = getDesktopTable(container);
+
+			// Expand the date row
+			const caretCells =
+				desktop.el.querySelectorAll<HTMLTableCellElement>("tbody tr td:first-child");
+			await user.click(caretCells[0]);
+
+			// Alice's note should be visible
+			expect(desktop.getByText('"Leaving at 9pm"')).toBeDefined();
+		});
+
+		it("does not show note text when respondent has no note", async () => {
+			const user = userEvent.setup();
+			const dates = [
+				makeDateResult({
+					date: "2025-03-15",
+					respondents: [
+						{ name: "Alice", status: "available" },
+						{ name: "Bob", status: "maybe" },
+					],
+				}),
+			];
+			const { container } = render(<ResultsHeatmap dates={dates} {...defaultProps} />);
+			const desktop = getDesktopTable(container);
+
+			const caretCells =
+				desktop.el.querySelectorAll<HTMLTableCellElement>("tbody tr td:first-child");
+			await user.click(caretCells[0]);
+
+			// No italic note elements should be present
+			const noteElements = desktop.el.querySelectorAll(".italic");
+			expect(noteElements.length).toBe(0);
+		});
+
+		it("shows notes for multiple respondents on the same date", async () => {
+			const user = userEvent.setup();
+			const dates = [
+				makeDateResult({
+					date: "2025-03-15",
+					respondents: [
+						{ name: "Alice", status: "available", note: "Can stay late" },
+						{ name: "Bob", status: "maybe", note: "Depends on work" },
+						{ name: "Carol", status: "not_available" },
+					],
+				}),
+			];
+			const { container } = render(<ResultsHeatmap dates={dates} {...defaultProps} />);
+			const desktop = getDesktopTable(container);
+
+			const caretCells =
+				desktop.el.querySelectorAll<HTMLTableCellElement>("tbody tr td:first-child");
+			await user.click(caretCells[0]);
+
+			expect(desktop.getByText('"Can stay late"')).toBeDefined();
+			expect(desktop.getByText('"Depends on work"')).toBeDefined();
 		});
 	});
 });

--- a/app/components/results-heatmap.tsx
+++ b/app/components/results-heatmap.tsx
@@ -19,7 +19,7 @@ interface DateResult {
 	noResponse: number;
 	total: number;
 	score: number;
-	respondents: Array<{ name: string; status: string }>;
+	respondents: Array<{ name: string; status: string; note?: string }>;
 }
 
 interface ResultsHeatmapProps {
@@ -63,8 +63,8 @@ const statusSortOrder: Record<string, number> = {
 };
 
 function sortRespondentsByResponse(
-	respondents: Array<{ name: string; status: string }>,
-): Array<{ name: string; status: string }> {
+	respondents: Array<{ name: string; status: string; note?: string }>,
+): Array<{ name: string; status: string; note?: string }> {
 	return [...respondents].sort((a, b) => {
 		const statusDiff = (statusSortOrder[a.status] ?? 3) - (statusSortOrder[b.status] ?? 3);
 		if (statusDiff !== 0) return statusDiff;
@@ -369,12 +369,21 @@ export function ResultsHeatmap({
 													<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
 														{row.respondents.length > 0 ? (
 															sortRespondentsByResponse(row.respondents).map((r) => (
-																<div key={r.name} className="flex items-center gap-2 text-sm">
-																	{statusIcon[r.status]}
-																	<span className="text-slate-700">{r.name}</span>
-																	<span className="text-xs text-slate-400">
-																		{statusLabel[r.status]}
-																	</span>
+																<div key={r.name} className="flex items-start gap-2 text-sm">
+																	<span className="mt-0.5">{statusIcon[r.status]}</span>
+																	<div>
+																		<div className="flex items-center gap-2">
+																			<span className="text-slate-700">{r.name}</span>
+																			<span className="text-xs text-slate-400">
+																				{statusLabel[r.status]}
+																			</span>
+																		</div>
+																		{r.note && (
+																			<p className="mt-0.5 text-xs text-slate-500 italic">
+																				"{r.note}"
+																			</p>
+																		)}
+																	</div>
 																</div>
 															))
 														) : (
@@ -494,9 +503,14 @@ export function ResultsHeatmap({
 									<div className="space-y-2">
 										{row.respondents.length > 0 ? (
 											sortRespondentsByResponse(row.respondents).map((r) => (
-												<div key={r.name} className="flex items-center gap-2 text-sm">
-													{statusIcon[r.status]}
-													<span className="text-slate-700">{r.name}</span>
+												<div key={r.name} className="flex items-start gap-2 text-sm">
+													<span className="mt-0.5">{statusIcon[r.status]}</span>
+													<div>
+														<span className="text-slate-700">{r.name}</span>
+														{r.note && (
+															<p className="mt-0.5 text-xs text-slate-500 italic">"{r.note}"</p>
+														)}
+													</div>
 												</div>
 											))
 										) : (

--- a/app/routes/groups.$groupId.availability.$requestId.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId.test.ts
@@ -103,6 +103,7 @@ describe("availability response action", () => {
 			requestId: "r1",
 			userId: "user-1",
 			responses,
+			notes: {},
 		});
 		expect(result).toEqual({ success: true, message: "Response saved!" });
 	});
@@ -259,6 +260,221 @@ describe("availability response action", () => {
 			expect(response).toBeInstanceOf(Response);
 			expect((response as Response).headers.get("Location")).toBe("/login");
 		}
+	});
+});
+
+describe("availability notes validation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+		});
+	});
+
+	function makeFormData(responses: Record<string, string>, notes?: string): FormData {
+		const formData = new FormData();
+		formData.set("intent", "respond");
+		formData.set("responses", JSON.stringify(responses));
+		if (notes !== undefined) {
+			formData.set("notes", notes);
+		}
+		return formData;
+	}
+
+	function makeRequest(formData: FormData) {
+		return new Request("http://localhost/groups/g1/availability/r1", {
+			method: "POST",
+			body: formData,
+		});
+	}
+
+	it("saves response with valid notes", async () => {
+		const responses = { "2025-03-15": "available", "2025-03-16": "maybe" };
+		const notes = { "2025-03-15": "Leaving early at 9pm" };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalledWith({
+			requestId: "r1",
+			userId: "user-1",
+			responses,
+			notes: { "2025-03-15": "Leaving early at 9pm" },
+		});
+		expect(result).toEqual({ success: true, message: "Response saved!" });
+	});
+
+	it("returns error for invalid notes JSON", async () => {
+		const responses = { "2025-03-15": "available" };
+		const formData = makeFormData(responses, "not valid json");
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid notes data." });
+		expect(submitAvailabilityResponse).not.toHaveBeenCalled();
+	});
+
+	it("returns error when a note exceeds 200 characters", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "2025-03-15": "x".repeat(201) };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Notes must be 200 characters or less per day." });
+		expect(submitAvailabilityResponse).not.toHaveBeenCalled();
+	});
+
+	it("filters out notes for dates without responses", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "2025-03-15": "Confirmed", "2025-03-16": "Orphaned note" };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalledWith({
+			requestId: "r1",
+			userId: "user-1",
+			responses,
+			notes: { "2025-03-15": "Confirmed" },
+		});
+		expect(result).toEqual({ success: true, message: "Response saved!" });
+	});
+
+	it("trims whitespace from notes", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "2025-03-15": "  Has spaces  " };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalledWith({
+			requestId: "r1",
+			userId: "user-1",
+			responses,
+			notes: { "2025-03-15": "Has spaces" },
+		});
+		expect(result).toEqual({ success: true, message: "Response saved!" });
+	});
+
+	it("filters out whitespace-only notes", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "2025-03-15": "   " };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalledWith({
+			requestId: "r1",
+			userId: "user-1",
+			responses,
+			notes: {},
+		});
+		expect(result).toEqual({ success: true, message: "Response saved!" });
+	});
+
+	it("returns error for notes with invalid date keys", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "not-a-date": "Note" };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid notes data." });
+		expect(submitAvailabilityResponse).not.toHaveBeenCalled();
+	});
+
+	it("returns error when notes is a JSON array", async () => {
+		const responses = { "2025-03-15": "available" };
+		const formData = makeFormData(responses, '["not", "an", "object"]');
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid notes data." });
+		expect(submitAvailabilityResponse).not.toHaveBeenCalled();
+	});
+
+	it("returns error when notes is JSON null", async () => {
+		const responses = { "2025-03-15": "available" };
+		const formData = makeFormData(responses, "null");
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ error: "Invalid notes data." });
+		expect(submitAvailabilityResponse).not.toHaveBeenCalled();
+	});
+
+	it("accepts a 200-character note (boundary)", async () => {
+		const responses = { "2025-03-15": "available" };
+		const notes = { "2025-03-15": "x".repeat(200) };
+		const formData = makeFormData(responses, JSON.stringify(notes));
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalled();
+		expect(result).toEqual({ success: true, message: "Response saved!" });
+	});
+
+	it("handles empty notes object gracefully", async () => {
+		const responses = { "2025-03-15": "available" };
+		const formData = makeFormData(responses, "{}");
+
+		const result = await action({
+			request: makeRequest(formData),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(submitAvailabilityResponse).toHaveBeenCalledWith({
+			requestId: "r1",
+			userId: "user-1",
+			responses,
+			notes: {},
+		});
+		expect(result).toEqual({ success: true, message: "Response saved!" });
 	});
 });
 

--- a/app/routes/groups.$groupId.availability.$requestId.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId.tsx
@@ -63,7 +63,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		throw new Response("Not Found", { status: 404 });
 	}
 
-	const userResponse = await getUserResponse(requestId, user.id);
+	const userResponseData = await getUserResponse(requestId, user.id);
 	const results = await getAggregatedResults(requestId);
 	const nonRespondentCount =
 		results && results.totalResponded < results.totalMembers
@@ -75,7 +75,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 	return {
 		availRequest,
-		userResponse,
+		userResponse: userResponseData?.responses ?? null,
+		userNotes: userResponseData?.notes ?? {},
 		results,
 		isAdmin: admin,
 		user,
@@ -115,10 +116,44 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			}
 		}
 
+		// Parse and validate optional per-day notes
+		const notesRaw = formData.get("notes");
+		let notes: Record<string, string> = {};
+		if (notesRaw && typeof notesRaw === "string" && notesRaw !== "{}") {
+			try {
+				const parsed = JSON.parse(notesRaw);
+				if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+					return { error: "Invalid notes data." };
+				}
+				notes = parsed;
+			} catch {
+				return { error: "Invalid notes data." };
+			}
+
+			for (const [key, value] of Object.entries(notes)) {
+				if (!datePattern.test(key) || typeof value !== "string") {
+					return { error: "Invalid notes data." };
+				}
+				if (value.length > 200) {
+					return { error: "Notes must be 200 characters or less per day." };
+				}
+			}
+
+			// Only keep notes for dates that have a response
+			const filteredNotes: Record<string, string> = {};
+			for (const [key, value] of Object.entries(notes)) {
+				if (responses[key] && value.trim()) {
+					filteredNotes[key] = value.trim();
+				}
+			}
+			notes = filteredNotes;
+		}
+
 		await submitAvailabilityResponse({
 			requestId,
 			userId: user.id,
 			responses,
+			notes,
 		});
 
 		return { success: true, message: "Response saved!" };
@@ -233,8 +268,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export default function AvailabilityRequestDetail() {
-	const { availRequest, userResponse, results, isAdmin, user, nonRespondentCount, reminderSentAt } =
-		useLoaderData<typeof loader>();
+	const {
+		availRequest,
+		userResponse,
+		userNotes,
+		results,
+		isAdmin,
+		user,
+		nonRespondentCount,
+		reminderSentAt,
+	} = useLoaderData<typeof loader>();
 	const parentData = useRouteLoaderData<typeof groupLayoutLoader>("routes/groups.$groupId");
 	const timezone = parentData?.user?.timezone ?? undefined;
 	const actionData = useActionData<typeof action>();
@@ -249,6 +292,9 @@ export default function AvailabilityRequestDetail() {
 	const dates = availRequest.requestedDates as string[];
 	const [responses, setResponses] = useState<Record<string, AvailabilityStatus>>(
 		(userResponse as Record<string, AvailabilityStatus>) ?? {},
+	);
+	const [notes, setNotes] = useState<Record<string, string>>(
+		(userNotes as Record<string, string>) ?? {},
 	);
 	const [view, setView] = useState<"respond" | "results">("respond");
 	const isClosed = availRequest.status === "closed";
@@ -415,6 +461,8 @@ export default function AvailabilityRequestDetail() {
 						dates={dates}
 						responses={responses}
 						onChange={setResponses}
+						notes={notes}
+						onNotesChange={setNotes}
 						disabled={isClosed}
 						timeRange={hasTimeRange ? timeRange : null}
 						timezone={timezone}
@@ -424,6 +472,7 @@ export default function AvailabilityRequestDetail() {
 							<CsrfInput />
 							<input type="hidden" name="intent" value="respond" />
 							<input type="hidden" name="responses" value={JSON.stringify(responses)} />
+							<input type="hidden" name="notes" value={JSON.stringify(notes)} />
 							<button
 								type="submit"
 								disabled={isSubmitting || Object.keys(responses).length === 0}

--- a/app/services/availability.server.ts
+++ b/app/services/availability.server.ts
@@ -133,14 +133,17 @@ export async function submitAvailabilityResponse(data: {
 	requestId: string;
 	userId: string;
 	responses: Record<string, "available" | "maybe" | "not_available">;
+	notes?: Record<string, string>;
 }): Promise<void> {
 	const now = new Date();
+	const notes = data.notes ?? {};
 	await db
 		.insert(availabilityResponses)
 		.values({
 			requestId: data.requestId,
 			userId: data.userId,
 			responses: data.responses,
+			notes,
 			respondedAt: now,
 			updatedAt: now,
 		})
@@ -148,6 +151,7 @@ export async function submitAvailabilityResponse(data: {
 			target: [availabilityResponses.requestId, availabilityResponses.userId],
 			set: {
 				responses: data.responses,
+				notes,
 				updatedAt: now,
 			},
 		});
@@ -158,15 +162,22 @@ export async function submitAvailabilityResponse(data: {
 export async function getUserResponse(
 	requestId: string,
 	userId: string,
-): Promise<Record<string, string> | null> {
+): Promise<{ responses: Record<string, string>; notes: Record<string, string> } | null> {
 	const [row] = await db
-		.select({ responses: availabilityResponses.responses })
+		.select({
+			responses: availabilityResponses.responses,
+			notes: availabilityResponses.notes,
+		})
 		.from(availabilityResponses)
 		.where(
 			and(eq(availabilityResponses.requestId, requestId), eq(availabilityResponses.userId, userId)),
 		)
 		.limit(1);
-	return (row?.responses as Record<string, string>) ?? null;
+	if (!row) return null;
+	return {
+		responses: row.responses as Record<string, string>,
+		notes: (row.notes as Record<string, string>) ?? {},
+	};
 }
 
 // --- Get All Responses ---
@@ -176,6 +187,7 @@ export async function getRequestResponses(requestId: string): Promise<
 		userId: string;
 		userName: string;
 		responses: Record<string, string>;
+		notes: Record<string, string>;
 		respondedAt: Date;
 	}>
 > {
@@ -184,18 +196,20 @@ export async function getRequestResponses(requestId: string): Promise<
 			userId: availabilityResponses.userId,
 			userName: users.name,
 			responses: availabilityResponses.responses,
+			notes: availabilityResponses.notes,
 			respondedAt: availabilityResponses.respondedAt,
 		})
 		.from(availabilityResponses)
 		.innerJoin(users, eq(availabilityResponses.userId, users.id))
 		.where(eq(availabilityResponses.requestId, requestId))
 		.orderBy(users.name);
-	return rows as Array<{
-		userId: string;
-		userName: string;
-		responses: Record<string, string>;
-		respondedAt: Date;
-	}>;
+	return rows.map((r) => ({
+		userId: r.userId,
+		userName: r.userName,
+		responses: r.responses as Record<string, string>,
+		notes: (r.notes as Record<string, string>) ?? {},
+		respondedAt: r.respondedAt,
+	}));
 }
 
 // --- Aggregated Results ---
@@ -209,7 +223,7 @@ export async function getAggregatedResults(requestId: string): Promise<{
 		noResponse: number;
 		total: number;
 		score: number;
-		respondents: Array<{ name: string; status: string }>;
+		respondents: Array<{ name: string; status: string; note?: string }>;
 	}>;
 	totalMembers: number;
 	totalResponded: number;
@@ -234,19 +248,24 @@ export async function getAggregatedResults(requestId: string): Promise<{
 		let available = 0;
 		let maybe = 0;
 		let notAvailable = 0;
-		const respondents: Array<{ name: string; status: string }> = [];
+		const respondents: Array<{ name: string; status: string; note?: string }> = [];
 
 		for (const resp of responses) {
 			const status = resp.responses[date];
+			const note = resp.notes[date];
 			if (status === "available") {
 				available++;
-				respondents.push({ name: resp.userName, status: "available" });
+				respondents.push({ name: resp.userName, status: "available", ...(note ? { note } : {}) });
 			} else if (status === "maybe") {
 				maybe++;
-				respondents.push({ name: resp.userName, status: "maybe" });
+				respondents.push({ name: resp.userName, status: "maybe", ...(note ? { note } : {}) });
 			} else if (status === "not_available") {
 				notAvailable++;
-				respondents.push({ name: resp.userName, status: "not_available" });
+				respondents.push({
+					name: resp.userName,
+					status: "not_available",
+					...(note ? { note } : {}),
+				});
 			}
 		}
 

--- a/drizzle/0014_chief_ser_duncan.sql
+++ b/drizzle/0014_chief_ser_duncan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "availability_responses" ADD COLUMN "notes" jsonb;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1115 @@
+{
+  "id": "ccbed80a-ebe5-47e2-a199-5f478b445393",
+  "prevId": "4957071d-a56a-4cca-a29d-5c6d576419c3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_requests": {
+      "name": "availability_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_dates": {
+          "name": "requested_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_start_time": {
+          "name": "requested_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_end_time": {
+          "name": "requested_end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "availability_requests_group_id_idx": {
+          "name": "availability_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_requests_group_id_groups_id_fk": {
+          "name": "availability_requests_group_id_groups_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_requests_created_by_id_users_id_fk": {
+          "name": "availability_requests_created_by_id_users_id_fk",
+          "tableFrom": "availability_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_responses": {
+      "name": "availability_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_responses_request_user_idx": {
+          "name": "availability_responses_request_user_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_responses_request_id_availability_requests_id_fk": {
+          "name": "availability_responses_request_id_availability_requests_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_responses_user_id_users_id_fk": {
+          "name": "availability_responses_user_id_users_id_fk",
+          "tableFrom": "availability_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_assignments": {
+      "name": "event_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_assignments_event_user_idx": {
+          "name": "event_assignments_event_user_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_assignments_user_id_idx": {
+          "name": "event_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_assignments_event_id_events_id_fk": {
+          "name": "event_assignments_event_id_events_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_assignments_user_id_users_id_fk": {
+          "name": "event_assignments_user_id_users_id_fk",
+          "tableFrom": "event_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_request_id": {
+          "name": "created_from_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_time": {
+          "name": "call_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_reminder_sent_at": {
+          "name": "confirmation_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_group_start_time_idx": {
+          "name": "events_group_start_time_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_group_id_groups_id_fk": {
+          "name": "events_group_id_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_id_users_id_fk": {
+          "name": "events_created_by_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_created_from_request_id_availability_requests_id_fk": {
+          "name": "events_created_from_request_id_availability_requests_id_fk",
+          "tableFrom": "events",
+          "tableTo": "availability_requests",
+          "columnsFrom": [
+            "created_from_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"availabilityRequests\":{\"email\":true},\"eventNotifications\":{\"email\":true},\"showReminders\":{\"email\":true}}'::jsonb"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_user_idx": {
+          "name": "group_memberships_group_user_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_can_create_requests": {
+          "name": "members_can_create_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "members_can_create_events": {
+          "name": "members_can_create_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_invite_code_idx": {
+          "name": "groups_invite_code_idx",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_id_users_id_fk": {
+          "name": "groups_created_by_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_invite_code_unique": {
+          "name": "groups_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvp_changes": {
+      "name": "rsvp_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rsvp_changes_event_id_idx": {
+          "name": "rsvp_changes_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rsvp_changes_event_changed_at_idx": {
+          "name": "rsvp_changes_event_changed_at_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rsvp_changes_event_id_events_id_fk": {
+          "name": "rsvp_changes_event_id_events_id_fk",
+          "tableFrom": "rsvp_changes",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvp_changes_user_id_users_id_fk": {
+          "name": "rsvp_changes_user_id_users_id_fk",
+          "tableFrom": "rsvp_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_expiry": {
+          "name": "email_verification_expiry",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_google_id_idx": {
+          "name": "users_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verification_token_idx": {
+          "name": "users_email_verification_token_idx",
+          "columns": [
+            {
+              "expression": "email_verification_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "declined"
+      ]
+    },
+    "public.availability_response_value": {
+      "name": "availability_response_value",
+      "schema": "public",
+      "values": [
+        "available",
+        "maybe",
+        "not_available"
+      ]
+    },
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "rehearsal",
+        "show",
+        "other"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1774857000000,
       "tag": "0013_high_gateway",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1775939366697,
+      "tag": "0014_chief_ser_duncan",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -152,6 +152,7 @@ export const availabilityResponses = pgTable(
 		responses: jsonb("responses")
 			.$type<Record<string, "available" | "maybe" | "not_available">>()
 			.notNull(),
+		notes: jsonb("notes").$type<Record<string, string>>(),
 		respondedAt: timestamp("responded_at", { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 	},


### PR DESCRIPTION
## Summary

Members can now attach optional text notes (up to 200 characters) to each day when submitting availability responses.

## Changes
- Schema: nullable jsonb notes column on availability_responses
- Migration: 0014_chief_ser_duncan.sql
- Route: validates notes, 200-char limit, filters orphaned notes, guards null/array injection
- AvailabilityGrid: per-day note toggle + inline text input (desktop + mobile)
- ResultsHeatmap: italic notes under respondent names in expanded view
- 660 tests pass (23 new tests for notes)
- 4 new component fixtures

## How to Test
1. Run migrations: `pnpm run db:migrate`
2. Submit availability - click the message icon next to any date to add a note
3. Check Results tab - expand a date to see notes under respondent names
4. Run tests: `pnpm test` (660 tests pass)
