### PR TITLE
fix: wrap fire-and-forget async blocks with try/catch

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -29,6 +29,7 @@ import {
 	getGroupWithMembers,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { logger } from "~/services/logger.server";
 import { sendBatchEventsCreatedWebhook } from "~/services/webhook.server";
 import type { NotificationPreferences } from "../../src/db/schema.js";
 
@@ -158,120 +159,124 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
 
 	void (async () => {
-		const [groupData, membersWithPrefs] = await Promise.all([
-			getGroupWithMembers(groupId),
-			getGroupMembersWithPreferences(groupId),
-		]);
-		if (!groupData) return;
+		try {
+			const [groupData, membersWithPrefs] = await Promise.all([
+				getGroupWithMembers(groupId),
+				getGroupMembersWithPreferences(groupId),
+			]);
+			if (!groupData) return;
 
-		const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m.notificationPreferences]));
+			const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m.notificationPreferences]));
 
-		// Build per-member "best status" across all batch dates
-		const memberBestStatus = new Map<string, "available" | "maybe" | "not_available">();
-		const respondedUserIds = new Set<string>();
+			// Build per-member "best status" across all batch dates
+			const memberBestStatus = new Map<string, "available" | "maybe" | "not_available">();
+			const respondedUserIds = new Set<string>();
 
-		for (const date of selectedDates) {
-			const availData = await getAvailabilityForEventDate(requestId, date);
-			for (const entry of availData) {
-				respondedUserIds.add(entry.userId);
-				const current = memberBestStatus.get(entry.userId);
-				if (entry.status === "available") {
-					memberBestStatus.set(entry.userId, "available");
-				} else if (entry.status === "maybe" && current !== "available") {
-					memberBestStatus.set(entry.userId, "maybe");
-				} else if (!current) {
-					memberBestStatus.set(entry.userId, entry.status as "not_available");
+			for (const date of selectedDates) {
+				const availData = await getAvailabilityForEventDate(requestId, date);
+				for (const entry of availData) {
+					respondedUserIds.add(entry.userId);
+					const current = memberBestStatus.get(entry.userId);
+					if (entry.status === "available") {
+						memberBestStatus.set(entry.userId, "available");
+					} else if (entry.status === "maybe" && current !== "available") {
+						memberBestStatus.set(entry.userId, "maybe");
+					} else if (!current) {
+						memberBestStatus.set(entry.userId, entry.status as "not_available");
+					}
 				}
 			}
-		}
 
-		const memberMap = new Map(
-			groupData.members.map((m) => [
-				m.id,
-				{
-					email: m.email,
-					name: m.name,
-					timezone: m.timezone,
-					notificationPreferences: prefsMap.get(m.id) as NotificationPreferences | undefined,
-				},
-			]),
-		);
+			const memberMap = new Map(
+				groupData.members.map((m) => [
+					m.id,
+					{
+						email: m.email,
+						name: m.name,
+						timezone: m.timezone,
+						notificationPreferences: prefsMap.get(m.id) as NotificationPreferences | undefined,
+					},
+				]),
+			);
 
-		const availableRecipients: Array<{
-			email: string;
-			name: string;
-			timezone?: string | null;
-			notificationPreferences?: NotificationPreferences;
-		}> = [];
-		const maybeRecipients: Array<{
-			email: string;
-			name: string;
-			timezone?: string | null;
-			notificationPreferences?: NotificationPreferences;
-		}> = [];
-		const noResponseRecipients: Array<{
-			email: string;
-			name: string;
-			timezone?: string | null;
-			notificationPreferences?: NotificationPreferences;
-		}> = [];
+			const availableRecipients: Array<{
+				email: string;
+				name: string;
+				timezone?: string | null;
+				notificationPreferences?: NotificationPreferences;
+			}> = [];
+			const maybeRecipients: Array<{
+				email: string;
+				name: string;
+				timezone?: string | null;
+				notificationPreferences?: NotificationPreferences;
+			}> = [];
+			const noResponseRecipients: Array<{
+				email: string;
+				name: string;
+				timezone?: string | null;
+				notificationPreferences?: NotificationPreferences;
+			}> = [];
 
-		for (const member of groupData.members) {
-			if (member.id === user.id) continue;
-			const info = memberMap.get(member.id);
-			if (!info) continue;
+			for (const member of groupData.members) {
+				if (member.id === user.id) continue;
+				const info = memberMap.get(member.id);
+				if (!info) continue;
 
-			const bestStatus = memberBestStatus.get(member.id);
-			if (!respondedUserIds.has(member.id)) {
-				noResponseRecipients.push(info);
-			} else if (bestStatus === "available") {
-				availableRecipients.push(info);
-			} else if (bestStatus === "maybe") {
-				maybeRecipients.push(info);
-			} else if (bestStatus === "not_available") {
-				// Explicitly said "not available" for all batch dates → no email
-			} else {
-				// Responded to the request but didn't mark these specific dates
-				noResponseRecipients.push(info);
+				const bestStatus = memberBestStatus.get(member.id);
+				if (!respondedUserIds.has(member.id)) {
+					noResponseRecipients.push(info);
+				} else if (bestStatus === "available") {
+					availableRecipients.push(info);
+				} else if (bestStatus === "maybe") {
+					maybeRecipients.push(info);
+				} else if (bestStatus === "not_available") {
+					// Explicitly said "not available" for all batch dates → no email
+				} else {
+					// Responded to the request but didn't mark these specific dates
+					noResponseRecipients.push(info);
+				}
 			}
-		}
 
-		const eventDetails = events.map((e) => ({
-			title: e.title,
-			eventType: e.eventType,
-			startTime: e.startTime,
-			endTime: e.endTime,
-			location: e.location ?? undefined,
-			eventUrl: `${appUrl}/groups/${groupId}/events/${e.id}`,
-		}));
+			const eventDetails = events.map((e) => ({
+				title: e.title,
+				eventType: e.eventType,
+				startTime: e.startTime,
+				endTime: e.endTime,
+				location: e.location ?? undefined,
+				eventUrl: `${appUrl}/groups/${groupId}/events/${e.id}`,
+			}));
 
-		void sendBatchEventsFromAvailabilityNotification({
-			events: eventDetails,
-			groupName: groupData.group.name,
-			availableRecipients,
-			maybeRecipients,
-			noResponseRecipients,
-			eventsUrl,
-			preferencesUrl,
-		});
-
-		if (groupData.group.webhookUrl) {
-			const tz = timezone ?? undefined;
-			const webhookEvents = events.map((e) => {
-				const dateTime = formatEventTime(e.startTime, e.endTime, tz);
-				const tzAbbrev = getTimezoneAbbreviation(e.startTime, tz);
-				return {
-					dateTime: tzAbbrev ? `${dateTime} (${tzAbbrev})` : dateTime,
-					location: e.location ?? undefined,
-				};
-			});
-			sendBatchEventsCreatedWebhook(groupData.group.webhookUrl, {
+			void sendBatchEventsFromAvailabilityNotification({
+				events: eventDetails,
 				groupName: groupData.group.name,
-				title: title.trim(),
-				eventType,
-				events: webhookEvents,
+				availableRecipients,
+				maybeRecipients,
+				noResponseRecipients,
 				eventsUrl,
+				preferencesUrl,
 			});
+
+			if (groupData.group.webhookUrl) {
+				const tz = timezone ?? undefined;
+				const webhookEvents = events.map((e) => {
+					const dateTime = formatEventTime(e.startTime, e.endTime, tz);
+					const tzAbbrev = getTimezoneAbbreviation(e.startTime, tz);
+					return {
+						dateTime: tzAbbrev ? `${dateTime} (${tzAbbrev})` : dateTime,
+						location: e.location ?? undefined,
+					};
+				});
+				sendBatchEventsCreatedWebhook(groupData.group.webhookUrl, {
+					groupName: groupData.group.name,
+					title: title.trim(),
+					eventType,
+					events: webhookEvents,
+					eventsUrl,
+				});
+			}
+		} catch (error) {
+			logger.error({ err: error, groupId, requestId }, "Failed to send batch event notifications");
 		}
 	})();
 

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -58,6 +58,7 @@ import {
 	isGroupAdmin,
 	requireGroupMember,
 } from "~/services/groups.server";
+import { logger } from "~/services/logger.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
 
 export const meta: MetaFunction = () => {
@@ -208,36 +209,39 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			const newlyAssignedIds = verifiedIds.filter((id) => !existingAssignmentIds.has(id));
 			if (newlyAssignedIds.length > 0) {
 				void (async () => {
-					const membersWithPrefs = await getGroupMembersWithPreferences(groupId);
-					const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m]));
-					const appUrl = process.env.APP_URL ?? "http://localhost:5173";
-					const eventUrl = `${appUrl}/groups/${groupId}/events/${eventId}`;
-					const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
-					const event = eventData.event;
-					const groupName = groupData?.group.name ?? "";
+					try {
+						const membersWithPrefs = await getGroupMembersWithPreferences(groupId);
+						const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m]));
+						const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+						const eventUrl = `${appUrl}/groups/${groupId}/events/${eventId}`;
+						const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
+						const event = eventData.event;
+						const groupName = groupData?.group.name ?? "";
 
-					for (const userId of newlyAssignedIds) {
-						const member = prefsMap.get(userId);
-						if (!member) continue;
-						const tz = member.timezone ?? undefined;
-						const dateTime = formatEventTime(
-							event.startTime as unknown as string,
-							event.endTime as unknown as string,
-							tz,
+						for (const userId of newlyAssignedIds) {
+							const member = prefsMap.get(userId);
+							if (!member) continue;
+							const tz = member.timezone ?? undefined;
+							const dateTime = formatEventTime(event.startTime, event.endTime, tz);
+							void sendEventAssignmentNotification({
+								eventTitle: event.title,
+								eventType: event.eventType,
+								dateTime,
+								groupName,
+								recipient: {
+									email: member.email,
+									name: member.name,
+									notificationPreferences: member.notificationPreferences,
+								},
+								eventUrl,
+								preferencesUrl,
+							});
+						}
+					} catch (error) {
+						logger.error(
+							{ err: error, groupId, eventId },
+							"Failed to send event assignment notifications",
 						);
-						void sendEventAssignmentNotification({
-							eventTitle: event.title,
-							eventType: event.eventType,
-							dateTime,
-							groupName,
-							recipient: {
-								email: member.email,
-								name: member.name,
-								notificationPreferences: member.notificationPreferences,
-							},
-							eventUrl,
-							preferencesUrl,
-						});
 					}
 				})();
 			}
@@ -268,35 +272,35 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 		if (sendNotification) {
 			void (async () => {
-				const membersWithPrefs = await getGroupMembersWithPreferences(groupId);
-				const member = membersWithPrefs.find((m) => m.id === targetUserId);
-				if (!member) return;
-				const appUrl = process.env.APP_URL ?? "http://localhost:5173";
-				const eventUrl = `${appUrl}/groups/${groupId}/events/${eventId}`;
-				const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
-				const event = eventData.event;
-				const groupData = await getGroupWithMembers(groupId);
-				const groupName = groupData?.group.name ?? "";
-				const tz = member.timezone ?? undefined;
-				const dateTime = formatEventTime(
-					event.startTime as unknown as string,
-					event.endTime as unknown as string,
-					tz,
-				);
-				void sendRoleChangeNotification({
-					eventTitle: event.title,
-					eventType: event.eventType,
-					dateTime,
-					groupName,
-					newRole: trimmedRole,
-					recipient: {
-						email: member.email,
-						name: member.name,
-						notificationPreferences: member.notificationPreferences,
-					},
-					eventUrl,
-					preferencesUrl,
-				});
+				try {
+					const membersWithPrefs = await getGroupMembersWithPreferences(groupId);
+					const member = membersWithPrefs.find((m) => m.id === targetUserId);
+					if (!member) return;
+					const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+					const eventUrl = `${appUrl}/groups/${groupId}/events/${eventId}`;
+					const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
+					const event = eventData.event;
+					const groupData = await getGroupWithMembers(groupId);
+					const groupName = groupData?.group.name ?? "";
+					const tz = member.timezone ?? undefined;
+					const dateTime = formatEventTime(event.startTime, event.endTime, tz);
+					void sendRoleChangeNotification({
+						eventTitle: event.title,
+						eventType: event.eventType,
+						dateTime,
+						groupName,
+						newRole: trimmedRole,
+						recipient: {
+							email: member.email,
+							name: member.name,
+							notificationPreferences: member.notificationPreferences,
+						},
+						eventUrl,
+						preferencesUrl,
+					});
+				} catch (error) {
+					logger.error({ err: error, groupId, eventId }, "Failed to send role change notification");
+				}
 			})();
 		}
 		return { success: true };
@@ -367,9 +371,7 @@ export default function EventDetail() {
 	const dateStr = formatDateLong(event.startTime, timezone);
 	const startTimeStr = formatTime(event.startTime, timezone);
 	const endTimeStr = formatTime(event.endTime, timezone);
-	const callTimeStr = event.callTime
-		? formatTime(event.callTime as unknown as string, timezone)
-		: null;
+	const callTimeStr = event.callTime ? formatTime(event.callTime, timezone) : null;
 
 	const toggleUser = (id: string) => {
 		const next = new Set(selectedUserIds);

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -38,6 +38,7 @@ import {
 	getGroupWithMembers,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { logger } from "~/services/logger.server";
 import { sendEventCreatedWebhook } from "~/services/webhook.server";
 import type { NotificationPreferences } from "../../src/db/schema.js";
 
@@ -178,126 +179,133 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		typeof fromRequestId === "string" && fromRequestId ? fromRequestId : null;
 
 	void (async () => {
-		const [groupData, membersWithPrefs] = await Promise.all([
-			getGroupWithMembers(groupId),
-			getGroupMembersWithPreferences(groupId),
-		]);
-		if (!groupData) return;
+		try {
+			const [groupData, membersWithPrefs] = await Promise.all([
+				getGroupWithMembers(groupId),
+				getGroupMembersWithPreferences(groupId),
+			]);
+			if (!groupData) return;
 
-		const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m.notificationPreferences]));
+			const prefsMap = new Map(membersWithPrefs.map((m) => [m.id, m.notificationPreferences]));
 
-		if (validFromRequestId && typeof date === "string") {
-			// Availability-aware notifications
-			const availData = await getAvailabilityForEventDate(validFromRequestId, date);
-			const memberMap = new Map(
-				groupData.members.map((m) => [
-					m.id,
-					{
+			if (validFromRequestId && typeof date === "string") {
+				// Availability-aware notifications
+				const availData = await getAvailabilityForEventDate(validFromRequestId, date);
+				const memberMap = new Map(
+					groupData.members.map((m) => [
+						m.id,
+						{
+							email: m.email,
+							name: m.name,
+							timezone: m.timezone,
+							notificationPreferences: prefsMap.get(m.id),
+						},
+					]),
+				);
+
+				const availableRecipients: Array<{
+					email: string;
+					name: string;
+					timezone?: string | null;
+					notificationPreferences?: NotificationPreferences;
+				}> = [];
+				const maybeRecipients: Array<{
+					email: string;
+					name: string;
+					timezone?: string | null;
+					notificationPreferences?: NotificationPreferences;
+				}> = [];
+				const respondedUserIds = new Set<string>();
+
+				for (const entry of availData) {
+					if (entry.userId === user.id) {
+						respondedUserIds.add(entry.userId);
+						continue;
+					}
+					respondedUserIds.add(entry.userId);
+					const member = memberMap.get(entry.userId);
+					if (!member) continue;
+					if (entry.status === "available") {
+						availableRecipients.push(member);
+					} else if (entry.status === "maybe") {
+						maybeRecipients.push(member);
+					}
+					// not_available → no email
+				}
+
+				// Members who didn't respond at all
+				const noResponseRecipients = groupData.members
+					.filter((m) => m.id !== user.id && !respondedUserIds.has(m.id))
+					.map((m) => ({
 						email: m.email,
 						name: m.name,
 						timezone: m.timezone,
 						notificationPreferences: prefsMap.get(m.id),
-					},
-				]),
-			);
+					}));
 
-			const availableRecipients: Array<{
-				email: string;
-				name: string;
-				timezone?: string | null;
-				notificationPreferences?: NotificationPreferences;
-			}> = [];
-			const maybeRecipients: Array<{
-				email: string;
-				name: string;
-				timezone?: string | null;
-				notificationPreferences?: NotificationPreferences;
-			}> = [];
-			const respondedUserIds = new Set<string>();
+				void sendEventFromAvailabilityNotification({
+					eventTitle: event.title,
+					eventType: event.eventType,
+					startTime: event.startTime,
+					endTime: event.endTime,
+					location: event.location ?? undefined,
+					groupName: groupData.group.name,
+					eventUrl,
+					availableRecipients,
+					maybeRecipients,
+					noResponseRecipients,
+					preferencesUrl,
+				});
+			} else {
+				// Standard notification
+				const recipients = groupData.members
+					.filter((m) => m.id !== user.id)
+					.map((m) => ({
+						email: m.email,
+						name: m.name,
+						timezone: m.timezone,
+						notificationPreferences: prefsMap.get(m.id),
+					}));
+				if (recipients.length === 0) return;
 
-			for (const entry of availData) {
-				if (entry.userId === user.id) {
-					respondedUserIds.add(entry.userId);
-					continue;
-				}
-				respondedUserIds.add(entry.userId);
-				const member = memberMap.get(entry.userId);
-				if (!member) continue;
-				if (entry.status === "available") {
-					availableRecipients.push(member);
-				} else if (entry.status === "maybe") {
-					maybeRecipients.push(member);
-				}
-				// not_available → no email
+				void sendEventCreatedNotification({
+					eventTitle: event.title,
+					eventType: event.eventType,
+					startTime: event.startTime,
+					endTime: event.endTime,
+					location: event.location ?? undefined,
+					groupName: groupData.group.name,
+					recipients,
+					eventUrl,
+					preferencesUrl,
+				});
 			}
 
-			// Members who didn't respond at all
-			const noResponseRecipients = groupData.members
-				.filter((m) => m.id !== user.id && !respondedUserIds.has(m.id))
-				.map((m) => ({
-					email: m.email,
-					name: m.name,
-					timezone: m.timezone,
-					notificationPreferences: prefsMap.get(m.id),
-				}));
-
-			void sendEventFromAvailabilityNotification({
-				eventTitle: event.title,
-				eventType: event.eventType,
-				startTime: event.startTime,
-				endTime: event.endTime,
-				location: event.location ?? undefined,
-				groupName: groupData.group.name,
-				eventUrl,
-				availableRecipients,
-				maybeRecipients,
-				noResponseRecipients,
-				preferencesUrl,
-			});
-		} else {
-			// Standard notification
-			const recipients = groupData.members
-				.filter((m) => m.id !== user.id)
-				.map((m) => ({
-					email: m.email,
-					name: m.name,
-					timezone: m.timezone,
-					notificationPreferences: prefsMap.get(m.id),
-				}));
-			if (recipients.length === 0) return;
-
-			void sendEventCreatedNotification({
-				eventTitle: event.title,
-				eventType: event.eventType,
-				startTime: event.startTime,
-				endTime: event.endTime,
-				location: event.location ?? undefined,
-				groupName: groupData.group.name,
-				recipients,
-				eventUrl,
-				preferencesUrl,
-			});
-		}
-
-		// Fire-and-forget Discord webhook
-		if (groupData.group.webhookUrl) {
-			const tz = event.timezone ?? undefined;
-			const webhookDateTime = formatEventTime(event.startTime, event.endTime, tz);
-			const tzAbbrev = getTimezoneAbbreviation(event.startTime, tz);
-			const webhookCallTime = event.callTime ? formatTime(event.callTime, tz) : null;
-			sendEventCreatedWebhook(groupData.group.webhookUrl, {
-				groupName: groupData.group.name,
-				eventTitle: event.title,
-				eventType: event.eventType,
-				dateTime: tzAbbrev ? `${webhookDateTime} (${tzAbbrev})` : webhookDateTime,
-				location: event.location ?? undefined,
-				callTime: webhookCallTime
-					? tzAbbrev
-						? `${webhookCallTime} (${tzAbbrev})`
-						: webhookCallTime
-					: undefined,
-				eventUrl,
-			});
+			// Fire-and-forget Discord webhook
+			if (groupData.group.webhookUrl) {
+				const tz = event.timezone ?? undefined;
+				const webhookDateTime = formatEventTime(event.startTime, event.endTime, tz);
+				const tzAbbrev = getTimezoneAbbreviation(event.startTime, tz);
+				const webhookCallTime = event.callTime ? formatTime(event.callTime, tz) : null;
+				sendEventCreatedWebhook(groupData.group.webhookUrl, {
+					groupName: groupData.group.name,
+					eventTitle: event.title,
+					eventType: event.eventType,
+					dateTime: tzAbbrev ? `${webhookDateTime} (${tzAbbrev})` : webhookDateTime,
+					location: event.location ?? undefined,
+					callTime: webhookCallTime
+						? tzAbbrev
+							? `${webhookCallTime} (${tzAbbrev})`
+							: webhookCallTime
+						: undefined,
+					eventUrl,
+				});
+			}
+		} catch (error) {
+			logger.error(
+				{ err: error, groupId, eventId: event.id },
+				"Failed to send event creation notifications",
+			);
 		}
 	})();
 


### PR DESCRIPTION
## Problem

Multiple route files use `void (async () => { ... })()` for background email/notification sending without try/catch. When DB calls inside these blocks fail (transient connection issues, pool exhaustion), the result is unhandled promise rejections that App Insights captures as exceptions — causing the recent spike.

## Fix

Wrapped all fire-and-forget async blocks with try/catch and proper error logging:

- `app/routes/groups.$groupId.events.$eventId.tsx` (2 instances)
- `app/routes/groups.$groupId.events.new.tsx` (1 instance)
- `app/routes/groups.$groupId.availability.$requestId_.batch.tsx` (1 instance)

## Testing

- Typecheck passes
- Lint passes
- Tests pass