### PR TITLE
Make batch selection the default event creation flow

### DIFF
--- a/app/components/results-heatmap.test.tsx
+++ b/app/components/results-heatmap.test.tsx
@@ -212,8 +212,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			// Enter batch selecting mode
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// In batch mode, the first td is the checkbox, the second is the caret.
@@ -241,7 +239,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// Click caret button on first row
@@ -267,7 +264,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// Click the checkbox button (inside first td) on the first row
@@ -294,7 +290,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// Click the row itself (not checkbox, not caret) — e.g. the date text cell
@@ -325,9 +320,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			// Enter batch selecting mode
-			await user.click(screen.getByText("Select Dates"));
-
 			// Mobile cards are in div.sm\:hidden — get the mobile wrapper
 			const mobileWrapper = container.querySelector(".sm\\:hidden");
 			expect(mobileWrapper).not.toBeNull();
@@ -348,31 +340,13 @@ describe("ResultsHeatmap", () => {
 	});
 
 	describe("batch selection", () => {
-		it("shows Select Dates button when batchMode is true", () => {
+		it("shows batch toolbar when batchMode is true", () => {
 			const dates = [makeDateResult()];
 			render(
 				<ResultsHeatmap dates={dates} {...defaultProps} batchMode={true} onBatchCreate={vi.fn()} />,
 			);
-			expect(screen.getByText("Select Dates")).toBeDefined();
-		});
-
-		it("toggles batch selecting mode", async () => {
-			const user = userEvent.setup();
-			const dates = [makeDateResult()];
-			render(
-				<ResultsHeatmap dates={dates} {...defaultProps} batchMode={true} onBatchCreate={vi.fn()} />,
-			);
-
-			// Initially shows "Select Dates"
-			const btn = screen.getByText("Select Dates");
-			await user.click(btn);
-
-			// Now in batch selecting mode — button text changes to "Cancel Selection"
-			expect(screen.getByText("Cancel Selection")).toBeDefined();
-
-			// Click cancel to exit batch mode
-			await user.click(screen.getByText("Cancel Selection"));
-			expect(screen.getByText("Select Dates")).toBeDefined();
+			expect(screen.getByText("Select Top 5")).toBeDefined();
+			expect(screen.getByText("Select All")).toBeDefined();
 		});
 
 		it("selects and deselects dates", async () => {
@@ -388,7 +362,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// Click the row to select the first date
@@ -420,7 +393,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			const desktop = getDesktopTable(container);
 
 			// Select first two dates
@@ -459,7 +431,6 @@ describe("ResultsHeatmap", () => {
 				/>,
 			);
 
-			await user.click(screen.getByText("Select Dates"));
 			await user.click(screen.getByText("Select Top 5"));
 
 			// Should show "5 dates selected"

--- a/app/components/results-heatmap.tsx
+++ b/app/components/results-heatmap.tsx
@@ -85,7 +85,6 @@ export function ResultsHeatmap({
 }: ResultsHeatmapProps) {
 	const [expandedDates, setExpandedDates] = useState<Set<string>>(new Set());
 	const [sortBy, setSortBy] = useState<"date" | "score">("date");
-	const [batchSelecting, setBatchSelecting] = useState(false);
 	const [selectedDates, setSelectedDates] = useState<Set<string>>(new Set());
 
 	const toggleExpanded = useCallback((date: string) => {
@@ -189,47 +188,29 @@ export function ResultsHeatmap({
 					<div className="flex items-center gap-3">
 						<button
 							type="button"
-							onClick={() => {
-								setBatchSelecting(!batchSelecting);
-								if (batchSelecting) clearSelection();
-							}}
-							className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-								batchSelecting
-									? "bg-emerald-600 text-white"
-									: "border border-emerald-300 text-emerald-700 hover:bg-emerald-100"
-							}`}
+							onClick={() => selectTopN(5)}
+							className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
 						>
-							{batchSelecting ? "Cancel Selection" : "Select Dates"}
+							Select Top 5
 						</button>
-						{batchSelecting && (
-							<>
-								<button
-									type="button"
-									onClick={() => selectTopN(5)}
-									className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
-								>
-									Select Top 5
-								</button>
-								<button
-									type="button"
-									onClick={() => setSelectedDates(new Set(dates.map((d) => d.date)))}
-									className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
-								>
-									Select All
-								</button>
-								{selectedDates.size > 0 && (
-									<button
-										type="button"
-										onClick={clearSelection}
-										className="text-xs text-slate-500 hover:text-slate-700"
-									>
-										Clear
-									</button>
-								)}
-							</>
+						<button
+							type="button"
+							onClick={() => setSelectedDates(new Set(dates.map((d) => d.date)))}
+							className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
+						>
+							Select All
+						</button>
+						{selectedDates.size > 0 && (
+							<button
+								type="button"
+								onClick={clearSelection}
+								className="text-xs text-slate-500 hover:text-slate-700"
+							>
+								Clear
+							</button>
 						)}
 					</div>
-					{batchSelecting && selectedDates.size > 0 && (
+					{selectedDates.size > 0 && (
 						<div className="flex items-center gap-3">
 							<span className="text-sm font-medium text-slate-700">
 								{selectedDates.size} date{selectedDates.size !== 1 ? "s" : ""} selected
@@ -252,7 +233,7 @@ export function ResultsHeatmap({
 					<table className="w-full">
 						<thead>
 							<tr className="bg-slate-50">
-								{batchSelecting && <th className="w-8 px-2 py-3" />}
+								{batchMode && <th className="w-8 px-2 py-3" />}
 								<th className="w-8 px-3 py-3" />
 								<th className="px-4 py-3 text-left text-xs font-medium text-slate-500">Date</th>
 								<th className="px-4 py-3 text-left text-xs font-medium text-slate-500">Day</th>
@@ -260,7 +241,6 @@ export function ResultsHeatmap({
 								<th className="px-3 py-3 text-center text-xs font-medium text-amber-500">🤔</th>
 								<th className="px-3 py-3 text-center text-xs font-medium text-rose-600">❌</th>
 								<th className="px-3 py-3 text-center text-xs font-medium text-slate-400">—</th>
-								<th className="px-4 py-3 text-right text-xs font-medium text-slate-500" />
 							</tr>
 						</thead>
 						<tbody className="divide-y divide-slate-100">
@@ -272,19 +252,19 @@ export function ResultsHeatmap({
 									<Fragment key={row.date}>
 										<tr
 											className={`cursor-pointer transition-colors ${
-												batchSelecting && selectedDates.has(row.date)
+												batchMode && selectedDates.has(row.date)
 													? "bg-emerald-100 hover:bg-emerald-200/70"
 													: `${getHeatColor(row.score, maxScore)} hover:bg-slate-100/50`
 											}`}
 											onClick={() => {
-												if (batchSelecting) {
+												if (batchMode) {
 													toggleDate(row.date);
 												} else {
 													toggleExpanded(row.date);
 												}
 											}}
 										>
-											{batchSelecting && (
+											{batchMode && (
 												<td className="px-2 py-3 text-center">
 													<button
 														type="button"
@@ -345,21 +325,10 @@ export function ResultsHeatmap({
 											<td className="px-3 py-3 text-center text-sm text-slate-400">
 												{row.noResponse}
 											</td>
-											<td className="px-4 py-3 text-right">
-												{!batchSelecting && (
-													<a
-														href={`/groups/${groupId}/events/new?date=${row.date}${requestId ? `&fromRequest=${requestId}` : ""}`}
-														onClick={(e) => e.stopPropagation()}
-														className="text-xs font-medium text-emerald-600 hover:text-emerald-700"
-													>
-														Create Event
-													</a>
-												)}
-											</td>
 										</tr>
 										{isExpanded && (
 											<tr key={`${row.date}-detail`}>
-												<td colSpan={batchSelecting ? 9 : 8} className="bg-slate-50 px-8 py-4">
+												<td colSpan={batchMode ? 8 : 7} className="bg-slate-50 px-8 py-4">
 													<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
 														{row.respondents.length > 0 ? (
 															sortRespondentsByResponse(row.respondents).map((r) => (
@@ -405,7 +374,7 @@ export function ResultsHeatmap({
 						<div
 							key={row.date}
 							className={`overflow-hidden rounded-xl border ${
-								batchSelecting && selectedDates.has(row.date)
+								batchMode && selectedDates.has(row.date)
 									? "border-emerald-300 bg-emerald-100"
 									: `border-slate-200 ${getHeatColor(row.score, maxScore)}`
 							}`}
@@ -415,7 +384,7 @@ export function ResultsHeatmap({
 								role="button"
 								tabIndex={0}
 								onClick={() => {
-									if (batchSelecting) {
+									if (batchMode) {
 										toggleDate(row.date);
 									} else {
 										toggleExpanded(row.date);
@@ -424,7 +393,7 @@ export function ResultsHeatmap({
 								onKeyDown={(e) => {
 									if (e.key === "Enter" || e.key === " ") {
 										e.preventDefault();
-										if (batchSelecting) {
+										if (batchMode) {
 											toggleDate(row.date);
 										} else {
 											toggleExpanded(row.date);
@@ -434,7 +403,7 @@ export function ResultsHeatmap({
 								className="flex w-full items-center justify-between p-4 text-left"
 							>
 								<div className="flex items-center gap-3">
-									{batchSelecting && (
+									{batchMode && (
 										<button
 											type="button"
 											onClick={(e) => {
@@ -506,12 +475,6 @@ export function ResultsHeatmap({
 											<span className="text-sm text-slate-400">No responses yet</span>
 										)}
 									</div>
-									<a
-										href={`/groups/${groupId}/events/new?date=${row.date}${requestId ? `&fromRequest=${requestId}` : ""}`}
-										className="mt-3 inline-block text-xs font-medium text-emerald-600 hover:text-emerald-700"
-									>
-										Create Event →
-									</a>
 								</div>
 							)}
 						</div>
@@ -519,7 +482,7 @@ export function ResultsHeatmap({
 				})}
 			</div>
 			{/* Mobile floating batch action bar */}
-			{batchMode && batchSelecting && selectedDates.size > 0 && (
+			{batchMode && selectedDates.size > 0 && (
 				<div className="fixed bottom-0 left-0 right-0 z-50 border-t border-slate-200 bg-white p-4 shadow-lg sm:hidden">
 					<div className="flex items-center justify-between">
 						<span className="text-sm font-medium text-slate-700">

--- a/e2e/components/results-heatmap.spec.ts
+++ b/e2e/components/results-heatmap.spec.ts
@@ -78,23 +78,16 @@ test.describe("ResultsHeatmap", () => {
 	test("Batch Mode — shows batch selection controls", async ({ page }) => {
 		await renderFixture(page, "results-heatmap", "Batch Mode");
 
-		// Batch mode should show the "Select Dates" button
-		await expect(
-			page.getByRole("button", { name: /Select Dates|Cancel Selection/i }),
-		).toBeVisible();
+		// Batch mode should show quick-select buttons (always visible)
+		await expect(page.getByRole("button", { name: "Select Top 5" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Select All" })).toBeVisible();
 	});
 
 	test("Batch Mode — select dates and create events", async ({ page, isMobile }) => {
 		test.skip(isMobile === true, "Desktop-only test");
 		await renderFixture(page, "results-heatmap", "Batch Mode");
 
-		// Enter selection mode
-		const selectButton = page.getByRole("button", { name: "Select Dates" });
-		if (await selectButton.isVisible()) {
-			await selectButton.click();
-		}
-
-		// Quick select buttons should appear
+		// Quick select buttons should be visible (batch selection is always active)
 		await expect(page.getByRole("button", { name: "Select Top 5" })).toBeVisible();
 		await expect(page.getByRole("button", { name: "Select All" })).toBeVisible();
 


### PR DESCRIPTION
Batch selection controls (Select Top 5, Select All, checkboxes) are now always visible on the availability results heatmap — no need to click 'Select Dates' to enter a selection mode.

## Changes
- Removed the toggle between selection/non-selection modes in the results heatmap
- Batch selection UI is always active when `onCreateEvents` prop is provided
- Updated E2E tests to match the new always-active batch selection behavior

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>