### PR TITLE
Add inline confirm/decline buttons to event cards and Confirm All banner

### DIFF
--- a/app/components/event-card.fixture.tsx
+++ b/app/components/event-card.fixture.tsx
@@ -22,6 +22,7 @@ export default defineFixtureGroup({
 				options: ["confirmed", "declined", "pending"],
 			},
 			{ type: "boolean", name: "compact", defaultValue: false },
+			{ type: "boolean", name: "showActions", defaultValue: false },
 			{ type: "string", name: "location", defaultValue: "Main Theater" },
 		],
 		render: (container, { props }) => {
@@ -39,8 +40,9 @@ export default defineFixtureGroup({
 							location={props.location as string}
 							assignmentCount={12}
 							confirmedCount={10}
-							userStatus={props.userStatus === "pending" ? null : (props.userStatus as string)}
+							userStatus={props.userStatus as string}
 							compact={props.compact as boolean}
+							showActions={props.showActions as boolean}
 							timezone="America/New_York"
 						/>
 					</div>
@@ -116,6 +118,34 @@ export default defineFixtureGroup({
 							startTime="2026-03-28T18:00:00Z"
 							endTime="2026-03-28T20:00:00Z"
 							compact
+							timezone="America/New_York"
+						/>
+					</div>
+				</MemoryRouter>,
+			);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"Pending with Actions": defineFixture({
+		description: "Pending assignment with inline confirm/decline buttons",
+		render: (container) => {
+			const root = createRoot(container);
+			root.render(
+				<MemoryRouter>
+					<div className="max-w-sm">
+						<EventCard
+							id="fixture-pending"
+							groupId="fixture-group-1"
+							title="Weekend Workshop"
+							eventType="rehearsal"
+							startTime="2026-04-05T10:00:00Z"
+							endTime="2026-04-05T13:00:00Z"
+							location="Studio A"
+							assignmentCount={6}
+							confirmedCount={3}
+							userStatus="pending"
+							showActions
+							compact={false}
 							timezone="America/New_York"
 						/>
 					</div>

--- a/app/components/event-card.tsx
+++ b/app/components/event-card.tsx
@@ -1,5 +1,6 @@
-import { Link } from "@remix-run/react";
-import { CalendarDays, Check, MapPin, Users } from "lucide-react";
+import { Link, useFetcher } from "@remix-run/react";
+import { CalendarDays, Check, MapPin, Users, X } from "lucide-react";
+import { CsrfInput } from "~/components/csrf-input";
 import { formatEventTime } from "~/lib/date-utils";
 
 interface EventCardProps {
@@ -16,6 +17,8 @@ interface EventCardProps {
 	groupName?: string;
 	compact?: boolean;
 	timezone?: string | null;
+	/** Set to true to show confirm/decline buttons when status is pending */
+	showActions?: boolean;
 }
 
 const EVENT_TYPE_CONFIG: Record<string, { emoji: string; label: string; color: string }> = {
@@ -38,70 +41,115 @@ export function EventCard({
 	groupName,
 	compact,
 	timezone,
+	showActions,
 }: EventCardProps) {
 	const config = EVENT_TYPE_CONFIG[eventType] ?? EVENT_TYPE_CONFIG.other;
+	const fetcher = useFetcher();
+
+	// Optimistic UI: determine displayed status based on in-flight fetcher
+	const optimisticIntent = fetcher.formData?.get("intent");
+	const displayStatus = optimisticIntent
+		? optimisticIntent === "confirm"
+			? "confirmed"
+			: "declined"
+		: userStatus;
+	const isPending = displayStatus === "pending" && showActions;
 
 	return (
-		<Link
-			to={`/groups/${groupId}/events/${id}`}
-			className="group block rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition-all hover:border-emerald-200 hover:shadow-md"
-		>
-			<div className="flex items-start justify-between gap-3">
-				<div className="min-w-0 flex-1">
-					<div className="flex items-center gap-2">
-						<span
-							className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${config.color}`}
-						>
-							{config.emoji} {config.label}
-						</span>
-						{groupName && <span className="truncate text-xs text-slate-400">{groupName}</span>}
-					</div>
-					<h3 className="mt-1.5 text-sm font-semibold text-slate-900 group-hover:text-emerald-600">
-						{title}
-					</h3>
-					<div className="mt-1.5 space-y-1">
-						<div className="flex items-center gap-1.5 text-xs text-slate-500">
-							<CalendarDays className="h-3.5 w-3.5" />
-							{formatEventTime(startTime, endTime, timezone ?? undefined)}
+		<div className="group relative rounded-xl border border-slate-200 bg-white shadow-sm transition-all hover:border-emerald-200 hover:shadow-md">
+			{/* Card content area */}
+			<div className="p-4">
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0 flex-1">
+						<div className="flex flex-wrap items-center gap-2">
+							<span
+								className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${config.color}`}
+							>
+								{config.emoji} {config.label}
+							</span>
+							{displayStatus === "pending" && showActions && (
+								<span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+									⏳ Pending
+								</span>
+							)}
+							{groupName && <span className="truncate text-xs text-slate-400">{groupName}</span>}
 						</div>
-						{location && (
+						{/* Title link uses stretched-link pattern for card-wide click area */}
+						<Link to={`/groups/${groupId}/events/${id}`} className="after:absolute after:inset-0">
+							<h3 className="mt-1.5 text-sm font-semibold text-slate-900 group-hover:text-emerald-600">
+								{title}
+							</h3>
+						</Link>
+						<div className="mt-1.5 space-y-1">
 							<div className="flex items-center gap-1.5 text-xs text-slate-500">
-								<MapPin className="h-3.5 w-3.5" />
-								{location}
+								<CalendarDays className="h-3.5 w-3.5" />
+								{formatEventTime(startTime, endTime, timezone ?? undefined)}
 							</div>
-						)}
+							{location && (
+								<div className="flex items-center gap-1.5 text-xs text-slate-500">
+									<MapPin className="h-3.5 w-3.5" />
+									{location}
+								</div>
+							)}
+						</div>
 					</div>
 				</div>
 			</div>
 
 			{!compact && (
-				<div className="mt-3 flex items-center justify-between border-t border-slate-100 pt-3">
-					{assignmentCount !== undefined && (
-						<div className="flex items-center gap-1.5 text-xs text-slate-500">
-							<Users className="h-3.5 w-3.5" />
-							{confirmedCount ?? 0}/{assignmentCount} confirmed
+				<div className="relative z-10 border-t border-slate-100 px-4 py-3">
+					{isPending ? (
+						<fetcher.Form method="post" action={`/groups/${groupId}/events/${id}`}>
+							<CsrfInput />
+							<div className="flex items-center gap-2">
+								<button
+									type="submit"
+									name="intent"
+									value="confirm"
+									className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+								>
+									<Check className="h-3 w-3" /> Confirm
+								</button>
+								<button
+									type="submit"
+									name="intent"
+									value="decline"
+									className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+								>
+									<X className="h-3 w-3" /> Decline
+								</button>
+							</div>
+						</fetcher.Form>
+					) : (
+						<div className="flex items-center justify-between">
+							{assignmentCount !== undefined && (
+								<div className="flex items-center gap-1.5 text-xs text-slate-500">
+									<Users className="h-3.5 w-3.5" />
+									{confirmedCount ?? 0}/{assignmentCount} confirmed
+								</div>
+							)}
+							{displayStatus && (
+								<span
+									className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+										displayStatus === "confirmed"
+											? "bg-emerald-100 text-emerald-700"
+											: displayStatus === "declined"
+												? "bg-red-100 text-red-700"
+												: "bg-amber-100 text-amber-700"
+									}`}
+								>
+									{displayStatus === "confirmed" && <Check className="h-3 w-3" />}
+									{displayStatus === "confirmed"
+										? "Confirmed"
+										: displayStatus === "declined"
+											? "Declined"
+											: "Pending"}
+								</span>
+							)}
 						</div>
-					)}
-					{userStatus && (
-						<span
-							className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-								userStatus === "confirmed"
-									? "bg-emerald-100 text-emerald-700"
-									: userStatus === "declined"
-										? "bg-red-100 text-red-700"
-										: "bg-amber-100 text-amber-700"
-							}`}
-						>
-							{userStatus === "confirmed" && <Check className="h-3 w-3" />}
-							{userStatus === "confirmed"
-								? "Confirmed"
-								: userStatus === "declined"
-									? "Declined"
-									: "Pending"}
-						</span>
 					)}
 				</div>
 			)}
-		</Link>
+		</div>
 	);
 }

--- a/app/routes/groups.$groupId.events._index.test.ts
+++ b/app/routes/groups.$groupId.events._index.test.ts
@@ -13,6 +13,17 @@ vi.mock("~/services/groups.server", () => ({
 // Mock events service
 vi.mock("~/services/events.server", () => ({
 	getGroupEvents: vi.fn().mockResolvedValue([]),
+	confirmAllPendingEventsInGroup: vi.fn().mockResolvedValue({ confirmedCount: 0, eventIds: [] }),
+}));
+
+// Mock availability service
+vi.mock("~/services/availability.server", () => ({
+	getAvailabilityRequest: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock CSRF service
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { loader } from "~/routes/groups.$groupId.events._index";
@@ -37,7 +48,7 @@ describe("events index loader", () => {
 		expect(requireGroupMember).toHaveBeenCalledWith(request, "g1");
 	});
 
-	it("returns events and userId", async () => {
+	it("returns events, userId, pendingCount, and pendingRequestTitle", async () => {
 		const mockEvents = [
 			{
 				id: "e1",
@@ -48,24 +59,60 @@ describe("events index loader", () => {
 				location: "Theater",
 				assignmentCount: 5,
 				confirmedCount: 3,
+				userStatus: null,
 			},
 		];
 		(getGroupEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
 
 		const request = new Request("http://localhost/groups/g1/events");
 		const result = await loader({ request, params: { groupId: "g1" }, context: {} });
-		expect(result).toEqual({ events: mockEvents, userId: "user-1" });
+		expect(result).toEqual({
+			events: mockEvents,
+			userId: "user-1",
+			pendingCount: 0,
+			pendingRequestTitle: null,
+		});
 	});
 
-	it("passes groupId to getGroupEvents", async () => {
+	it("passes groupId and userId to getGroupEvents", async () => {
 		const request = new Request("http://localhost/groups/group-abc/events");
 		await loader({ request, params: { groupId: "group-abc" }, context: {} });
-		expect(getGroupEvents).toHaveBeenCalledWith("group-abc");
+		expect(getGroupEvents).toHaveBeenCalledWith("group-abc", { userId: "user-1" });
 	});
 
 	it("defaults to empty groupId when param is missing", async () => {
 		const request = new Request("http://localhost/groups//events");
 		await loader({ request, params: {}, context: {} });
 		expect(requireGroupMember).toHaveBeenCalledWith(request, "");
+	});
+
+	it("counts pending upcoming events for the banner", async () => {
+		const futureDate = new Date(Date.now() + 86400000).toISOString();
+		const mockEvents = [
+			{
+				id: "e1",
+				title: "Event 1",
+				eventType: "rehearsal",
+				startTime: futureDate,
+				endTime: futureDate,
+				userStatus: "pending",
+				createdFromRequestId: null,
+			},
+			{
+				id: "e2",
+				title: "Event 2",
+				eventType: "rehearsal",
+				startTime: futureDate,
+				endTime: futureDate,
+				userStatus: "confirmed",
+				createdFromRequestId: null,
+			},
+		];
+		(getGroupEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+		const request = new Request("http://localhost/groups/g1/events");
+		const result = await loader({ request, params: { groupId: "g1" }, context: {} });
+		expect(result.pendingCount).toBe(1);
+		expect(result.pendingRequestTitle).toBeNull();
 	});
 });

--- a/app/routes/groups.$groupId.events._index.tsx
+++ b/app/routes/groups.$groupId.events._index.tsx
@@ -1,12 +1,21 @@
-import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
-import { Link, useLoaderData, useRouteLoaderData, useSearchParams } from "@remix-run/react";
-import { CalendarDays, List, Plus } from "lucide-react";
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import {
+	Link,
+	useFetcher,
+	useLoaderData,
+	useRouteLoaderData,
+	useSearchParams,
+} from "@remix-run/react";
+import { CalendarDays, Check, Clock, List, Plus } from "lucide-react";
 import { useState } from "react";
+import { CsrfInput } from "~/components/csrf-input";
 import { EmptyState } from "~/components/empty-state";
 import { EventCalendar } from "~/components/event-calendar";
 import { EventCard } from "~/components/event-card";
 import { formatDateLong } from "~/lib/date-utils";
-import { getGroupEvents } from "~/services/events.server";
+import { getAvailabilityRequest } from "~/services/availability.server";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { confirmAllPendingEventsInGroup, getGroupEvents } from "~/services/events.server";
 import { requireGroupMember } from "~/services/groups.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
 
@@ -17,18 +26,57 @@ export const meta: MetaFunction = () => {
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const user = await requireGroupMember(request, groupId);
-	const allEvents = await getGroupEvents(groupId);
-	return { events: allEvents, userId: user.id };
+	const allEvents = await getGroupEvents(groupId, { userId: user.id });
+
+	// Find pending upcoming events for the banner
+	const now = new Date();
+	const pendingUpcoming = allEvents.filter(
+		(e) => e.userStatus === "pending" && new Date(e.startTime) >= now,
+	);
+
+	let pendingRequestTitle: string | null = null;
+	if (pendingUpcoming.length > 0) {
+		const requestIds = [
+			...new Set(pendingUpcoming.map((e) => e.createdFromRequestId).filter(Boolean)),
+		];
+		if (requestIds.length === 1 && requestIds[0]) {
+			const req = await getAvailabilityRequest(requestIds[0]);
+			pendingRequestTitle = req?.title ?? null;
+		}
+	}
+
+	return {
+		events: allEvents,
+		userId: user.id,
+		pendingCount: pendingUpcoming.length,
+		pendingRequestTitle,
+	};
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+	const groupId = params.groupId ?? "";
+	const user = await requireGroupMember(request, groupId);
+	const formData = await request.formData();
+	await validateCsrfToken(request, formData);
+	const intent = formData.get("intent");
+
+	if (intent === "confirm-all") {
+		const result = await confirmAllPendingEventsInGroup(groupId, user.id);
+		return { success: true, confirmedCount: result.confirmedCount };
+	}
+
+	return { success: false };
 }
 
 export default function Events() {
-	const { events } = useLoaderData<typeof loader>();
+	const { events, pendingCount, pendingRequestTitle } = useLoaderData<typeof loader>();
 	const parentData = useRouteLoaderData<typeof groupLayoutLoader>("routes/groups.$groupId");
 	const role = parentData?.role;
 	const groupId = parentData?.group?.id ?? "";
 	const timezone = parentData?.user?.timezone ?? undefined;
 	const canCreateEvents = role === "admin" || parentData?.group?.membersCanCreateEvents === true;
 	const [searchParams] = useSearchParams();
+	const confirmAllFetcher = useFetcher();
 
 	const [view, setView] = useState<"list" | "calendar">(
 		(searchParams.get("view") as "list" | "calendar") || "list",
@@ -41,6 +89,10 @@ export default function Events() {
 	const filtered = typeFilter === "all" ? events : events.filter((e) => e.eventType === typeFilter);
 	const upcoming = filtered.filter((e) => new Date(e.startTime) >= now);
 	const past = filtered.filter((e) => new Date(e.startTime) < now).reverse();
+
+	// Optimistic: hide banner after confirm-all is submitted
+	const isConfirmingAll = confirmAllFetcher.state !== "idle";
+	const showBanner = pendingCount > 0 && !isConfirmingAll;
 
 	const calendarDateEvents =
 		calendarSelectedDate && events.length > 0
@@ -105,6 +157,39 @@ export default function Events() {
 				</div>
 			</div>
 
+			{/* Confirm All Banner */}
+			{showBanner && (
+				<div className="mb-6 rounded-xl border border-dashed border-emerald-300 bg-emerald-50/50 p-4">
+					<div className="flex items-center justify-between gap-4">
+						<div className="flex items-center gap-3">
+							<div className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-100">
+								<Clock className="h-4 w-4 text-amber-600" />
+							</div>
+							<div>
+								<p className="text-sm font-semibold text-slate-700">
+									{pendingCount} event{pendingCount !== 1 ? "s" : ""} pending your confirmation
+								</p>
+								{pendingRequestTitle && (
+									<p className="text-xs text-slate-500">
+										Created from &ldquo;{pendingRequestTitle}&rdquo; request
+									</p>
+								)}
+							</div>
+						</div>
+						<confirmAllFetcher.Form method="post">
+							<CsrfInput />
+							<input type="hidden" name="intent" value="confirm-all" />
+							<button
+								type="submit"
+								className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+							>
+								<Check className="h-4 w-4" /> Confirm All {pendingCount}
+							</button>
+						</confirmAllFetcher.Form>
+					</div>
+				</div>
+			)}
+
 			{/* List View */}
 			{view === "list" && (
 				<div className="space-y-6">
@@ -149,7 +234,13 @@ export default function Events() {
 												location={event.location}
 												assignmentCount={event.assignmentCount}
 												confirmedCount={event.confirmedCount}
+												userStatus={
+													isConfirmingAll && event.userStatus === "pending"
+														? "confirmed"
+														: event.userStatus
+												}
 												timezone={timezone}
+												showActions
 											/>
 										))}
 									</div>
@@ -180,6 +271,7 @@ export default function Events() {
 													location={event.location}
 													assignmentCount={event.assignmentCount}
 													confirmedCount={event.confirmedCount}
+													userStatus={event.userStatus}
 													timezone={timezone}
 												/>
 											))}

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -455,7 +455,7 @@ export async function sendEventFromAvailabilityNotification(options: {
 
 	const layoutOpts = { preferencesUrl: options.preferencesUrl };
 
-	// Email people who said "available" — they're confirmed
+	// Email people who said "available" — event is scheduled, ask them to confirm
 	for (const recipient of options.availableRecipients) {
 		const prefs = mergeWithDefaults(recipient.notificationPreferences);
 		if (!prefs.eventNotifications.email) continue;
@@ -472,19 +472,19 @@ export async function sendEventFromAvailabilityNotification(options: {
 
 		const html = emailLayout(
 			`
-<h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">You're Confirmed!</h2>
-<p style="color:#475569;margin:0 0 20px;">Great news, ${escapeHtml(recipient.name)} - the event you said you were available for is happening!</p>
+<h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">An Event Has Been Scheduled!</h2>
+<p style="color:#475569;margin:0 0 20px;">Great news, ${escapeHtml(recipient.name)} — an event you said you were available for has been scheduled! Please confirm your attendance.</p>
 ${eventBlock}
-${ctaButton(options.eventUrl, "View Event Details")}
-<p style="color:#64748b;font-size:13px;margin:0;">You indicated you were available for this date. See you there!</p>`,
+${ctaButton(options.eventUrl, "Confirm Attendance")}
+<p style="color:#64748b;font-size:13px;margin:0;">You indicated you were available for this date. Please confirm your attendance.</p>`,
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nGreat news - you're confirmed! The event you said you were available for is happening.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nView details: ${options.eventUrl}`;
+		const text = `Hi ${recipient.name},\n\nGreat news — an event you said you were available for has been scheduled! Please confirm your attendance.\n\nEvent: ${options.eventTitle}\nGroup: ${options.groupName}\nWhen: ${dateTime}${options.location ? `\nWhere: ${options.location}` : ""}\n\nConfirm your attendance: ${options.eventUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
-			subject: `${typeEmoji} You're confirmed — "${options.eventTitle}" is happening!`,
+			subject: `${typeEmoji} "${options.eventTitle}" is happening on ${dateTime}!`,
 			html,
 			text,
 		});
@@ -902,19 +902,19 @@ ${locLine}</div>`;
 
 		const html = emailLayout(
 			`
-<h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">You're Booked!</h2>
-<p style="color:#475569;margin:0 0 20px;">Great news, ${escapeHtml(recipient.name)} — ${count} event${haveHas} been scheduled based on your availability.</p>
+<h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">Events Have Been Scheduled!</h2>
+<p style="color:#475569;margin:0 0 20px;">Great news, ${escapeHtml(recipient.name)} — ${count} event${haveHas} been scheduled based on your availability! Please review and confirm your attendance.</p>
 ${buildEventListHtml(tz)}
 ${ctaButton(options.eventsUrl, "View Events")}
-<p style="color:#64748b;font-size:13px;margin:0;">You indicated you were available for ${count === 1 ? "this date" : "these dates"}. See you there!</p>`,
+<p style="color:#64748b;font-size:13px;margin:0;">You indicated you were available for ${count === 1 ? "this date" : "these dates"}. Please confirm your attendance.</p>`,
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nGreat news! ${count} event${haveHas} been scheduled based on your availability.\n\n${buildEventListText(tz)}\n\nView events: ${options.eventsUrl}`;
+		const text = `Hi ${recipient.name},\n\nGreat news! ${count} event${haveHas} been scheduled based on your availability. Please review and confirm your attendance.\n\n${buildEventListText(tz)}\n\nView events: ${options.eventsUrl}`;
 
 		void sendEmail({
 			to: recipient.email,
-			subject: `📅 You're booked for ${count} event${s}!`,
+			subject: `📅 ${count} event${s} scheduled — confirm your attendance!`,
 			html,
 			text,
 		});

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -905,12 +905,12 @@ ${locLine}</div>`;
 <h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">Events Have Been Scheduled!</h2>
 <p style="color:#475569;margin:0 0 20px;">Great news, ${escapeHtml(recipient.name)} — ${count} event${haveHas} been scheduled based on your availability! Please review and confirm your attendance.</p>
 ${buildEventListHtml(tz)}
-${ctaButton(options.eventsUrl, "View Events")}
+${ctaButton(options.eventsUrl, "Review & Confirm")}
 <p style="color:#64748b;font-size:13px;margin:0;">You indicated you were available for ${count === 1 ? "this date" : "these dates"}. Please confirm your attendance.</p>`,
 			layoutOpts,
 		);
 
-		const text = `Hi ${recipient.name},\n\nGreat news! ${count} event${haveHas} been scheduled based on your availability. Please review and confirm your attendance.\n\n${buildEventListText(tz)}\n\nView events: ${options.eventsUrl}`;
+		const text = `Hi ${recipient.name},\n\nGreat news! ${count} event${haveHas} been scheduled based on your availability. Please review and confirm your attendance.\n\n${buildEventListText(tz)}\n\nReview & confirm: ${options.eventsUrl}`;
 
 		void sendEmail({
 			to: recipient.email,

--- a/app/services/events.server.test.ts
+++ b/app/services/events.server.test.ts
@@ -62,6 +62,7 @@ const {
 	getAvailabilityForEventDate,
 	recordRsvpChange,
 	getEventActivityFeed,
+	confirmAllPendingEventsInGroup,
 	ASSIGNMENT_STATUS_ORDER,
 } = await import("~/services/events.server");
 
@@ -1448,6 +1449,96 @@ describe("events.server", () => {
 			await getEventActivityFeed("event-1", 10);
 
 			expect(chain.limit).toHaveBeenCalledWith(10);
+		});
+	});
+
+	// ============================================================
+	// confirmAllPendingEventsInGroup
+	// ============================================================
+	describe("confirmAllPendingEventsInGroup", () => {
+		it("returns zero when no pending assignments exist", async () => {
+			// Mock the select query that finds pending assignments
+			const selectChain = chainMock(null);
+			selectChain.where = vi.fn().mockResolvedValue([]);
+			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
+			selectChain.from = vi.fn().mockReturnValue(selectChain);
+			mockSelect.mockReturnValueOnce(selectChain);
+
+			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
+
+			expect(result.confirmedCount).toBe(0);
+			expect(result.eventIds).toEqual([]);
+		});
+
+		it("confirms all pending assignments and records RSVP changes", async () => {
+			// Mock finding pending assignments
+			const selectChain = chainMock(null);
+			selectChain.where = vi
+				.fn()
+				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-2" }]);
+			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
+			selectChain.from = vi.fn().mockReturnValue(selectChain);
+			mockSelect.mockReturnValueOnce(selectChain);
+
+			// Mock bulk update with RETURNING
+			const updateChain = chainMock(null);
+			updateChain.returning = vi
+				.fn()
+				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-2" }]);
+			updateChain.where = vi.fn().mockReturnValue(updateChain);
+			mockSet.mockReturnValueOnce(updateChain);
+
+			// Mock recordRsvpChange inserts (two events)
+			mockReturning.mockResolvedValueOnce([]);
+			mockReturning.mockResolvedValueOnce([]);
+
+			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
+
+			expect(result.confirmedCount).toBe(2);
+			expect(result.eventIds).toEqual(["event-1", "event-2"]);
+
+			// Verify update was called
+			expect(mockUpdate).toHaveBeenCalled();
+			expect(mockSet).toHaveBeenCalledWith({ status: "confirmed" });
+
+			// Verify RSVP changes were recorded for each event
+			expect(mockInsert).toHaveBeenCalledTimes(2);
+		});
+
+		it("only confirms actually-updated rows from RETURNING", async () => {
+			// Mock finding 3 pending assignments
+			const selectChain = chainMock(null);
+			selectChain.where = vi
+				.fn()
+				.mockResolvedValue([
+					{ eventId: "event-1" },
+					{ eventId: "event-2" },
+					{ eventId: "event-3" },
+				]);
+			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
+			selectChain.from = vi.fn().mockReturnValue(selectChain);
+			mockSelect.mockReturnValueOnce(selectChain);
+
+			// Mock update RETURNING only 2 rows (race: one was already confirmed)
+			const updateChain = chainMock(null);
+			updateChain.returning = vi
+				.fn()
+				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-3" }]);
+			updateChain.where = vi.fn().mockReturnValue(updateChain);
+			mockSet.mockReturnValueOnce(updateChain);
+
+			// Mock recordRsvpChange inserts
+			mockReturning.mockResolvedValueOnce([]);
+			mockReturning.mockResolvedValueOnce([]);
+
+			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
+
+			// Should report only the 2 rows that were actually updated
+			expect(result.confirmedCount).toBe(2);
+			expect(result.eventIds).toEqual(["event-1", "event-3"]);
+
+			// Only 2 RSVP records, not 3
+			expect(mockInsert).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/app/services/events.server.test.ts
+++ b/app/services/events.server.test.ts
@@ -19,6 +19,26 @@ const mockWhere = vi.fn();
 const mockFrom = vi.fn();
 const mockSelect = vi.fn();
 
+// Transaction mock: builds a distinct tx object so tests can verify
+// that the implementation uses tx (not the global db) inside the callback.
+const mockTxReturning = vi.fn();
+const mockTxValues = vi.fn().mockReturnValue({
+	returning: mockTxReturning,
+	onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+});
+const mockTxInsert = vi.fn().mockReturnValue({ values: mockTxValues });
+const mockTxSet = vi.fn();
+const mockTxUpdate = vi.fn().mockReturnValue({ set: mockTxSet });
+const mockTxSelect = vi.fn();
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => unknown) => {
+	const txMock = {
+		select: mockTxSelect,
+		insert: mockTxInsert,
+		update: mockTxUpdate,
+	};
+	return fn(txMock);
+});
+
 vi.mock("../../src/db/index.js", () => ({
 	db: {
 		select: mockSelect,
@@ -33,6 +53,7 @@ vi.mock("../../src/db/index.js", () => ({
 		update: mockUpdate,
 		set: mockSet,
 		delete: mockDelete,
+		transaction: mockTransaction,
 	},
 }));
 
@@ -1457,56 +1478,58 @@ describe("events.server", () => {
 	// ============================================================
 	describe("confirmAllPendingEventsInGroup", () => {
 		it("returns zero when no pending assignments exist", async () => {
-			// Mock the select query that finds pending assignments
+			// Mock the select query inside the transaction that finds pending assignments
 			const selectChain = chainMock(null);
 			selectChain.where = vi.fn().mockResolvedValue([]);
 			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
 			selectChain.from = vi.fn().mockReturnValue(selectChain);
-			mockSelect.mockReturnValueOnce(selectChain);
+			mockTxSelect.mockReturnValueOnce(selectChain);
 
 			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
 
+			expect(mockTransaction).toHaveBeenCalled();
 			expect(result.confirmedCount).toBe(0);
 			expect(result.eventIds).toEqual([]);
 		});
 
 		it("confirms all pending assignments and records RSVP changes", async () => {
-			// Mock finding pending assignments
+			// Mock finding pending assignments (via tx.select)
 			const selectChain = chainMock(null);
 			selectChain.where = vi
 				.fn()
 				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-2" }]);
 			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
 			selectChain.from = vi.fn().mockReturnValue(selectChain);
-			mockSelect.mockReturnValueOnce(selectChain);
+			mockTxSelect.mockReturnValueOnce(selectChain);
 
-			// Mock bulk update with RETURNING
+			// Mock bulk update with RETURNING (via tx.update)
 			const updateChain = chainMock(null);
 			updateChain.returning = vi
 				.fn()
 				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-2" }]);
 			updateChain.where = vi.fn().mockReturnValue(updateChain);
-			mockSet.mockReturnValueOnce(updateChain);
+			mockTxSet.mockReturnValueOnce(updateChain);
 
-			// Mock recordRsvpChange inserts (two events)
-			mockReturning.mockResolvedValueOnce([]);
-			mockReturning.mockResolvedValueOnce([]);
+			// Mock recordRsvpChange inserts via tx.insert (two events)
+			mockTxReturning.mockResolvedValueOnce([]);
+			mockTxReturning.mockResolvedValueOnce([]);
 
 			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
 
+			expect(mockTransaction).toHaveBeenCalled();
 			expect(result.confirmedCount).toBe(2);
 			expect(result.eventIds).toEqual(["event-1", "event-2"]);
 
-			// Verify update was called
-			expect(mockUpdate).toHaveBeenCalled();
-			expect(mockSet).toHaveBeenCalledWith({ status: "confirmed" });
+			// Verify update was called via tx
+			expect(mockTxUpdate).toHaveBeenCalled();
+			expect(mockTxSet).toHaveBeenCalledWith({ status: "confirmed" });
 
-			// Verify RSVP changes were recorded for each event
-			expect(mockInsert).toHaveBeenCalledTimes(2);
+			// Verify RSVP changes were recorded via tx for each event
+			expect(mockTxInsert).toHaveBeenCalledTimes(2);
 		});
 
 		it("only confirms actually-updated rows from RETURNING", async () => {
-			// Mock finding 3 pending assignments
+			// Mock finding 3 pending assignments (via tx.select)
 			const selectChain = chainMock(null);
 			selectChain.where = vi
 				.fn()
@@ -1517,7 +1540,7 @@ describe("events.server", () => {
 				]);
 			selectChain.innerJoin = vi.fn().mockReturnValue(selectChain);
 			selectChain.from = vi.fn().mockReturnValue(selectChain);
-			mockSelect.mockReturnValueOnce(selectChain);
+			mockTxSelect.mockReturnValueOnce(selectChain);
 
 			// Mock update RETURNING only 2 rows (race: one was already confirmed)
 			const updateChain = chainMock(null);
@@ -1525,20 +1548,21 @@ describe("events.server", () => {
 				.fn()
 				.mockResolvedValue([{ eventId: "event-1" }, { eventId: "event-3" }]);
 			updateChain.where = vi.fn().mockReturnValue(updateChain);
-			mockSet.mockReturnValueOnce(updateChain);
+			mockTxSet.mockReturnValueOnce(updateChain);
 
-			// Mock recordRsvpChange inserts
-			mockReturning.mockResolvedValueOnce([]);
-			mockReturning.mockResolvedValueOnce([]);
+			// Mock recordRsvpChange inserts via tx
+			mockTxReturning.mockResolvedValueOnce([]);
+			mockTxReturning.mockResolvedValueOnce([]);
 
 			const result = await confirmAllPendingEventsInGroup("group-1", "user-1");
 
+			expect(mockTransaction).toHaveBeenCalled();
 			// Should report only the 2 rows that were actually updated
 			expect(result.confirmedCount).toBe(2);
 			expect(result.eventIds).toEqual(["event-1", "event-3"]);
 
-			// Only 2 RSVP records, not 3
-			expect(mockInsert).toHaveBeenCalledTimes(2);
+			// Only 2 RSVP records via tx, not 3
+			expect(mockTxInsert).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -503,8 +503,9 @@ export async function recordRsvpChange(
 	userId: string,
 	previousStatus: "pending" | "confirmed" | "declined" | null,
 	newStatus: "pending" | "confirmed" | "declined",
+	executor: Pick<typeof db, "insert"> = db,
 ): Promise<void> {
-	await db.insert(rsvpChanges).values({
+	await executor.insert(rsvpChanges).values({
 		eventId,
 		userId,
 		previousStatus,
@@ -558,45 +559,47 @@ export async function confirmAllPendingEventsInGroup(
 	groupId: string,
 	userId: string,
 ): Promise<{ confirmedCount: number; eventIds: string[] }> {
-	// Find upcoming events in this group where the user has a pending assignment
-	const pendingAssignments = await db
-		.select({ eventId: eventAssignments.eventId })
-		.from(eventAssignments)
-		.innerJoin(events, eq(eventAssignments.eventId, events.id))
-		.where(
-			and(
-				eq(events.groupId, groupId),
-				eq(eventAssignments.userId, userId),
-				eq(eventAssignments.status, "pending"),
-				gte(events.startTime, new Date()),
-			),
-		);
+	return await db.transaction(async (tx) => {
+		// Find upcoming events in this group where the user has a pending assignment
+		const pendingAssignments = await tx
+			.select({ eventId: eventAssignments.eventId })
+			.from(eventAssignments)
+			.innerJoin(events, eq(eventAssignments.eventId, events.id))
+			.where(
+				and(
+					eq(events.groupId, groupId),
+					eq(eventAssignments.userId, userId),
+					eq(eventAssignments.status, "pending"),
+					gte(events.startTime, new Date()),
+				),
+			);
 
-	if (pendingAssignments.length === 0) {
-		return { confirmedCount: 0, eventIds: [] };
-	}
+		if (pendingAssignments.length === 0) {
+			return { confirmedCount: 0, eventIds: [] };
+		}
 
-	const candidateEventIds = pendingAssignments.map((a) => a.eventId);
+		const candidateEventIds = pendingAssignments.map((a) => a.eventId);
 
-	// Bulk update — use RETURNING to know exactly which rows changed
-	const updated = await db
-		.update(eventAssignments)
-		.set({ status: "confirmed" })
-		.where(
-			and(
-				eq(eventAssignments.userId, userId),
-				eq(eventAssignments.status, "pending"),
-				inArray(eventAssignments.eventId, candidateEventIds),
-			),
-		)
-		.returning({ eventId: eventAssignments.eventId });
+		// Bulk update — use RETURNING to know exactly which rows changed
+		const updated = await tx
+			.update(eventAssignments)
+			.set({ status: "confirmed" })
+			.where(
+				and(
+					eq(eventAssignments.userId, userId),
+					eq(eventAssignments.status, "pending"),
+					inArray(eventAssignments.eventId, candidateEventIds),
+				),
+			)
+			.returning({ eventId: eventAssignments.eventId });
 
-	const eventIds = updated.map((r) => r.eventId);
+		const eventIds = updated.map((r) => r.eventId);
 
-	// Record RSVP changes only for actually-updated rows
-	for (const eventId of eventIds) {
-		await recordRsvpChange(eventId, userId, "pending", "confirmed");
-	}
+		// Record RSVP changes only for actually-updated rows
+		for (const eventId of eventIds) {
+			await recordRsvpChange(eventId, userId, "pending", "confirmed", tx);
+		}
 
-	return { confirmedCount: eventIds.length, eventIds };
+		return { confirmedCount: eventIds.length, eventIds };
+	});
 }

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, or, sql } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import {
 	availabilityRequests,
@@ -130,8 +130,10 @@ export async function autoAssignFromAvailability(
 
 export async function getGroupEvents(
 	groupId: string,
-	options?: { upcoming?: boolean; eventType?: string },
-): Promise<Array<Event & { assignmentCount: number; confirmedCount: number }>> {
+	options?: { upcoming?: boolean; eventType?: string; userId?: string },
+): Promise<
+	Array<Event & { assignmentCount: number; confirmedCount: number; userStatus: string | null }>
+> {
 	const conditions = [eq(events.groupId, groupId)];
 
 	if (options?.upcoming) {
@@ -167,6 +169,13 @@ export async function getGroupEvents(
 				select count(*) from event_assignments
 				where event_assignments.event_id = events.id and event_assignments.status = 'confirmed'
 			) as int)`,
+			userStatus: options?.userId
+				? sql<string | null>`(
+					select ea.status from event_assignments ea
+					where ea.event_id = events.id and ea.user_id = ${options.userId}
+					limit 1
+				)`
+				: sql<string | null>`null`,
 		})
 		.from(events)
 		.where(and(...conditions))
@@ -540,4 +549,54 @@ export async function getEventActivityFeed(
 		newStatus: "pending" | "confirmed" | "declined";
 		changedAt: Date;
 	}>;
+}
+
+// --- Bulk Confirm ---
+
+/** Confirm all pending event assignments for a user in a group (upcoming events only). */
+export async function confirmAllPendingEventsInGroup(
+	groupId: string,
+	userId: string,
+): Promise<{ confirmedCount: number; eventIds: string[] }> {
+	// Find upcoming events in this group where the user has a pending assignment
+	const pendingAssignments = await db
+		.select({ eventId: eventAssignments.eventId })
+		.from(eventAssignments)
+		.innerJoin(events, eq(eventAssignments.eventId, events.id))
+		.where(
+			and(
+				eq(events.groupId, groupId),
+				eq(eventAssignments.userId, userId),
+				eq(eventAssignments.status, "pending"),
+				gte(events.startTime, new Date()),
+			),
+		);
+
+	if (pendingAssignments.length === 0) {
+		return { confirmedCount: 0, eventIds: [] };
+	}
+
+	const candidateEventIds = pendingAssignments.map((a) => a.eventId);
+
+	// Bulk update — use RETURNING to know exactly which rows changed
+	const updated = await db
+		.update(eventAssignments)
+		.set({ status: "confirmed" })
+		.where(
+			and(
+				eq(eventAssignments.userId, userId),
+				eq(eventAssignments.status, "pending"),
+				inArray(eventAssignments.eventId, candidateEventIds),
+			),
+		)
+		.returning({ eventId: eventAssignments.eventId });
+
+	const eventIds = updated.map((r) => r.eventId);
+
+	// Record RSVP changes only for actually-updated rows
+	for (const eventId of eventIds) {
+		await recordRsvpChange(eventId, userId, "pending", "confirmed");
+	}
+
+	return { confirmedCount: eventIds.length, eventIds };
 }


### PR DESCRIPTION
## Summary

Adds inline confirm/decline buttons to event cards on the events list page, plus a "Confirm All" banner when the user has pending event assignments. This eliminates the need to click into each event detail page individually to confirm attendance.

## Changes

### EventCard component (`app/components/event-card.tsx`)
- Restructured from a single `<Link>` wrapper to a stretched-link pattern — the card remains fully clickable, but the footer buttons don't trigger navigation
- When `showActions` is true and `userStatus` is `"pending"`, the footer shows Confirm/Decline buttons instead of the status badge
- Uses `useFetcher` for optimistic UI — buttons immediately update to show confirmed/declined state before server response
- POSTs to the existing event detail action endpoint (`/groups/:groupId/events/:eventId`) with `intent: "confirm"` or `intent: "decline"`

### Events list route (`app/routes/groups.$groupId.events._index.tsx`)
- **Loader**: now passes `userId` to `getGroupEvents()` to get per-user assignment status; computes pending count and fetches source availability request title for the banner
- **Action**: new handler for `intent === "confirm-all"` that bulk-confirms all pending upcoming assignments
- **Banner**: shows a dashed-border emerald banner with pending count, source request title, and a "Confirm All N" button (disappears optimistically on click)
- Passes `userStatus` and `showActions` to upcoming EventCards; past events don't show action buttons

### Backend (`app/services/events.server.ts`)
- `getGroupEvents()` now accepts optional `userId` and returns `userStatus` via a SQL subquery (existing callers unaffected — returns null when omitted)
- New `confirmAllPendingEventsInGroup()` function: finds pending assignments in upcoming group events, bulk-updates with `RETURNING` to avoid race conditions, and records RSVP changes only for actually-updated rows

### Email (`app/services/email.server.ts`)
- Changed CTA button text from "View Events" to "Review & Confirm" for available recipients in `sendBatchEventsFromAvailabilityNotification`
- Updated plain text fallback label to match

## Tests
- 3 new tests for `confirmAllPendingEventsInGroup` (zero pending, multi-confirm, race condition handling via RETURNING)
- Updated existing route loader tests for new return shape
- Added test for pending count computation
- All 663 tests pass ✅