### PR TITLE
Add inline confirm/decline buttons to dashboard EventCards

### DIFF
--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -138,9 +138,11 @@ export default function Dashboard() {
 								endTime={event.endTime as unknown as string}
 								location={event.location}
 								groupName={event.groupName}
+								assignmentCount={event.assignmentCount}
+								confirmedCount={event.confirmedCount}
 								userStatus={event.userStatus}
 								timezone={user.timezone}
-								compact
+								showActions
 							/>
 						))}
 					</div>

--- a/app/services/dashboard.server.ts
+++ b/app/services/dashboard.server.ts
@@ -45,7 +45,15 @@ export async function getDashboardData(userId: string) {
 				createdAt: events.createdAt,
 				updatedAt: events.updatedAt,
 				groupName: groups.name,
-				userStatus: sql<string | null>`(
+				assignmentCount: sql<number>`cast((
+					select count(*) from event_assignments
+					where event_assignments.event_id = ${events.id}
+				) as int)`,
+			confirmedCount: sql<number>`cast((
+					select count(*) from event_assignments
+					where event_assignments.event_id = ${events.id} and event_assignments.status = 'confirmed'
+				) as int)`,
+			userStatus: sql<string | null>`(
 					select ea.status from event_assignments ea
 					where ea.event_id = ${events.id} and ea.user_id = ${userId}
 					limit 1


### PR DESCRIPTION
## Summary

Adds inline confirm/decline buttons to EventCards on the dashboard page, matching the UX already shipped on the events list page.

### Changes

**`app/routes/dashboard.tsx`**
- Removed `compact` prop from EventCard — the full card footer now renders
- Added `showActions` prop — pending events show Confirm/Decline buttons
- Pass `assignmentCount` and `confirmedCount` for the X/Y confirmed display

**`app/services/dashboard.server.ts`**
- Added `assignmentCount` and `confirmedCount` subqueries to the upcoming events query

### How it works
The EventCard component already handles everything (useFetcher, optimistic UI, CSRF). The fetcher POSTs directly to `/groups/$groupId/events/$eventId`, so it works from any page.

### Quality gates
- ✅ `tsc --noEmit` passes
- ✅ All 663 vitest tests pass