### PR TITLE
Collapse per-event pending confirmations into one card per group

### DIFF
--- a/app/components/pending-group-card.fixture.tsx
+++ b/app/components/pending-group-card.fixture.tsx
@@ -1,0 +1,63 @@
+import { defineFixture, defineFixtureGroup } from "@vscode/component-explorer";
+import { createRoot } from "react-dom/client";
+import { createMemoryRouter, type RouteObject, RouterProvider } from "react-router-dom";
+import { PendingGroupCard } from "./pending-group-card";
+import "~/tailwind.css";
+
+function createRouter(element: React.ReactElement): ReturnType<typeof createMemoryRouter> {
+	const routes: RouteObject[] = [
+		{ path: "/", element },
+		{ path: "/groups/:groupId/events", element: <div>Events page</div> },
+	];
+	return createMemoryRouter(routes);
+}
+
+export default defineFixtureGroup({
+	Interactive: defineFixture({
+		description: "Pending group confirmation card with configurable props",
+		properties: [
+			{ type: "string", name: "groupName", defaultValue: "Improv Comedy Group" },
+			{ type: "number", name: "count", defaultValue: 3 },
+		],
+		render: (container, { props }) => {
+			const root = createRoot(container);
+			const router = createRouter(
+				<div className="max-w-md">
+					<PendingGroupCard
+						groupId="fixture-group-1"
+						groupName={props.groupName as string}
+						count={props.count as number}
+					/>
+				</div>,
+			);
+			root.render(<RouterProvider router={router} />);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"Single Event": defineFixture({
+		description: "Singular 'event needs' text when count is 1",
+		render: (container) => {
+			const root = createRoot(container);
+			const router = createRouter(
+				<div className="max-w-md">
+					<PendingGroupCard groupId="fixture-group-1" groupName="Thursday Night Jam" count={1} />
+				</div>,
+			);
+			root.render(<RouterProvider router={router} />);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+	"Multiple Events": defineFixture({
+		description: "Plural 'events need' text when count is greater than 1",
+		render: (container) => {
+			const root = createRoot(container);
+			const router = createRouter(
+				<div className="max-w-md">
+					<PendingGroupCard groupId="fixture-group-2" groupName="Weekend Warriors" count={5} />
+				</div>,
+			);
+			root.render(<RouterProvider router={router} />);
+			return { dispose: () => root.unmount() };
+		},
+	}),
+});

--- a/app/components/pending-group-card.tsx
+++ b/app/components/pending-group-card.tsx
@@ -1,0 +1,31 @@
+import { Link } from "@remix-run/react";
+
+export interface PendingGroupCardProps {
+	groupId: string;
+	groupName: string;
+	count: number;
+}
+
+export function PendingGroupCard({ groupId, groupName, count }: PendingGroupCardProps) {
+	return (
+		<Link
+			to={`/groups/${groupId}/events`}
+			className="block rounded-xl border-l-4 border-amber-400 bg-white p-4 shadow-sm transition-all hover:shadow-md"
+		>
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+						{count}
+					</span>
+					<div>
+						<p className="text-sm font-semibold text-slate-900">{groupName}</p>
+						<p className="text-xs text-slate-500">
+							{count} {count === 1 ? "event needs" : "events need"} your confirmation
+						</p>
+					</div>
+				</div>
+				<span className="text-xs font-medium text-emerald-600">Confirm →</span>
+			</div>
+		</Link>
+	);
+}

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -3,6 +3,7 @@ import { Link, useLoaderData } from "@remix-run/react";
 import { AlertCircle, CalendarDays, Clock, Plus, Users } from "lucide-react";
 import { EmptyState } from "~/components/empty-state";
 import { EventCard } from "~/components/event-card";
+import { PendingGroupCard } from "~/components/pending-group-card";
 import { formatDateShort, parseDateOnly } from "~/lib/date-utils";
 import { requireUser } from "~/services/auth.server";
 import { getDashboardData } from "~/services/dashboard.server";
@@ -72,35 +73,13 @@ export default function Dashboard() {
 								</span>
 							</Link>
 						))}
-						{pendingConfirmations.map((evt) => (
-							<Link
-								key={evt.id}
-								to={`/groups/${evt.groupId}/events/${evt.id}`}
-								className="flex items-center justify-between rounded-xl border border-amber-200 bg-amber-50 p-4 transition-all hover:border-amber-300 hover:shadow-sm"
-							>
-								<div className="min-w-0 flex-1">
-									<div className="flex items-center gap-2">
-										<span className="text-sm">
-											{evt.eventType === "show"
-												? "🎭"
-												: evt.eventType === "rehearsal"
-													? "🎯"
-													: "📅"}
-										</span>
-										<span className="truncate text-sm font-semibold text-slate-900">
-											Confirm attendance: &ldquo;{evt.title}&rdquo;
-										</span>
-									</div>
-									<div className="mt-1 flex items-center gap-2 text-xs text-slate-500">
-										<span>{evt.groupName}</span>
-										<span>·</span>
-										<span>{formatDateShort(evt.startTime, user.timezone ?? undefined)}</span>
-									</div>
-								</div>
-								<span className="ml-4 shrink-0 text-sm font-medium text-emerald-600">
-									Confirm →
-								</span>
-							</Link>
+						{pendingConfirmations.map((group) => (
+							<PendingGroupCard
+								key={group.groupId}
+								groupId={group.groupId}
+								groupName={group.groupName}
+								count={group.count}
+							/>
 						))}
 					</div>
 				</div>

--- a/app/services/dashboard.server.test.ts
+++ b/app/services/dashboard.server.test.ts
@@ -6,7 +6,7 @@ function createChainableMock(resolvedValue: unknown[] = []) {
 		// biome-ignore lint/suspicious/noThenProperty: needed to make the mock awaitable for Promise.all
 		then: (resolve: (v: unknown) => void) => resolve(resolvedValue),
 	};
-	const methods = ["select", "from", "innerJoin", "leftJoin", "where", "orderBy", "limit"];
+	const methods = ["select", "from", "innerJoin", "leftJoin", "where", "orderBy", "limit", "groupBy"];
 	for (const method of methods) {
 		chain[method] = vi.fn().mockReturnValue(chain);
 	}

--- a/app/services/dashboard.server.ts
+++ b/app/services/dashboard.server.ts
@@ -98,22 +98,12 @@ export async function getDashboardData(userId: string) {
 			)
 			.orderBy(availabilityRequests.expiresAt),
 
-		// Events where user is assigned with pending status
+		// Pending confirmations grouped by group
 		db
 			.select({
-				id: events.id,
 				groupId: events.groupId,
-				title: events.title,
-				description: events.description,
-				eventType: events.eventType,
-				startTime: events.startTime,
-				endTime: events.endTime,
-				location: events.location,
-				createdById: events.createdById,
-				createdFromRequestId: events.createdFromRequestId,
-				createdAt: events.createdAt,
-				updatedAt: events.updatedAt,
 				groupName: groups.name,
+				count: sql<number>`cast(count(*) as int)`,
 			})
 			.from(eventAssignments)
 			.innerJoin(events, eq(eventAssignments.eventId, events.id))
@@ -125,7 +115,8 @@ export async function getDashboardData(userId: string) {
 					gte(events.startTime, new Date()),
 				),
 			)
-			.orderBy(events.startTime),
+			.groupBy(events.groupId, groups.name)
+			.orderBy(groups.name),
 	]);
 
 	// Format date ranges for pending requests


### PR DESCRIPTION
## Summary

Replaces individual pending confirmation cards on the dashboard with grouped per-group cards (Variant C amber style). Instead of showing 5 separate cards for 5 pending events across 2 groups, it now shows 2 compact cards — one per group with a count badge.

## Changes

- **`app/components/pending-group-card.tsx`** — New `PendingGroupCard` component with amber left-border, count badge, group name, and pluralized subtitle
- **`app/components/pending-group-card.fixture.tsx`** — Component explorer fixture with Interactive, Single Event, and Multiple Events variants
- **`app/services/dashboard.server.ts`** — Simplified SQL query: `GROUP BY` groupId/groupName with `COUNT(*)` instead of fetching full event details
- **`app/routes/dashboard.tsx`** — Swapped per-event cards for per-group `PendingGroupCard` components
- **`app/services/dashboard.server.test.ts`** — Added `groupBy` to chainable mock methods

## Card design (Variant C)

```
┌─────────────────────────────────────────────────────┐
│ ▌ [3] Improv Comedy Group                           │
│ ▌     3 events need your confirmation    Confirm →  │
└─────────────────────────────────────────────────────┘
```

Each card links to `/groups/{groupId}/events` where inline confirm/decline buttons exist.

## Quality gates

- ✅ `tsc --noEmit` passes
- ✅ `vitest run` — 663/663 tests pass
- ✅ `biome check` clean on changed files