### PR TITLE
feat: Add trackEvent() calls for 7 user actions

### DIFF
--- a/app/routes/groups.$groupId._index.tsx
+++ b/app/routes/groups.$groupId._index.tsx
@@ -14,6 +14,7 @@ import {
 	requireGroupMember,
 } from "~/services/groups.server";
 import { logger } from "~/services/logger.server";
+import { trackEvent } from "~/services/telemetry.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -30,7 +31,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdmin(request, groupId);
 
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
@@ -43,6 +44,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		}
 		try {
 			await removeMember(groupId, userId);
+			trackEvent("MemberRemoved", {
+				userId: user.id,
+				removedUserId: userId,
+				groupId,
+			});
 		} catch (error) {
 			logger.error({ err: error, route: "groups.$groupId._index" }, "Failed to remove member");
 			return { error: error instanceof Error ? error.message : "Failed to remove member." };

--- a/app/routes/groups.$groupId.availability.$requestId.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId.tsx
@@ -43,6 +43,7 @@ import { validateCsrfToken } from "~/services/csrf.server";
 import { sendAvailabilityReminderNotification } from "~/services/email.server";
 import { getGroupById, isGroupAdmin, requireGroupMember } from "~/services/groups.server";
 import { checkReminderRateLimit } from "~/services/rate-limit.server";
+import { trackEvent } from "~/services/telemetry.server";
 import { sendAvailabilityReminderWebhook } from "~/services/webhook.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
 
@@ -154,6 +155,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			userId: user.id,
 			responses,
 			notes,
+		});
+		trackEvent("AvailabilityResponseSubmitted", {
+			userId: user.id,
+			requestId,
+			groupId,
 		});
 
 		return { success: true, message: "Response saved!" };

--- a/app/routes/groups.$groupId.events.$eventId_.edit.tsx
+++ b/app/routes/groups.$groupId.events.$eventId_.edit.tsx
@@ -39,6 +39,7 @@ import {
 	isGroupAdmin,
 	requireGroupMember,
 } from "~/services/groups.server";
+import { trackEvent } from "~/services/telemetry.server";
 import { sendEventEditedWebhook } from "~/services/webhook.server";
 
 export const meta: MetaFunction = () => {
@@ -104,6 +105,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 	if (intent === "delete") {
 		await deleteEvent(eventId);
+		trackEvent("EventDeleted", { userId: user.id, eventId, groupId });
 		return redirect(`/groups/${groupId}/events`);
 	}
 
@@ -198,6 +200,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		callTime: newCallTime,
 		timezone,
 	});
+
+	trackEvent("EventUpdated", { userId: user.id, eventId, groupId });
 
 	// Handle re-confirmation: reset confirmed attendees to pending
 	if (requestReconfirmation && data.assignments.length > 0) {

--- a/app/routes/groups.$groupId.settings.tsx
+++ b/app/routes/groups.$groupId.settings.tsx
@@ -15,6 +15,7 @@ import {
 	updateGroupPermissions,
 } from "~/services/groups.server";
 import { logger } from "~/services/logger.server";
+import { trackEvent } from "~/services/telemetry.server";
 import { isValidWebhookUrl, sendTestWebhook } from "~/services/webhook.server";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -34,7 +35,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	await requireGroupAdmin(request, groupId);
+	const user = await requireGroupAdmin(request, groupId);
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 	const intent = formData.get("intent");
@@ -165,6 +166,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		}
 
 		await deleteGroup(groupId);
+		trackEvent("GroupDeleted", { userId: user.id, groupId });
 		return redirect("/dashboard");
 	}
 

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/db/schema.js";
 import { requireUser } from "./auth.server.js";
 import { mergeWithDefaults } from "./notification-utils.server.js";
+import { trackEvent } from "./telemetry.server.js";
 
 type Group = typeof groups.$inferSelect;
 
@@ -55,6 +56,7 @@ export async function createGroup(
 
 				return group;
 			});
+			trackEvent("GroupCreated", { userId, groupId: result.id });
 			return result;
 		} catch (error) {
 			// If unique constraint violation on invite_code, retry
@@ -161,6 +163,7 @@ export async function joinGroup(
 		notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES,
 	});
 
+	trackEvent("GroupJoined", { userId, groupId: group.id });
 	return { success: true, groupId: group.id };
 }
 


### PR DESCRIPTION
## Summary

Adds Application Insights telemetry tracking for user actions that weren't previously tracked, following the existing fire-and-forget `trackEvent()` pattern.

## New events tracked

| Event | Location | Properties |
|-------|----------|------------|
| `GroupCreated` | `groups.server.ts` (service) | userId, groupId |
| `GroupJoined` | `groups.server.ts` (service) | userId, groupId |
| `GroupDeleted` | `groups.$groupId.settings.tsx` (route) | userId, groupId |
| `MemberRemoved` | `groups.$groupId._index.tsx` (route) | userId, removedUserId, groupId |
| `AvailabilityResponseSubmitted` | `groups.$groupId.availability.$requestId.tsx` (route) | userId, requestId, groupId |
| `EventUpdated` | `groups.$groupId.events.$eventId_.edit.tsx` (route) | userId, eventId, groupId |
| `EventDeleted` | `groups.$groupId.events.$eventId_.edit.tsx` (route) | userId, eventId, groupId |

## Pattern

- Service-level tracking where all needed context (especially `groupId`) is available in the function parameters
- Route-level tracking where the service function doesn't have the full context (e.g., `userId` from auth, `groupId` from route params)
- Fire-and-forget — no `await`, never blocks the request
- Only IDs as properties, no PII

## Quality gates

- ✅ `tsc --noEmit` — passes
- ✅ `biome check .` — clean
- ✅ `vitest run` — 663 tests pass