### PR TITLE
feat: add per-user rate limiting on creation/mutation actions

### DIFF
--- a/app/routes/groups.$groupId.availability.$requestId.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId.test.ts
@@ -54,6 +54,8 @@ vi.mock("~/services/csrf.server", () => ({
 // Mock rate limiting — allow all by default
 vi.mock("~/services/rate-limit.server", () => ({
 	checkReminderRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	checkAvailabilityResponseRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	_resetForTests: vi.fn(),
 }));
 
 import { action, loader } from "~/routes/groups.$groupId.availability.$requestId";

--- a/app/routes/groups.$groupId.availability.$requestId.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId.tsx
@@ -42,7 +42,10 @@ import {
 import { validateCsrfToken } from "~/services/csrf.server";
 import { sendAvailabilityReminderNotification } from "~/services/email.server";
 import { getGroupById, isGroupAdmin, requireGroupMember } from "~/services/groups.server";
-import { checkReminderRateLimit } from "~/services/rate-limit.server";
+import {
+	checkAvailabilityResponseRateLimit,
+	checkReminderRateLimit,
+} from "~/services/rate-limit.server";
 import { trackEvent } from "~/services/telemetry.server";
 import { sendAvailabilityReminderWebhook } from "~/services/webhook.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
@@ -96,6 +99,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const intent = formData.get("intent");
 
 	if (intent === "respond") {
+		const rateCheck = checkAvailabilityResponseRateLimit(user.id);
+		if (rateCheck.limited) {
+			return Response.json(
+				{ error: "You've submitted too many responses recently. Please try again later." },
+				{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+			);
+		}
+
 		const responsesRaw = formData.get("responses");
 		let responses: Record<string, AvailabilityStatus> = {};
 		try {

--- a/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests } from "~/services/rate-limit.server";
+
+// Reset rate limiter before each test to prevent cross-test interference
+beforeEach(() => {
+	_resetForTests();
+});
 
 // --- Mocks (before imports) ---
 

--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -29,6 +29,7 @@ import {
 	getGroupWithMembers,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { checkEventCreateRateLimit } from "~/services/rate-limit.server";
 import { sendBatchEventsCreatedWebhook } from "~/services/webhook.server";
 import type { NotificationPreferences } from "../../src/db/schema.js";
 
@@ -70,6 +71,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const requestId = params.requestId ?? "";
 	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
+
+	const rateCheck = checkEventCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ error: "You've created too many events today. Please try again later." },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
+
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 

--- a/app/routes/groups.$groupId.availability.new.test.ts
+++ b/app/routes/groups.$groupId.availability.new.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests } from "~/services/rate-limit.server";
+
+// Reset rate limiter before each test to prevent cross-test interference
+beforeEach(() => {
+	_resetForTests();
+});
 
 vi.mock("~/services/auth.server", () => ({
 	requireUser: vi.fn().mockResolvedValue({

--- a/app/routes/groups.$groupId.availability.new.tsx
+++ b/app/routes/groups.$groupId.availability.new.tsx
@@ -22,6 +22,7 @@ import {
 	getGroupMembersWithPreferences,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { checkAvailabilityRequestCreateRateLimit } from "~/services/rate-limit.server";
 import { sendAvailabilityRequestWebhook } from "~/services/webhook.server";
 
 export const meta: MetaFunction = () => {
@@ -37,6 +38,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateRequests");
+
+	const rateCheck = checkAvailabilityRequestCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{
+				error: "You've created too many availability requests today. Please try again later.",
+			},
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
+
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 

--- a/app/routes/groups.$groupId.events.new.test.ts
+++ b/app/routes/groups.$groupId.events.new.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests } from "~/services/rate-limit.server";
+
+// Reset rate limiter before each test to prevent cross-test interference
+beforeEach(() => {
+	_resetForTests();
+});
 
 vi.mock("~/services/auth.server", () => ({
 	requireUser: vi.fn().mockResolvedValue({

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -38,6 +38,7 @@ import {
 	getGroupWithMembers,
 	requireGroupAdminOrPermission,
 } from "~/services/groups.server";
+import { checkEventCreateRateLimit } from "~/services/rate-limit.server";
 import { sendEventCreatedWebhook } from "~/services/webhook.server";
 import type { NotificationPreferences } from "../../src/db/schema.js";
 
@@ -74,6 +75,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
+
+	const rateCheck = checkEventCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ error: "You've created too many events today. Please try again later." },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
+
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 

--- a/app/routes/groups.join.test.ts
+++ b/app/routes/groups.join.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests } from "~/services/rate-limit.server";
+
+// Reset rate limiter before each test to prevent cross-test interference
+beforeEach(() => {
+	_resetForTests();
+});
 
 // Mock auth service
 vi.mock("~/services/auth.server", () => ({

--- a/app/routes/groups.join.tsx
+++ b/app/routes/groups.join.tsx
@@ -5,6 +5,7 @@ import { CsrfInput } from "~/components/csrf-input";
 import { getOptionalUser, requireUser } from "~/services/auth.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { joinGroup } from "~/services/groups.server";
+import { checkGroupJoinRateLimit } from "~/services/rate-limit.server";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "Join Group — My Call Time" }];
@@ -19,6 +20,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
 	const user = await requireUser(request);
+
+	const rateCheck = checkGroupJoinRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ error: "You've made too many join attempts today. Please try again later." },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
+
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 	const code = formData.get("code");

--- a/app/routes/groups.new.test.ts
+++ b/app/routes/groups.new.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests } from "~/services/rate-limit.server";
+
+// Reset rate limiter before each test to prevent cross-test interference
+beforeEach(() => {
+	_resetForTests();
+});
 
 vi.mock("~/services/auth.server", () => ({
 	requireUser: vi.fn().mockResolvedValue({

--- a/app/routes/groups.new.tsx
+++ b/app/routes/groups.new.tsx
@@ -6,6 +6,7 @@ import { requireUser } from "~/services/auth.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { createGroup } from "~/services/groups.server";
 import { logger } from "~/services/logger.server";
+import { checkGroupCreateRateLimit } from "~/services/rate-limit.server";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "Create Group — My Call Time" }];
@@ -18,6 +19,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
 	const user = await requireUser(request);
+
+	const rateCheck = checkGroupCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ errors: { form: "You've created too many groups today. Please try again later." } },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
+
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
 

--- a/app/services/rate-limit.server.test.ts
+++ b/app/services/rate-limit.server.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { _resetForTests, checkRateLimit } from "~/services/rate-limit.server";
+import {
+	_resetForTests,
+	checkAvailabilityRequestCreateRateLimit,
+	checkAvailabilityResponseRateLimit,
+	checkEventCreateRateLimit,
+	checkGroupCreateRateLimit,
+	checkGroupJoinRateLimit,
+	checkRateLimit,
+} from "~/services/rate-limit.server";
 
 describe("rate limiter", () => {
 	beforeEach(() => {
@@ -52,5 +60,88 @@ describe("rate limiter", () => {
 
 		const allowedResult = checkRateLimit("expire-key", 3, 50);
 		expect(allowedResult.limited).toBe(false);
+	});
+});
+
+describe("per-user rate limit functions", () => {
+	beforeEach(() => {
+		_resetForTests();
+	});
+
+	it("checkGroupCreateRateLimit allows 5 requests then blocks", () => {
+		const userId = "user-1";
+		for (let i = 0; i < 5; i++) {
+			expect(checkGroupCreateRateLimit(userId).limited).toBe(false);
+		}
+		const result = checkGroupCreateRateLimit(userId);
+		expect(result.limited).toBe(true);
+		if (result.limited) {
+			expect(result.retryAfter).toBeGreaterThan(0);
+		}
+	});
+
+	it("checkEventCreateRateLimit allows 20 requests then blocks", () => {
+		const userId = "user-2";
+		for (let i = 0; i < 20; i++) {
+			expect(checkEventCreateRateLimit(userId).limited).toBe(false);
+		}
+		expect(checkEventCreateRateLimit(userId).limited).toBe(true);
+	});
+
+	it("checkAvailabilityRequestCreateRateLimit allows 10 requests then blocks", () => {
+		const userId = "user-3";
+		for (let i = 0; i < 10; i++) {
+			expect(checkAvailabilityRequestCreateRateLimit(userId).limited).toBe(false);
+		}
+		expect(checkAvailabilityRequestCreateRateLimit(userId).limited).toBe(true);
+	});
+
+	it("checkAvailabilityResponseRateLimit allows 50 requests then blocks", () => {
+		const userId = "user-4";
+		for (let i = 0; i < 50; i++) {
+			expect(checkAvailabilityResponseRateLimit(userId).limited).toBe(false);
+		}
+		expect(checkAvailabilityResponseRateLimit(userId).limited).toBe(true);
+	});
+
+	it("checkGroupJoinRateLimit allows 10 requests then blocks", () => {
+		const userId = "user-5";
+		for (let i = 0; i < 10; i++) {
+			expect(checkGroupJoinRateLimit(userId).limited).toBe(false);
+		}
+		expect(checkGroupJoinRateLimit(userId).limited).toBe(true);
+	});
+
+	it("isolates rate limits between different users", () => {
+		for (let i = 0; i < 5; i++) {
+			checkGroupCreateRateLimit("user-a");
+		}
+		expect(checkGroupCreateRateLimit("user-a").limited).toBe(true);
+		expect(checkGroupCreateRateLimit("user-b").limited).toBe(false);
+	});
+
+	it("isolates rate limits between different action types for the same user", () => {
+		const userId = "user-x";
+		for (let i = 0; i < 5; i++) {
+			checkGroupCreateRateLimit(userId);
+		}
+		expect(checkGroupCreateRateLimit(userId).limited).toBe(true);
+		// Same user should still be allowed for other actions
+		expect(checkEventCreateRateLimit(userId).limited).toBe(false);
+		expect(checkGroupJoinRateLimit(userId).limited).toBe(false);
+	});
+
+	it("returns a positive retryAfter value when blocked", () => {
+		const userId = "user-retry";
+		for (let i = 0; i < 5; i++) {
+			checkGroupCreateRateLimit(userId);
+		}
+		const result = checkGroupCreateRateLimit(userId);
+		expect(result.limited).toBe(true);
+		if (result.limited) {
+			expect(result.retryAfter).toBeGreaterThan(0);
+			// 24-hour window → retryAfter should be ≤ 86400 seconds
+			expect(result.retryAfter).toBeLessThanOrEqual(86400);
+		}
 	});
 });

--- a/app/services/rate-limit.server.ts
+++ b/app/services/rate-limit.server.ts
@@ -67,6 +67,8 @@ function getClientIp(request: Request): string {
 }
 
 const ONE_MINUTE_MS = 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export function checkLoginRateLimit(request: Request) {
 	const ip = getClientIp(request);
@@ -86,6 +88,26 @@ const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
 export function checkReminderRateLimit(requestId: string) {
 	return checkRateLimit(`availability-reminder:${requestId}`, 1, FIVE_MINUTES_MS);
+}
+
+export function checkGroupCreateRateLimit(userId: string) {
+	return checkRateLimit(`group-create:${userId}`, 5, ONE_DAY_MS);
+}
+
+export function checkEventCreateRateLimit(userId: string) {
+	return checkRateLimit(`event-create:${userId}`, 20, ONE_DAY_MS);
+}
+
+export function checkAvailabilityRequestCreateRateLimit(userId: string) {
+	return checkRateLimit(`avail-request-create:${userId}`, 10, ONE_DAY_MS);
+}
+
+export function checkAvailabilityResponseRateLimit(userId: string) {
+	return checkRateLimit(`avail-response:${userId}`, 50, ONE_HOUR_MS);
+}
+
+export function checkGroupJoinRateLimit(userId: string) {
+	return checkRateLimit(`group-join:${userId}`, 10, ONE_DAY_MS);
 }
 
 /** Visible for testing */


### PR DESCRIPTION
## Summary

Adds per-user rate limiting on 5 creation/mutation actions to prevent abuse.

### New rate limit functions

| Action | Limit | Window |
|--------|-------|--------|
| Group creation | 5 | 24 hours |
| Event creation | 20 | 24 hours |
| Availability request creation | 10 | 24 hours |
| Availability response | 50 | 1 hour |
| Group join | 10 | 24 hours |

### Integration points

- `groups.new.tsx` — `checkGroupCreateRateLimit(user.id)`
- `groups.$groupId.events.new.tsx` — `checkEventCreateRateLimit(user.id)`
- `groups.$groupId.availability.new.tsx` — `checkAvailabilityRequestCreateRateLimit(user.id)`
- `groups.$groupId.availability.$requestId.tsx` — `checkAvailabilityResponseRateLimit(user.id)` (respond intent only)
- `groups.join.tsx` — `checkGroupJoinRateLimit(user.id)`

Each check runs after auth but before form processing. Returns 429 with `Retry-After` header and user-friendly error message when limited.

### Tests

Added 7 new tests covering all new rate limit functions, user isolation, cross-action isolation, and retryAfter bounds.

### Quality gates

- ✅ `tsc --noEmit` passes
- ✅ `vitest run` — 671 tests pass
- ✅ `biome check .` — clean