### PR TITLE
fix: increase health check timeout and relax availability alert

### DIFF
--- a/app/routes/api.health.tsx
+++ b/app/routes/api.health.tsx
@@ -6,7 +6,7 @@ import { db } from "../../src/db/index.js";
 export async function loader(_args: LoaderFunctionArgs) {
 	try {
 		const timeout = new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error("Health check timeout")), 2000),
+			setTimeout(() => reject(new Error("Health check timeout")), 5000),
 		);
 		await Promise.race([db.execute(sql`SELECT 1`), timeout]);
 	} catch (error) {


### PR DESCRIPTION
## Problem
The health check endpoint uses a 2-second timeout on the `SELECT 1` database query. Cold DB connections on Azure Container Apps can exceed this, causing false-positive 503s that trigger the `mycalltime-app-unhealthy` alert.

## Changes

### Code
- Increased health check timeout from 2s → 5s in `app/routes/api.health.tsx`

### Infrastructure (manual step after merge)
- Alert window: 5m → 15m (requires sustained failures)
- Evaluation frequency: 1m → 5m
- Availability threshold: 95% → 80% (tolerates 1–2 transient failures)

```bash
az monitor metrics alert update \
  --name mycalltime-app-unhealthy \
  -g greenroom-rg \
  --window-size 15m \
  --evaluation-frequency 5m \
  --condition "avg availabilityResults/availabilityPercentage < 80"
```

## Quality gates
- ✅ `tsc --noEmit` — no errors
- ✅ `vitest run` — 671 tests pass
- ✅ `biome check .` — clean