### PR TITLE
Fix EventCalendar Playwright test for event dots

### DIFF
--- a/app/components/event-calendar.fixture.tsx
+++ b/app/components/event-calendar.fixture.tsx
@@ -51,6 +51,7 @@ export default defineFixtureGroup({
 				<div className="max-w-lg">
 					<EventCalendar
 						events={sampleEvents}
+						initialDate={new Date(2026, 2, 1)}
 						onDateClick={(date, events) => console.log("Date clicked:", date, events)}
 					/>
 				</div>,

--- a/app/components/event-calendar.tsx
+++ b/app/components/event-calendar.tsx
@@ -15,6 +15,8 @@ interface EventCalendarProps {
 		startTime: string;
 	}>;
 	onDateClick?: (date: string, events: EventIndicator[]) => void;
+	/** Override the initially displayed month (defaults to today). */
+	initialDate?: Date;
 }
 
 const EVENT_TYPE_COLORS: Record<string, string> = {
@@ -29,10 +31,11 @@ function toDateKey(date: Date): string {
 	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
-export function EventCalendar({ events, onDateClick }: EventCalendarProps) {
+export function EventCalendar({ events, onDateClick, initialDate }: EventCalendarProps) {
 	const today = new Date();
-	const [year, setYear] = useState(today.getFullYear());
-	const [month, setMonth] = useState(today.getMonth());
+	const start = initialDate ?? today;
+	const [year, setYear] = useState(start.getFullYear());
+	const [month, setMonth] = useState(start.getMonth());
 
 	const todayKey = toDateKey(today);
 
@@ -143,6 +146,7 @@ export function EventCalendar({ events, onDateClick }: EventCalendarProps) {
 									{dayEvents.slice(0, 3).map((e) => (
 										<span
 											key={e.id}
+											data-testid="event-dot"
 											className={`h-1.5 w-1.5 rounded-full ${EVENT_TYPE_COLORS[e.eventType] ?? "bg-slate-600"}`}
 										/>
 									))}

--- a/e2e/components/event-calendar.spec.ts
+++ b/e2e/components/event-calendar.spec.ts
@@ -43,8 +43,8 @@ test.describe("EventCalendar", () => {
 	test("With Events — event dots are displayed", async ({ page }) => {
 		await renderFixture(page, "event-calendar", "With Events");
 
-		// Event dots are small colored circles (h-1.5 w-1.5 rounded-full)
-		const dots = page.locator(".rounded-full.h-1\\.5");
+		// Event dots use data-testid for resilient selection
+		const dots = page.getByTestId("event-dot");
 		await expect(dots.first()).toBeVisible();
 	});
 
@@ -55,7 +55,7 @@ test.describe("EventCalendar", () => {
 		await expect(page.getByText("Sun")).toBeVisible();
 
 		// No event dots
-		const dots = page.locator(".rounded-full.h-1\\.5");
+		const dots = page.getByTestId("event-dot");
 		await expect(dots).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
## Problem

The component explorer Playwright test "With Events — event dots are displayed" was failing on both desktop and mobile. The test looked for `.rounded-full.h-1\.5` elements but couldn't find them.

## Root Cause

The `EventCalendar` component defaults to displaying the **current month**, but the fixture events were hardcoded to March/April 2026 — now in the past. Since there are no events in the current month, no dots were rendered.

## Fix

1. **Added `initialDate` prop** to `EventCalendar` (optional, defaults to today) so fixtures can control the displayed month
2. **Added `data-testid="event-dot"`** to event dot spans for resilient test selectors
3. **Updated fixture** to pass `initialDate={new Date(2026, 2, 1)}` (March 2026) matching event dates
4. **Updated test selectors** from fragile CSS class selectors (`.h-1\.5`) to `data-testid`

## Verification

- All 10 EventCalendar Playwright tests pass (desktop + mobile)
- `tsc --noEmit` passes
- `biome check .` is clean