### PR TITLE
feat: Subscribable iCalendar feed for calendar apps

### DIFF
--- a/.github/skills/codebase-conventions/SKILL.md
+++ b/.github/skills/codebase-conventions/SKILL.md
@@ -5,6 +5,8 @@ description: GreenRoom (My Call Time) project stack, coding conventions, route p
 
 # GreenRoom Codebase Conventions
 
+Start here for a quick orientation. Detailed patterns live in the specialized skills listed at the bottom.
+
 ## Project Stack
 
 | Layer | Technology |
@@ -68,152 +70,6 @@ src/
 
 The `.server.ts` suffix is required for service files — Remix uses it to strip server-only code from the client bundle.
 
-## Route Patterns
-
-### File-Based Routing
-
-Remix v2 flat file routing maps dots to path segments:
-
-```
-groups.$groupId.events.new.tsx  →  /groups/:groupId/events/new
-groups.$groupId.tsx             →  Layout route (renders <Outlet />)
-groups.$groupId._index.tsx      →  Index route for the layout
-settings_.delete-account.tsx    →  /settings/delete-account (escaped from settings layout)
-```
-
-### Loader/Action Pattern
-
-Every route that reads data has a `loader`. Every route that writes data has an `action`:
-
-```typescript
-export async function loader({ request, params }: LoaderFunctionArgs) {
-	const groupId = params.groupId ?? "";
-	const user = await requireGroupMember(request, groupId);
-	const data = await getGroupEvents(groupId);
-	return { events: data, userId: user.id };
-}
-
-export async function action({ request, params }: ActionFunctionArgs) {
-	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdmin(request, groupId);
-	const formData = await request.formData();
-	const intent = formData.get("intent");
-	// ... handle based on intent
-}
-```
-
-### Intent-Based Multi-Action Routes
-
-When a route has multiple form actions, use a hidden `intent` field:
-
-```typescript
-// In the action:
-if (intent === "close") { /* ... */ }
-if (intent === "reopen") { /* ... */ }
-if (intent === "respond") { /* ... */ }
-
-// In the component:
-<Form method="post">
-	<input type="hidden" name="intent" value="close" />
-	<button type="submit">Close</button>
-</Form>
-```
-
-### Resource Routes (API Endpoints)
-
-Routes that return non-HTML responses (JSON, iCal, etc.) are **resource routes** — they export a `loader` and/or `action` but no `default` component:
-
-```typescript
-// app/routes/api.health.tsx — JSON health check
-export async function loader() {
-	return Response.json({ status: "ok", timestamp: new Date().toISOString() });
-}
-
-// app/routes/api.calendar.$token.ics.tsx — iCal feed
-export async function loader({ params }: LoaderFunctionArgs) {
-	// ... return new Response(icsContent, { headers: { "Content-Type": "text/calendar" } })
-}
-```
-
-### Accessing Parent Layout Data
-
-Child routes can access parent layout loader data:
-
-```typescript
-const parentData = useRouteLoaderData<typeof groupLayoutLoader>("routes/groups.$groupId");
-const role = parentData?.role;
-```
-
-## Authentication
-
-### Auth Guards
-
-Four levels of protection, used in every loader/action:
-
-```typescript
-// Any authenticated user — redirects to /login
-const user = await requireUser(request);
-
-// Must be a member of the group — throws 404
-const user = await requireGroupMember(request, groupId);
-
-// Must be an admin — throws 403
-const user = await requireGroupAdmin(request, groupId);
-
-// Admin OR member with a specific permission — throws 403
-const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateRequests");
-```
-
-- `getOptionalUser(request)` returns `AuthUser | null` (used in root loader for nav)
-- Auth uses `remix-auth` with `FormStrategy` for email/password
-- Google OAuth is a manual implementation (not using remix-auth adapter)
-- Session cookie: `__greenroom_session`, httpOnly, sameSite lax, secure in production, 30-day expiry
-- **No "logged in but unverified" state** — signup doesn't create a session; users must verify email first
-
-### Soft-Delete User Handling
-
-Deleted users have `deletedAt` set. Auth guards and token lookups reject them:
-
-```typescript
-if (!row || row.deletedAt) return null;
-```
-
-Account deletion has a 30-day reactivation window — logging in within 30 days clears `deletedAt`.
-
-## Service Layer
-
-### Pattern
-
-Services live in `app/services/*.server.ts`. They export functions that encapsulate business logic and database queries:
-
-```typescript
-// app/services/events.server.ts
-export async function createEvent(data: CreateEventInput): Promise<Event> {
-	const [event] = await db.insert(events).values({ ... }).returning();
-	getTelemetryClient()?.trackEvent({ name: "EventCreated", properties: { ... } });
-	return event;
-}
-```
-
-Conventions:
-- Import `db` from `../../src/db/index.js` and schema tables from `../../src/db/schema.js`
-- Return typed objects or DB rows
-- Trim user input before writing
-- Track custom events via `getTelemetryClient()?.trackEvent()`
-- Auth guards (`requireUser`, `requireGroupMember`, etc.) live in `app/services/groups.server.ts`
-- Throw `Response` objects for HTTP errors (404, 403), `Error` for unexpected failures
-
-### Fire-and-Forget Pattern
-
-Email notifications and webhooks use fire-and-forget — don't block the user's request:
-
-```typescript
-// void prefix, no await — fire and forget
-void sendAvailabilityRequestNotification({ ... });
-```
-
-Email service gracefully degrades: if `AZURE_COMMUNICATION_CONNECTION_STRING` is not set, it logs instead of throwing.
-
 ## Shared Utilities (`app/lib/`)
 
 | File | Purpose |
@@ -230,137 +86,12 @@ import { formatDate, formatTime, formatDateTime } from "~/lib/date-utils";
 formatDate(event.startTime, user.timezone);
 ```
 
-## Testing Approach
+## UI Component Patterns
 
-### Unit Tests (Vitest)
-
-Test files are co-located with their source: `foo.server.ts` → `foo.server.test.ts`.
-
-#### Mocking Services
-
-Mock dependencies with `vi.mock()` **before** importing the module under test:
-
-```typescript
-vi.mock("~/services/calendar-token.server", () => ({
-	getUserByCalendarToken: vi.fn(),
-}));
-vi.mock("~/services/events.server", () => ({
-	getUserCalendarEvents: vi.fn(),
-}));
-vi.mock("~/services/logger.server", () => ({
-	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
-}));
-vi.mock("../../src/db/index.js", () => ({ db: {} }));
-
-// Then import:
-import { loader } from "./api.calendar.$token.ics";
-```
-
-#### Testing Route Loaders/Actions
-
-Construct `Request` objects and call loaders/actions directly:
-
-```typescript
-const response = await loader({
-	request: new Request("http://localhost/api/calendar/validtoken.ics"),
-	params: { token: "validtoken" },
-	context: {},
-});
-
-expect(response.status).toBe(200);
-const body = await response.text();
-expect(body).toContain("BEGIN:VCALENDAR");
-```
-
-For actions, use `FormData`:
-
-```typescript
-const formData = new FormData();
-formData.set("intent", "close");
-const response = await action({
-	request: new Request("http://localhost/route", { method: "POST", body: formData }),
-	params: { groupId: "group-1" },
-	context: {},
-});
-```
-
-#### Component Tests
-
-Use jsdom environment + Testing Library + `userEvent`:
-
-```typescript
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-```
-
-#### Test Lifecycle
-
-```typescript
-beforeEach(() => {
-	vi.clearAllMocks();
-});
-```
-
-### Rate Limiting in Tests
-
-The rate limiter uses in-memory state. Reset it between tests:
-
-```typescript
-import { _resetForTests } from "~/services/rate-limit.server";
-beforeEach(() => _resetForTests());
-```
-
-## UI Patterns
-
-### Forms
-
-Standard Remix `<Form>` with intent-based actions:
-
-```tsx
-<Form method="post">
-	<CsrfInput />
-	<input type="hidden" name="intent" value="update-name" />
-	<input name="name" defaultValue={group.name} />
-	<button type="submit" disabled={isSubmitting}>Save</button>
-</Form>
-```
-
-- Always include `<CsrfInput />` for state-changing forms
-- Disable submit buttons during submission using `useNavigation().state`
-
-### Danger Zone
-
-Use the `DangerZone` component for destructive actions (delete group, delete account):
-
-```tsx
-<DangerZone>
-	<DangerZone.Title>Delete Group</DangerZone.Title>
-	<DangerZone.Description>This action cannot be undone.</DangerZone.Description>
-	<Form method="post">
-		<input type="hidden" name="intent" value="delete" />
-		<button type="submit">Delete</button>
-	</Form>
-</DangerZone>
-```
-
-For high-stakes deletions, require the user to type a confirmation string (e.g., their email address) before the submit button is enabled.
-
-### Confirmation Dialogs
-
-For destructive actions that are less severe than full deletion, use `onClick` confirmation:
-
-```tsx
-<button
-	type="submit"
-	onClick={(e) => {
-		if (!confirm("Are you sure you want to regenerate your calendar feed URL?")) {
-			e.preventDefault();
-		}
-	}}
->
-	Regenerate
-</button>
-```
+- **`<CsrfInput />`** — Include in every state-changing `<Form>`. Renders a hidden CSRF token field.
+- **`<DangerZone>`** — Wrapper for destructive actions (delete group, delete account). Compound component: `<DangerZone.Title>`, `<DangerZone.Description>`, then a `<Form>` inside. For high-stakes deletions, require typing a confirmation string before enabling submit.
+- **Confirmation dialogs** — For less severe destructive actions, use `onClick` with `confirm()` and `e.preventDefault()` on cancel.
+- **Submit buttons** — Disable during submission using `useNavigation().state`.
 
 ## Logging
 
@@ -388,6 +119,13 @@ getTelemetryClient()?.trackEvent({ name: "EventCreated", properties: { groupId }
 getTelemetryClient()?.trackException({ exception: error });
 ```
 
+## Session Cookie
+
+- Name: `__greenroom_session`
+- httpOnly, sameSite lax, secure in production
+- 30-day expiry
+- Signed with `SESSION_SECRET` env var
+
 ## Adding a New Feature — Checklist
 
 1. **Schema** — Add tables/columns in `src/db/schema.ts`
@@ -398,3 +136,17 @@ getTelemetryClient()?.trackException({ exception: error });
 6. **Auth** — Use appropriate guard (`requireUser`, `requireGroupMember`, `requireGroupAdmin`, or `requireGroupAdminOrPermission`)
 7. **Tests** — Co-located test file, mock services, test loaders/actions directly
 8. **Quality Gates** — `pnpm run typecheck && pnpm run lint && pnpm test && pnpm run build`
+
+## Specialized Skills
+
+For deeper guidance, see these skills:
+
+| Skill | What It Covers |
+|-------|---------------|
+| `greenroom-architecture` | Remix route structure, loader/action patterns, service layer conventions, intent-based actions, component architecture, UI styling |
+| `greenroom-db` | Drizzle ORM schema reference, table definitions, query patterns (joins, upserts, transactions), JSON columns, indexes, multi-tenancy |
+| `drizzle-migrations` | Migration toolchain internals: snapshot chain, `_journal.json`, `drizzle.config.ts`, `scripts/migrate.mjs`, statement breakpoints |
+| `schema-changes` | Pre-commit checklist for schema changes: finding write sites, NOT NULL pitfalls, migration defaults, FK cascades, LEFT JOIN awareness |
+| `greenroom-testing` | Vitest configuration, testing loaders/actions, mocking services and auth, test file structure, rate limiting tests, environment setup |
+| `greenroom-security` | Auth guard hierarchy, multi-tenancy isolation, rate limiting, CSRF protection, session security, password hashing, OAuth CSRF, invite codes |
+| `ical-feeds` | iCalendar (RFC 5545) feed generation, token-based auth for non-browser clients, subscribable calendar feeds |

--- a/.github/skills/codebase-conventions/SKILL.md
+++ b/.github/skills/codebase-conventions/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: codebase-conventions
+description: GreenRoom (My Call Time) project stack, coding conventions, route patterns, service layer, testing approach, and quality gates
+---
+
+# GreenRoom Codebase Conventions
+
+## Project Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Remix v2 (React) with Vite bundler |
+| Database | PostgreSQL via Drizzle ORM |
+| Styling | TailwindCSS v4 (utility classes, emerald/slate palette) |
+| Icons | `lucide-react` exclusively |
+| Components | shadcn/ui patterns (Radix primitives, `cn()` from `src/lib/utils.ts`) |
+| Unit Tests | Vitest |
+| E2E Tests | Playwright |
+| Linter/Formatter | Biome (tabs, double quotes, semicolons, 100 char line width) |
+| Runtime | Node.js 20+ |
+| Package Manager | pnpm 9+ |
+| Deployment | Docker → Azure Container Apps |
+
+## Quality Gates
+
+Run these before every commit. CI enforces them on every push/PR to `master`:
+
+```bash
+pnpm run typecheck   # tsc --noEmit (strict mode)
+pnpm run lint        # biome check . (lint + format check)
+pnpm test            # vitest run (unit tests)
+pnpm run build       # remix vite:build (production build)
+```
+
+**CI has three parallel jobs:**
+1. **check** — typecheck → lint → build → vitest
+2. **playwright-explorer** — Component explorer Playwright tests (no DB needed)
+3. **playwright-e2e** — App E2E tests with PostgreSQL service container
+
+## File Structure
+
+```
+app/
+├── routes/          # Remix file-based routes
+├── services/        # Server-side business logic (*.server.ts)
+├── components/      # Reusable React components
+├── lib/             # Shared utility functions
+├── root.tsx         # Root layout
+└── tailwind.css     # TailwindCSS v4 entry
+
+src/
+├── db/
+│   ├── schema.ts    # Drizzle ORM schema (single file, all tables)
+│   └── index.ts     # Database connection
+└── lib/
+    └── utils.ts     # cn() utility (clsx + tailwind-merge)
+```
+
+### Naming Conventions
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Routes | Flat dot notation | `groups.$groupId.events.new.tsx` |
+| Services | `*.server.ts` suffix | `app/services/events.server.ts` |
+| Components | kebab-case | `app/components/event-card.tsx` |
+| Tests | Co-located `.test.ts(x)` | `app/services/groups.server.test.ts` |
+| Utilities | In `app/lib/` | `app/lib/date-utils.ts` |
+
+The `.server.ts` suffix is required for service files — Remix uses it to strip server-only code from the client bundle.
+
+## Route Patterns
+
+### File-Based Routing
+
+Remix v2 flat file routing maps dots to path segments:
+
+```
+groups.$groupId.events.new.tsx  →  /groups/:groupId/events/new
+groups.$groupId.tsx             →  Layout route (renders <Outlet />)
+groups.$groupId._index.tsx      →  Index route for the layout
+settings_.delete-account.tsx    →  /settings/delete-account (escaped from settings layout)
+```
+
+### Loader/Action Pattern
+
+Every route that reads data has a `loader`. Every route that writes data has an `action`:
+
+```typescript
+export async function loader({ request, params }: LoaderFunctionArgs) {
+	const groupId = params.groupId ?? "";
+	const user = await requireGroupMember(request, groupId);
+	const data = await getGroupEvents(groupId);
+	return { events: data, userId: user.id };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+	const groupId = params.groupId ?? "";
+	const user = await requireGroupAdmin(request, groupId);
+	const formData = await request.formData();
+	const intent = formData.get("intent");
+	// ... handle based on intent
+}
+```
+
+### Intent-Based Multi-Action Routes
+
+When a route has multiple form actions, use a hidden `intent` field:
+
+```typescript
+// In the action:
+if (intent === "close") { /* ... */ }
+if (intent === "reopen") { /* ... */ }
+if (intent === "respond") { /* ... */ }
+
+// In the component:
+<Form method="post">
+	<input type="hidden" name="intent" value="close" />
+	<button type="submit">Close</button>
+</Form>
+```
+
+### Resource Routes (API Endpoints)
+
+Routes that return non-HTML responses (JSON, iCal, etc.) are **resource routes** — they export a `loader` and/or `action` but no `default` component:
+
+```typescript
+// app/routes/api.health.tsx — JSON health check
+export async function loader() {
+	return Response.json({ status: "ok", timestamp: new Date().toISOString() });
+}
+
+// app/routes/api.calendar.$token.ics.tsx — iCal feed
+export async function loader({ params }: LoaderFunctionArgs) {
+	// ... return new Response(icsContent, { headers: { "Content-Type": "text/calendar" } })
+}
+```
+
+### Accessing Parent Layout Data
+
+Child routes can access parent layout loader data:
+
+```typescript
+const parentData = useRouteLoaderData<typeof groupLayoutLoader>("routes/groups.$groupId");
+const role = parentData?.role;
+```
+
+## Authentication
+
+### Auth Guards
+
+Four levels of protection, used in every loader/action:
+
+```typescript
+// Any authenticated user — redirects to /login
+const user = await requireUser(request);
+
+// Must be a member of the group — throws 404
+const user = await requireGroupMember(request, groupId);
+
+// Must be an admin — throws 403
+const user = await requireGroupAdmin(request, groupId);
+
+// Admin OR member with a specific permission — throws 403
+const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateRequests");
+```
+
+- `getOptionalUser(request)` returns `AuthUser | null` (used in root loader for nav)
+- Auth uses `remix-auth` with `FormStrategy` for email/password
+- Google OAuth is a manual implementation (not using remix-auth adapter)
+- Session cookie: `__greenroom_session`, httpOnly, sameSite lax, secure in production, 30-day expiry
+- **No "logged in but unverified" state** — signup doesn't create a session; users must verify email first
+
+### Soft-Delete User Handling
+
+Deleted users have `deletedAt` set. Auth guards and token lookups reject them:
+
+```typescript
+if (!row || row.deletedAt) return null;
+```
+
+Account deletion has a 30-day reactivation window — logging in within 30 days clears `deletedAt`.
+
+## Service Layer
+
+### Pattern
+
+Services live in `app/services/*.server.ts`. They export functions that encapsulate business logic and database queries:
+
+```typescript
+// app/services/events.server.ts
+export async function createEvent(data: CreateEventInput): Promise<Event> {
+	const [event] = await db.insert(events).values({ ... }).returning();
+	getTelemetryClient()?.trackEvent({ name: "EventCreated", properties: { ... } });
+	return event;
+}
+```
+
+Conventions:
+- Import `db` from `../../src/db/index.js` and schema tables from `../../src/db/schema.js`
+- Return typed objects or DB rows
+- Trim user input before writing
+- Track custom events via `getTelemetryClient()?.trackEvent()`
+- Auth guards (`requireUser`, `requireGroupMember`, etc.) live in `app/services/groups.server.ts`
+- Throw `Response` objects for HTTP errors (404, 403), `Error` for unexpected failures
+
+### Fire-and-Forget Pattern
+
+Email notifications and webhooks use fire-and-forget — don't block the user's request:
+
+```typescript
+// void prefix, no await — fire and forget
+void sendAvailabilityRequestNotification({ ... });
+```
+
+Email service gracefully degrades: if `AZURE_COMMUNICATION_CONNECTION_STRING` is not set, it logs instead of throwing.
+
+## Shared Utilities (`app/lib/`)
+
+| File | Purpose |
+|------|---------|
+| `date-utils.ts` | Centralized date/time formatting (all `Intl.DateTimeFormat`). Single source of truth — never use inline `toLocaleDateString()`. All functions accept optional `timezone?: string`. |
+| `ical-utils.ts` | RFC 5545 iCalendar format helpers (date formatting, text escaping, line folding, feed generation) |
+| `edit-utils.ts` | Diff/change detection and human-readable summaries for event and availability request edits |
+
+```typescript
+// Always use date-utils for formatting:
+import { formatDate, formatTime, formatDateTime } from "~/lib/date-utils";
+
+// Pass user's timezone for server-side rendering:
+formatDate(event.startTime, user.timezone);
+```
+
+## Testing Approach
+
+### Unit Tests (Vitest)
+
+Test files are co-located with their source: `foo.server.ts` → `foo.server.test.ts`.
+
+#### Mocking Services
+
+Mock dependencies with `vi.mock()` **before** importing the module under test:
+
+```typescript
+vi.mock("~/services/calendar-token.server", () => ({
+	getUserByCalendarToken: vi.fn(),
+}));
+vi.mock("~/services/events.server", () => ({
+	getUserCalendarEvents: vi.fn(),
+}));
+vi.mock("~/services/logger.server", () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../../src/db/index.js", () => ({ db: {} }));
+
+// Then import:
+import { loader } from "./api.calendar.$token.ics";
+```
+
+#### Testing Route Loaders/Actions
+
+Construct `Request` objects and call loaders/actions directly:
+
+```typescript
+const response = await loader({
+	request: new Request("http://localhost/api/calendar/validtoken.ics"),
+	params: { token: "validtoken" },
+	context: {},
+});
+
+expect(response.status).toBe(200);
+const body = await response.text();
+expect(body).toContain("BEGIN:VCALENDAR");
+```
+
+For actions, use `FormData`:
+
+```typescript
+const formData = new FormData();
+formData.set("intent", "close");
+const response = await action({
+	request: new Request("http://localhost/route", { method: "POST", body: formData }),
+	params: { groupId: "group-1" },
+	context: {},
+});
+```
+
+#### Component Tests
+
+Use jsdom environment + Testing Library + `userEvent`:
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+```
+
+#### Test Lifecycle
+
+```typescript
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+```
+
+### Rate Limiting in Tests
+
+The rate limiter uses in-memory state. Reset it between tests:
+
+```typescript
+import { _resetForTests } from "~/services/rate-limit.server";
+beforeEach(() => _resetForTests());
+```
+
+## UI Patterns
+
+### Forms
+
+Standard Remix `<Form>` with intent-based actions:
+
+```tsx
+<Form method="post">
+	<CsrfInput />
+	<input type="hidden" name="intent" value="update-name" />
+	<input name="name" defaultValue={group.name} />
+	<button type="submit" disabled={isSubmitting}>Save</button>
+</Form>
+```
+
+- Always include `<CsrfInput />` for state-changing forms
+- Disable submit buttons during submission using `useNavigation().state`
+
+### Danger Zone
+
+Use the `DangerZone` component for destructive actions (delete group, delete account):
+
+```tsx
+<DangerZone>
+	<DangerZone.Title>Delete Group</DangerZone.Title>
+	<DangerZone.Description>This action cannot be undone.</DangerZone.Description>
+	<Form method="post">
+		<input type="hidden" name="intent" value="delete" />
+		<button type="submit">Delete</button>
+	</Form>
+</DangerZone>
+```
+
+For high-stakes deletions, require the user to type a confirmation string (e.g., their email address) before the submit button is enabled.
+
+### Confirmation Dialogs
+
+For destructive actions that are less severe than full deletion, use `onClick` confirmation:
+
+```tsx
+<button
+	type="submit"
+	onClick={(e) => {
+		if (!confirm("Are you sure you want to regenerate your calendar feed URL?")) {
+			e.preventDefault();
+		}
+	}}
+>
+	Regenerate
+</button>
+```
+
+## Logging
+
+Structured logging via pino. Import from `app/services/logger.server.ts`:
+
+```typescript
+import { logger } from "./logger.server.js";
+
+logger.info({ userId, groupId }, "User joined group");
+logger.error({ err: error, to: recipients }, "Failed to send email");
+```
+
+- Structured context as first argument, message as second
+- `LOG_LEVEL` env var controls verbosity (default: `"info"`)
+- Production: plain JSON to stdout (for log aggregation)
+
+## Telemetry
+
+Optional Azure Application Insights integration. Graceful no-op if not configured:
+
+```typescript
+import { getTelemetryClient } from "~/services/telemetry.server";
+
+getTelemetryClient()?.trackEvent({ name: "EventCreated", properties: { groupId } });
+getTelemetryClient()?.trackException({ exception: error });
+```
+
+## Adding a New Feature — Checklist
+
+1. **Schema** — Add tables/columns in `src/db/schema.ts`
+2. **Migration** — `pnpm run db:generate` → review SQL → `pnpm run db:migrate`
+3. **Service** — Create `app/services/{feature}.server.ts` with query functions
+4. **Route** — Add `app/routes/{path}.tsx` with loader/action + component
+5. **Components** — Extract reusable UI to `app/components/`
+6. **Auth** — Use appropriate guard (`requireUser`, `requireGroupMember`, `requireGroupAdmin`, or `requireGroupAdminOrPermission`)
+7. **Tests** — Co-located test file, mock services, test loaders/actions directly
+8. **Quality Gates** — `pnpm run typecheck && pnpm run lint && pnpm test && pnpm run build`

--- a/.github/skills/drizzle-migrations/SKILL.md
+++ b/.github/skills/drizzle-migrations/SKILL.md
@@ -3,26 +3,11 @@ name: drizzle-migrations
 description: Drizzle ORM migration workflow, snapshot chain management, and schema conventions for the My Call Time codebase
 ---
 
-# Drizzle Migration Patterns
+# Drizzle Migration Internals
 
-## Migration Workflow
+This skill covers the migration toolchain, file structure, and snapshot chain mechanics. For schema conventions and table patterns, see the `greenroom-db` skill. For the full schema change safety checklist, see the `schema-changes` skill.
 
-### Overview
-
-Schema changes flow through three steps:
-
-```
-src/db/schema.ts  →  pnpm run db:generate  →  drizzle/  →  pnpm run db:migrate
-     (edit)              (generate)            (review)         (apply)
-```
-
-1. **Edit** `src/db/schema.ts` — the single source of truth for all tables, enums, and indexes
-2. **Generate** migration with `pnpm run db:generate` — creates SQL + snapshot in `drizzle/`
-3. **Review** the generated SQL — never blindly trust it (see gotchas below)
-4. **Apply** locally with `pnpm run db:migrate`
-5. **Commit** both the schema change AND the `drizzle/` output
-
-### Drizzle Config
+## Drizzle Config
 
 ```typescript
 // drizzle.config.ts
@@ -34,17 +19,21 @@ export default defineConfig({
 });
 ```
 
-### Production Migrations
+- `out` — output directory for generated SQL and snapshots
+- `schema` — single source of truth for all tables, enums, and indexes
+- `dialect` — PostgreSQL-specific generation
 
-Migrations auto-run on container startup via `scripts/migrate.mjs`:
+## Production Migrations (`scripts/migrate.mjs`)
+
+Migrations auto-run on container startup:
 
 ```javascript
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 await migrate(db, { migrationsFolder: "./drizzle" });
 ```
 
-- Idempotent — safe with multiple replicas
-- Fails fast on error — prevents app from starting with a broken schema
+- **Idempotent** — safe with multiple replicas (Drizzle tracks applied migrations in a `__drizzle_migrations` table)
+- **Fails fast** on error — prevents app from starting with a broken schema
 - Uses the same `pg.Pool` config as the app (SSL in production with DigiCert CA cert)
 
 ## The `drizzle/` Directory
@@ -54,22 +43,17 @@ drizzle/
 ├── 0000_wise_hammerhead.sql      # Migration SQL files (auto-named)
 ├── 0001_narrow_liz_osborn.sql
 ├── ...
-├── 0015_sticky_leper_queen.sql   # Latest: calendar_tokens table
+├── 0015_sticky_leper_queen.sql   # Latest migration
 └── meta/
-    ├── _journal.json             # Migration journal (ordered list of entries)
-    ├── 0000_snapshot.json        # Schema snapshot after each migration
-    ├── 0001_snapshot.json
+    ├── _journal.json             # Migration journal (ordered list)
+    ├── 0000_snapshot.json        # Schema snapshot per migration
     ├── ...
     └── 0015_snapshot.json
 ```
 
 ### Journal (`_journal.json`)
 
-An ordered list of migration entries. Each entry has:
-- `idx` — sequential integer (0, 1, 2, ...)
-- `tag` — migration name (matches the `.sql` filename)
-- `when` — Unix timestamp of generation
-- `version` — journal format version (currently `"7"`)
+Ordered array of migration entries:
 
 ```json
 {
@@ -81,176 +65,43 @@ An ordered list of migration entries. Each entry has:
 }
 ```
 
-### Snapshots
+- `idx` — sequential integer (0, 1, 2, ...)
+- `tag` — matches the `.sql` filename (without extension)
+- `when` — Unix timestamp of generation
+- `breakpoints` — whether the SQL uses statement breakpoints (always `true`)
 
-Each snapshot captures the full schema state after that migration. Snapshots form a chain:
+### Snapshot Chain
+
+Each snapshot captures the full schema state after that migration. Snapshots form a **linked chain** via `prevId` → `id`:
 
 ```
 0012_snapshot.json: { "id": "4957071d-...", "prevId": "8b50307a-..." }
 0013_snapshot.json: { "id": "02f0375f-...", "prevId": "4957071d-..." }
 ```
 
-`prevId` of snapshot N must equal `id` of snapshot N-1. If this chain breaks, `db:generate` may produce incorrect or empty migrations.
+`prevId` of snapshot N **must** equal `id` of snapshot N-1. Drizzle diffs the previous snapshot against the current schema to generate migration SQL. If this chain breaks, `db:generate` produces incorrect or empty migrations.
 
 ### The Snapshot ID Collision Problem
 
-When multiple branches create migrations concurrently (e.g., both branch off the same base and add migration `0012`), they can produce snapshots with **different content but the same index**. When merged:
+When multiple branches create migrations concurrently (both branch off the same base and add migration `0012`), they produce snapshots with **different content but the same index**. After merging:
 
 - The journal may have duplicate `idx` values
-- The snapshot chain `prevId → id` can break
+- The snapshot chain `prevId → id` breaks
 - `pnpm run db:generate` silently produces wrong diffs or no-op migrations
 
-**How to detect:** After merging branches that both touched `drizzle/`, check:
+**How to detect** (after merging branches that both touched `drizzle/`):
 1. `_journal.json` has no duplicate `idx` values
 2. Each snapshot's `prevId` matches the previous snapshot's `id`
 3. Run `pnpm run db:generate` — if it generates a migration on a clean schema, the chain is broken
 
-**How to fix:** If you hit this, the safest approach is:
+**How to fix:**
 1. Re-number the colliding migration (rename SQL file and update journal entry)
 2. Regenerate the snapshot for the re-numbered migration by running `pnpm run db:generate` from a clean state
 3. Verify the chain is intact
 
 **Prevention:** Coordinate with other developers when multiple branches need schema changes. Ideally only one in-flight branch adds migrations at a time.
 
-## Schema Conventions
-
-### Table Definition Pattern
-
-Every table follows this structure:
-
-```typescript
-export const tableName = pgTable(
-	"table_name",                                    // snake_case DB name
-	{
-		id: uuid("id").defaultRandom().primaryKey(),   // UUID PK always
-		groupId: uuid("group_id")                      // FK example
-			.notNull()
-			.references(() => groups.id, { onDelete: "cascade" }),
-		name: varchar("name", { length: 255 }).notNull(),
-		// ... other columns ...
-		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
-	},
-	(table) => [
-		index("table_name_group_id_idx").on(table.groupId),
-	],
-);
-```
-
-### Column Conventions
-
-| Convention | Pattern |
-|-----------|---------|
-| Primary keys | `uuid("id").defaultRandom().primaryKey()` — always UUID |
-| Timestamps | `timestamp("col", { withTimezone: true })` — always with timezone |
-| Created/Updated | `createdAt` + `updatedAt` with `.defaultNow().notNull()` |
-| Soft deletes | `deletedAt: timestamp(...)` — nullable, null means active |
-| String lengths | `varchar(255)` for names/titles, `varchar(500)` for locations, `text` for descriptions |
-| JSON columns | `jsonb("col").$type<TypeHere>().notNull()` |
-| Enums | Define with `pgEnum(...)` at top of schema file |
-
-### Foreign Key Conventions
-
-| Relationship | `onDelete` | Why |
-|-------------|-----------|-----|
-| Child → parent group | `cascade` | Deleting a group removes all its data |
-| Assignment → event/user | `cascade` | Removing event/user cleans up assignments |
-| Token → user | `cascade` | Deleting user removes their token |
-| Record → creator (`createdById`) | default (`no action`) | Preserve creator reference |
-
-### Uniqueness: `.unique()` vs `uniqueIndex()`
-
-- **Single-column uniqueness:** Use column-level `.unique()` — e.g., `users.email`, `calendarTokens.token`
-- **Composite uniqueness:** Use `uniqueIndex(...)` in the table's index callback — e.g., `uniqueIndex("event_assignments_event_user_idx").on(table.eventId, table.userId)`
-
-Both create a DB unique constraint, but `uniqueIndex` is needed for multi-column keys and is the pattern used for upsert conflict targets.
-
-## Adding a New Table — Step by Step
-
-### 1. Define the Table in `src/db/schema.ts`
-
-```typescript
-export const myNewTable = pgTable(
-	"my_new_table",
-	{
-		id: uuid("id").defaultRandom().primaryKey(),
-		userId: uuid("user_id")
-			.notNull()
-			.references(() => users.id, { onDelete: "cascade" })
-			.unique(),                                    // one row per user
-		someValue: varchar("some_value", { length: 255 }).notNull(),
-		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-	},
-);
-```
-
-### 2. Generate the Migration
-
-```bash
-pnpm run db:generate
-```
-
-This creates:
-- `drizzle/NNNN_random_name.sql` — the SQL migration
-- `drizzle/meta/NNNN_snapshot.json` — updated schema snapshot
-- Updated `drizzle/meta/_journal.json` — new entry appended
-
-### 3. Review the Generated SQL
-
-**Always read the migration SQL.** Check for:
-- Correct column types and constraints
-- `DEFAULT` clauses for NOT NULL columns with existing data
-- Foreign key references pointing to the right tables
-- Index creation
-
-Example (from `0015_sticky_leper_queen.sql` — the `calendar_tokens` migration):
-
-```sql
-CREATE TABLE "calendar_tokens" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"user_id" uuid NOT NULL,
-	"token" varchar(64) NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "calendar_tokens_user_id_unique" UNIQUE("user_id"),
-	CONSTRAINT "calendar_tokens_token_unique" UNIQUE("token")
-);
-
-ALTER TABLE "calendar_tokens" ADD CONSTRAINT "calendar_tokens_user_id_users_id_fk"
-  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
-  ON DELETE cascade ON UPDATE no action;
-```
-
-### 4. Apply Locally
-
-```bash
-pnpm run db:migrate
-```
-
-### 5. Verify
-
-```bash
-pnpm run typecheck   # Schema types propagate correctly
-pnpm test            # Existing tests still pass
-pnpm run build       # No build errors
-```
-
-### 6. Commit Everything
-
-Commit the schema change AND all `drizzle/` files together. The migration files are source-controlled and run in production on deploy.
-
-## Common Migration Gotchas
-
-### Drizzle `.default()` ≠ SQL `DEFAULT`
-
-Drizzle's schema `.default()` does **not** always produce a `DEFAULT` clause in the migration SQL. If you add a NOT NULL column to a table with existing rows:
-
-1. Check the generated SQL for `DEFAULT`
-2. If missing, manually add it to the migration SQL
-3. Or make the column nullable and set values in a data migration
-
-See `.github/skills/schema-changes/SKILL.md` for the full checklist.
-
-### Statement Breakpoints
+## Statement Breakpoints
 
 Migration SQL files use `--> statement-breakpoint` comments to separate statements:
 
@@ -260,17 +111,4 @@ CREATE TABLE "calendar_tokens" ( ... );
 ALTER TABLE "calendar_tokens" ADD CONSTRAINT ...;
 ```
 
-Drizzle's migrator splits on these. Don't remove them.
-
-### Testing After Schema Changes
-
-After any schema change, grep for ALL write and read sites:
-
-```bash
-grep -rn "insert(tableName)" app/ src/
-grep -rn "update(tableName)" app/ src/
-grep -rn "from(tableName)" app/ src/
-grep -rn "innerJoin(tableName" app/ src/
-```
-
-Every insert must provide values for new NOT NULL columns. Every select/join may need the new column added to its field list.
+Drizzle's migrator splits the file on these markers and executes each statement independently. **Do not remove them** — without breakpoints, multi-statement migrations will fail because PostgreSQL cannot run certain DDL combinations in a single statement.

--- a/.github/skills/drizzle-migrations/SKILL.md
+++ b/.github/skills/drizzle-migrations/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: drizzle-migrations
+description: Drizzle ORM migration workflow, snapshot chain management, and schema conventions for the My Call Time codebase
+---
+
+# Drizzle Migration Patterns
+
+## Migration Workflow
+
+### Overview
+
+Schema changes flow through three steps:
+
+```
+src/db/schema.ts  →  pnpm run db:generate  →  drizzle/  →  pnpm run db:migrate
+     (edit)              (generate)            (review)         (apply)
+```
+
+1. **Edit** `src/db/schema.ts` — the single source of truth for all tables, enums, and indexes
+2. **Generate** migration with `pnpm run db:generate` — creates SQL + snapshot in `drizzle/`
+3. **Review** the generated SQL — never blindly trust it (see gotchas below)
+4. **Apply** locally with `pnpm run db:migrate`
+5. **Commit** both the schema change AND the `drizzle/` output
+
+### Drizzle Config
+
+```typescript
+// drizzle.config.ts
+export default defineConfig({
+	out: "./drizzle",
+	schema: "./src/db/schema.ts",
+	dialect: "postgresql",
+	dbCredentials: { url: process.env.DATABASE_URL },
+});
+```
+
+### Production Migrations
+
+Migrations auto-run on container startup via `scripts/migrate.mjs`:
+
+```javascript
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+await migrate(db, { migrationsFolder: "./drizzle" });
+```
+
+- Idempotent — safe with multiple replicas
+- Fails fast on error — prevents app from starting with a broken schema
+- Uses the same `pg.Pool` config as the app (SSL in production with DigiCert CA cert)
+
+## The `drizzle/` Directory
+
+```
+drizzle/
+├── 0000_wise_hammerhead.sql      # Migration SQL files (auto-named)
+├── 0001_narrow_liz_osborn.sql
+├── ...
+├── 0015_sticky_leper_queen.sql   # Latest: calendar_tokens table
+└── meta/
+    ├── _journal.json             # Migration journal (ordered list of entries)
+    ├── 0000_snapshot.json        # Schema snapshot after each migration
+    ├── 0001_snapshot.json
+    ├── ...
+    └── 0015_snapshot.json
+```
+
+### Journal (`_journal.json`)
+
+An ordered list of migration entries. Each entry has:
+- `idx` — sequential integer (0, 1, 2, ...)
+- `tag` — migration name (matches the `.sql` filename)
+- `when` — Unix timestamp of generation
+- `version` — journal format version (currently `"7"`)
+
+```json
+{
+  "idx": 15,
+  "version": "7",
+  "when": 1777905664500,
+  "tag": "0015_sticky_leper_queen",
+  "breakpoints": true
+}
+```
+
+### Snapshots
+
+Each snapshot captures the full schema state after that migration. Snapshots form a chain:
+
+```
+0012_snapshot.json: { "id": "4957071d-...", "prevId": "8b50307a-..." }
+0013_snapshot.json: { "id": "02f0375f-...", "prevId": "4957071d-..." }
+```
+
+`prevId` of snapshot N must equal `id` of snapshot N-1. If this chain breaks, `db:generate` may produce incorrect or empty migrations.
+
+### The Snapshot ID Collision Problem
+
+When multiple branches create migrations concurrently (e.g., both branch off the same base and add migration `0012`), they can produce snapshots with **different content but the same index**. When merged:
+
+- The journal may have duplicate `idx` values
+- The snapshot chain `prevId → id` can break
+- `pnpm run db:generate` silently produces wrong diffs or no-op migrations
+
+**How to detect:** After merging branches that both touched `drizzle/`, check:
+1. `_journal.json` has no duplicate `idx` values
+2. Each snapshot's `prevId` matches the previous snapshot's `id`
+3. Run `pnpm run db:generate` — if it generates a migration on a clean schema, the chain is broken
+
+**How to fix:** If you hit this, the safest approach is:
+1. Re-number the colliding migration (rename SQL file and update journal entry)
+2. Regenerate the snapshot for the re-numbered migration by running `pnpm run db:generate` from a clean state
+3. Verify the chain is intact
+
+**Prevention:** Coordinate with other developers when multiple branches need schema changes. Ideally only one in-flight branch adds migrations at a time.
+
+## Schema Conventions
+
+### Table Definition Pattern
+
+Every table follows this structure:
+
+```typescript
+export const tableName = pgTable(
+	"table_name",                                    // snake_case DB name
+	{
+		id: uuid("id").defaultRandom().primaryKey(),   // UUID PK always
+		groupId: uuid("group_id")                      // FK example
+			.notNull()
+			.references(() => groups.id, { onDelete: "cascade" }),
+		name: varchar("name", { length: 255 }).notNull(),
+		// ... other columns ...
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		index("table_name_group_id_idx").on(table.groupId),
+	],
+);
+```
+
+### Column Conventions
+
+| Convention | Pattern |
+|-----------|---------|
+| Primary keys | `uuid("id").defaultRandom().primaryKey()` — always UUID |
+| Timestamps | `timestamp("col", { withTimezone: true })` — always with timezone |
+| Created/Updated | `createdAt` + `updatedAt` with `.defaultNow().notNull()` |
+| Soft deletes | `deletedAt: timestamp(...)` — nullable, null means active |
+| String lengths | `varchar(255)` for names/titles, `varchar(500)` for locations, `text` for descriptions |
+| JSON columns | `jsonb("col").$type<TypeHere>().notNull()` |
+| Enums | Define with `pgEnum(...)` at top of schema file |
+
+### Foreign Key Conventions
+
+| Relationship | `onDelete` | Why |
+|-------------|-----------|-----|
+| Child → parent group | `cascade` | Deleting a group removes all its data |
+| Assignment → event/user | `cascade` | Removing event/user cleans up assignments |
+| Token → user | `cascade` | Deleting user removes their token |
+| Record → creator (`createdById`) | default (`no action`) | Preserve creator reference |
+
+### Uniqueness: `.unique()` vs `uniqueIndex()`
+
+- **Single-column uniqueness:** Use column-level `.unique()` — e.g., `users.email`, `calendarTokens.token`
+- **Composite uniqueness:** Use `uniqueIndex(...)` in the table's index callback — e.g., `uniqueIndex("event_assignments_event_user_idx").on(table.eventId, table.userId)`
+
+Both create a DB unique constraint, but `uniqueIndex` is needed for multi-column keys and is the pattern used for upsert conflict targets.
+
+## Adding a New Table — Step by Step
+
+### 1. Define the Table in `src/db/schema.ts`
+
+```typescript
+export const myNewTable = pgTable(
+	"my_new_table",
+	{
+		id: uuid("id").defaultRandom().primaryKey(),
+		userId: uuid("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" })
+			.unique(),                                    // one row per user
+		someValue: varchar("some_value", { length: 255 }).notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+	},
+);
+```
+
+### 2. Generate the Migration
+
+```bash
+pnpm run db:generate
+```
+
+This creates:
+- `drizzle/NNNN_random_name.sql` — the SQL migration
+- `drizzle/meta/NNNN_snapshot.json` — updated schema snapshot
+- Updated `drizzle/meta/_journal.json` — new entry appended
+
+### 3. Review the Generated SQL
+
+**Always read the migration SQL.** Check for:
+- Correct column types and constraints
+- `DEFAULT` clauses for NOT NULL columns with existing data
+- Foreign key references pointing to the right tables
+- Index creation
+
+Example (from `0015_sticky_leper_queen.sql` — the `calendar_tokens` migration):
+
+```sql
+CREATE TABLE "calendar_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token" varchar(64) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "calendar_tokens_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "calendar_tokens_token_unique" UNIQUE("token")
+);
+
+ALTER TABLE "calendar_tokens" ADD CONSTRAINT "calendar_tokens_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+  ON DELETE cascade ON UPDATE no action;
+```
+
+### 4. Apply Locally
+
+```bash
+pnpm run db:migrate
+```
+
+### 5. Verify
+
+```bash
+pnpm run typecheck   # Schema types propagate correctly
+pnpm test            # Existing tests still pass
+pnpm run build       # No build errors
+```
+
+### 6. Commit Everything
+
+Commit the schema change AND all `drizzle/` files together. The migration files are source-controlled and run in production on deploy.
+
+## Common Migration Gotchas
+
+### Drizzle `.default()` ≠ SQL `DEFAULT`
+
+Drizzle's schema `.default()` does **not** always produce a `DEFAULT` clause in the migration SQL. If you add a NOT NULL column to a table with existing rows:
+
+1. Check the generated SQL for `DEFAULT`
+2. If missing, manually add it to the migration SQL
+3. Or make the column nullable and set values in a data migration
+
+See `.github/skills/schema-changes/SKILL.md` for the full checklist.
+
+### Statement Breakpoints
+
+Migration SQL files use `--> statement-breakpoint` comments to separate statements:
+
+```sql
+CREATE TABLE "calendar_tokens" ( ... );
+--> statement-breakpoint
+ALTER TABLE "calendar_tokens" ADD CONSTRAINT ...;
+```
+
+Drizzle's migrator splits on these. Don't remove them.
+
+### Testing After Schema Changes
+
+After any schema change, grep for ALL write and read sites:
+
+```bash
+grep -rn "insert(tableName)" app/ src/
+grep -rn "update(tableName)" app/ src/
+grep -rn "from(tableName)" app/ src/
+grep -rn "innerJoin(tableName" app/ src/
+```
+
+Every insert must provide values for new NOT NULL columns. Every select/join may need the new column added to its field list.

--- a/.github/skills/greenroom-db/SKILL.md
+++ b/.github/skills/greenroom-db/SKILL.md
@@ -215,6 +215,8 @@ export const newTable = pgTable(
 3. Review the generated SQL in `drizzle/`
 4. Run migration: `pnpm run db:migrate`
 
+> **⚠️ Snapshot collision risk:** If multiple branches add migrations concurrently, the snapshot chain in `drizzle/meta/` can break (duplicate `idx` values, broken `prevId` → `id` links). After merging branches that both touched `drizzle/`, verify the chain is intact and `db:generate` doesn't produce unexpected output. See the `drizzle-migrations` skill for detection and repair steps.
+
 ### Schema Conventions
 
 - All PKs: `uuid("id").defaultRandom().primaryKey()`

--- a/.github/skills/ical-feeds/SKILL.md
+++ b/.github/skills/ical-feeds/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: ical-feeds
+description: iCalendar (RFC 5545) feed generation, token-based auth for non-browser clients, and the subscribable calendar feed feature
+---
+
+# iCalendar Feed Patterns
+
+## Overview
+
+My Call Time exposes a subscribable iCalendar feed at `/api/calendar/:token.ics`. Calendar apps (Google Calendar, Apple Calendar, Outlook) can poll this URL to stay in sync with a user's events across all their groups.
+
+Key difference from the per-event `.ics` export (`/api/events/:eventId/ics`): the feed is **multi-event**, **cross-group**, and uses **token-based auth** instead of cookie sessions — because calendar apps can't authenticate with browser cookies.
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `app/lib/ical-utils.ts` | Shared iCal formatting functions (RFC 5545 compliant) |
+| `app/lib/ical-utils.test.ts` | Unit tests for iCal utils |
+| `app/routes/api.calendar.$token.ics.tsx` | Feed route (loader only, no action) |
+| `app/routes/api.calendar.$token.ics.test.ts` | Route tests |
+| `app/services/calendar-token.server.ts` | Token CRUD (generate, read, revoke via regenerate) |
+| `src/db/schema.ts` → `calendarTokens` | Schema: one token per user, cascade delete |
+
+## iCal Format (RFC 5545 Basics)
+
+### Date-Time Formatting
+
+All times are UTC. Format: `YYYYMMDDTHHMMSSZ` — no dashes, no colons, no milliseconds.
+
+```typescript
+// app/lib/ical-utils.ts
+export function formatICalDate(date: Date): string {
+	return date
+		.toISOString()
+		.replace(/[-:]/g, "")
+		.replace(/\.\d{3}/, "");
+}
+// new Date("2026-03-15T19:00:00Z") → "20260315T190000Z"
+```
+
+Using UTC throughout means we don't need `VTIMEZONE` components.
+
+### Text Escaping (RFC 5545 §3.3.11)
+
+Four characters must be escaped in TEXT property values:
+
+```typescript
+export function escapeICalText(text: string): string {
+	return text
+		.replace(/\\/g, "\\\\")   // backslash first (avoid double-escaping)
+		.replace(/;/g, "\\;")
+		.replace(/,/g, "\\,")
+		.replace(/\n/g, "\\n");   // literal newline → iCal \n escape
+}
+```
+
+**Order matters:** Backslashes must be escaped first, otherwise you'll double-escape the backslashes from subsequent replacements.
+
+### Line Folding (RFC 5545 §3.1)
+
+Content lines must be folded at 75 octets. Continuation lines start with a single space:
+
+```typescript
+export function foldLine(line: string): string {
+	const maxLen = 75;
+	if (line.length <= maxLen) return line;
+	const parts: string[] = [];
+	parts.push(line.slice(0, maxLen));
+	let i = maxLen;
+	while (i < line.length) {
+		parts.push(` ${line.slice(i, i + maxLen - 1)}`);
+		i += maxLen - 1;
+	}
+	return parts.join("\r\n");
+}
+```
+
+**Note:** This implementation uses JS string length (code units), not byte/octet count. For ASCII-only content (which our data largely is), this is fine. If we add emoji or non-ASCII text in event titles, this could break — see Pitfalls below.
+
+### CRLF Line Endings
+
+RFC 5545 requires `\r\n` (CRLF) between content lines, not bare `\n`. The feed joins all lines with `\r\n`:
+
+```typescript
+return lines.join("\r\n");
+```
+
+## Feed Generation (`generateCalendarFeed`)
+
+The `generateCalendarFeed(calendarEvents: CalendarEvent[]): string` function in `app/lib/ical-utils.ts` builds a full `VCALENDAR` document:
+
+### VCALENDAR Envelope
+
+```
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//My Call Time//Calendar Feed//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:My Call Time
+```
+
+- `METHOD:PUBLISH` signals this is a read-only feed (not a scheduling request)
+- `X-WR-CALNAME` sets the calendar name shown in apps like Google Calendar
+
+### VEVENT Per Event
+
+Each event produces a `VEVENT` block with:
+
+| Property | Source | Notes |
+|----------|--------|-------|
+| `UID` | `${event.id}@mycalltime.app` | Stable across refreshes — calendar apps use this to detect updates |
+| `DTSTAMP` | `new Date()` (generation time) | When the feed was generated |
+| `DTSTART` | `startTime` or `callTime` | See performer logic below |
+| `DTEND` | `endTime` | Always the event's end time |
+| `LAST-MODIFIED` | `updatedAt` | Tells calendar apps when the event was last changed |
+| `SUMMARY` | `title` | Escaped via `escapeICalText` |
+| `DESCRIPTION` | `"Group: {groupName}\n{description}"` | Optional; omitted if both empty |
+| `LOCATION` | `location` | Optional; omitted if null |
+| `CATEGORIES` | `groupName` | Allows filtering by group in calendar apps |
+
+### Performer Call Time Logic
+
+For shows, performers see `callTime` (when they need to arrive) instead of `startTime` (when the show starts for the audience):
+
+```typescript
+const isPerformerAtShow =
+	event.userRole === "Performer" && event.eventType === "show" && event.callTime;
+const startTime = isPerformerAtShow ? (event.callTime as Date) : event.startTime;
+```
+
+All three conditions must be true: role is Performer, event type is show, AND callTime exists.
+
+### CalendarEvent Interface
+
+```typescript
+export interface CalendarEvent {
+	id: string;
+	title: string;
+	description: string | null;
+	location: string | null;
+	startTime: Date;
+	endTime: Date;
+	callTime: Date | null;
+	eventType: string;
+	groupName: string;
+	userRole: string | null;
+	updatedAt: Date;
+}
+```
+
+## Token-Based Auth
+
+### Why Not Cookies?
+
+Calendar apps (Google Calendar, Apple Calendar, Outlook) subscribe to a URL and poll it periodically. They can't:
+- Visit a login page
+- Store browser cookies
+- Follow OAuth flows
+
+So we use a **secret URL** pattern: the token IS the authentication. Anyone with the URL can read the feed.
+
+### Token Lifecycle
+
+Managed via `app/services/calendar-token.server.ts`:
+
+```typescript
+// Read existing token for a user (null if none)
+getCalendarToken(userId: string): Promise<string | null>
+
+// Generate or replace token — crypto.randomBytes(32) → 64-char hex
+regenerateCalendarToken(userId: string): Promise<string>
+
+// Look up user by token (rejects soft-deleted users)
+getUserByCalendarToken(token: string): Promise<{ id: string; timezone: string | null } | null>
+```
+
+- **One token per user** — enforced by `UNIQUE(user_id)` in the schema
+- **Regenerate = revoke old + create new** — old URL stops working immediately
+- Token: `crypto.randomBytes(32).toString("hex")` → 64 hex characters (256 bits of entropy)
+- Soft-deleted users (`deletedAt IS NOT NULL`) are rejected even if the token is valid
+
+### Token Storage Schema
+
+```typescript
+// src/db/schema.ts
+export const calendarTokens = pgTable("calendar_tokens", {
+	id: uuid("id").defaultRandom().primaryKey(),
+	userId: uuid("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" })
+		.unique(),
+	token: varchar("token", { length: 64 }).notNull().unique(),
+	createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+- `onDelete: "cascade"` — deleting a user automatically removes their token
+- Both `userId` and `token` have column-level `.unique()` constraints
+
+### Token Management UI
+
+The settings page (`app/routes/settings.tsx`) handles token creation and regeneration:
+- `intent: "generate-calendar-token"` — first-time creation, shows the feed URL
+- `intent: "regenerate-calendar-token"` — replaces existing token (old URL stops working)
+- The feed URL is displayed for copy-paste: `{APP_URL}/api/calendar/{token}.ics`
+
+**Important:** Token generation happens in an `action` (POST), never in a `loader` (GET). Creating credentials in a GET request is a security anti-pattern (URL referer leakage, browser prefetch, etc.).
+
+## Feed Route (`api.calendar.$token.ics.tsx`)
+
+A Remix **resource route** (loader only, no component). Responds with `text/calendar`:
+
+```typescript
+export async function loader({ params }: LoaderFunctionArgs) {
+	const token = params.token;
+	if (!token) throw new Response("Not Found", { status: 404 });
+
+	const user = await getUserByCalendarToken(token);
+	if (!user) throw new Response("Not Found", { status: 404 });
+
+	const events = await getUserCalendarEvents(user.id);
+	// ... map to CalendarEvent objects ...
+	const icsContent = generateCalendarFeed(calendarEvents);
+
+	return new Response(icsContent, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/calendar; charset=utf-8",
+			"Cache-Control": "private, no-store",
+			"X-Robots-Tag": "noindex, nofollow",
+		},
+	});
+}
+```
+
+### Security Headers
+
+| Header | Value | Why |
+|--------|-------|-----|
+| `Content-Type` | `text/calendar; charset=utf-8` | Proper MIME type for iCal feeds |
+| `Cache-Control` | `private, no-store` | Prevents caching by CDNs/proxies — token in URL is sensitive |
+| `X-Robots-Tag` | `noindex, nofollow` | Prevents search engine indexing of feed URLs |
+| `Content-Disposition` | **Not set** | Intentionally omitted — setting it would trigger a download instead of a subscription |
+
+### Event Query — Bounded Time Range
+
+`getUserCalendarEvents()` in `app/services/events.server.ts` limits the query window:
+
+```typescript
+const thirtyDaysAgo = new Date();
+thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+const sixMonthsOut = new Date();
+sixMonthsOut.setMonth(sixMonthsOut.getMonth() + 6);
+```
+
+This is important: without bounds, the query would scan ALL events for the user across ALL groups across ALL time — a performance disaster for active users.
+
+## Common Pitfalls
+
+### 1. Double-Escaped Newlines
+
+When building `DESCRIPTION`, the group name and description are joined with `\n`:
+
+```typescript
+descParts.join("\n")  // literal newline
+```
+
+Then `escapeICalText()` converts `\n` to the iCal `\n` escape. If you pre-escape the newline (e.g., using `\\n` in the join), you'll get `\\n` in the output — which renders as a literal backslash-n instead of a line break.
+
+**Test for this:**
+```typescript
+expect(feed).toContain("Group: Team Alpha\\nWeekly practice");
+expect(feed).not.toContain("Group: Team Alpha\\\\nWeekly practice");
+```
+
+### 2. Unbounded Time Range
+
+Always bound event queries. Calendar feeds are polled automatically (every 15 min to 24 hours depending on the client). An unbounded query on every poll would hammer the database.
+
+### 3. Content-Disposition Breaks Subscriptions
+
+Do NOT set `Content-Disposition: attachment`. Calendar apps need to GET the URL repeatedly — an attachment header causes a one-time download instead of a live subscription.
+
+### 4. CRLF vs LF
+
+Every test that checks iCal output should verify CRLF line endings:
+
+```typescript
+it("uses CRLF line endings", () => {
+	const feed = generateCalendarFeed([baseEvent]);
+	expect(feed).toContain("\r\n");
+	const lines = feed.split("\r\n");
+	for (const line of lines) {
+		expect(line).not.toContain("\n");
+	}
+});
+```
+
+### 5. Folding Uses Character Count, Not Octet Count
+
+RFC 5545 specifies 75 **octets**, but our `foldLine` uses JS string length. For ASCII content this is equivalent. If non-ASCII characters (emoji, accented names) appear in event titles or descriptions, multi-byte UTF-8 characters could push lines past 75 octets while appearing under 75 characters. Monitor this if internationalization is added.
+
+## Testing iCal Output
+
+### Unit Tests (`app/lib/ical-utils.test.ts`)
+
+Test each function in isolation:
+- `formatICalDate` — midnight, end-of-day, typical times
+- `escapeICalText` — each special character individually, then combined
+- `foldLine` — short lines unchanged, exactly 75 chars unchanged, long lines fold with CRLF + space
+- `generateCalendarFeed` — VCALENDAR structure, VEVENT count, UID format, optional properties omitted when null, performer callTime logic, CRLF line endings, double-escape prevention
+
+### Route Tests (`app/routes/api.calendar.$token.ics.test.ts`)
+
+Mock the service layer and test the route loader:
+
+```typescript
+vi.mock("~/services/calendar-token.server", () => ({
+	getUserByCalendarToken: vi.fn(),
+}));
+vi.mock("~/services/events.server", () => ({
+	getUserCalendarEvents: vi.fn(),
+}));
+vi.mock("~/services/logger.server", () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../../src/db/index.js", () => ({ db: {} }));
+```
+
+Test scenarios:
+- Valid token → 200 with `text/calendar` content type
+- Invalid/missing token → 404
+- Security headers present (`Cache-Control`, `X-Robots-Tag`)
+- `Content-Disposition` header is NOT set
+- Events from multiple groups appear in feed
+- Performer at show uses `callTime` for `DTSTART`
+- Empty feed (no events) still has valid VCALENDAR wrapper
+
+### Key Testing Pattern: Unfold to Verify
+
+Long property values get folded. To verify content in tests, either:
+1. Use `toContain()` on the raw output (works for short values)
+2. Unfold first: `feed.replace(/\r\n /g, "")` then check the unfolded string

--- a/.github/skills/schema-changes/SKILL.md
+++ b/.github/skills/schema-changes/SKILL.md
@@ -23,6 +23,7 @@ Read this **before** adding or modifying any database column, table, or constrai
 ## After Schema Changes
 
 - [ ] **Run `pnpm run db:generate`.** Always generate the migration file and review the SQL it produces. Commit the migration with your schema change.
+- [ ] **Check statement breakpoints.** The generated SQL uses `--> statement-breakpoint` comments to separate DDL statements. Drizzle's migrator splits on these markers — do not remove them, or multi-statement migrations will fail.
 - [ ] **Run `pnpm run db:migrate`.** Apply locally and verify no errors.
 - [ ] **Test the full lifecycle manually.** Create, read, update, delete for the affected entity. The test suite alone isn't enough — new columns can break flows that have no test coverage.
 - [ ] **Run the quality gates.** `pnpm run typecheck && pnpm run lint && pnpm run build && pnpm test`

--- a/app/lib/ical-utils.test.ts
+++ b/app/lib/ical-utils.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+	type CalendarEvent,
+	escapeICalText,
+	foldLine,
+	formatICalDate,
+	generateCalendarFeed,
+} from "./ical-utils";
+
+describe("formatICalDate", () => {
+	it("formats a UTC date correctly", () => {
+		const date = new Date("2026-03-15T19:00:00Z");
+		expect(formatICalDate(date)).toBe("20260315T190000Z");
+	});
+
+	it("formats midnight correctly", () => {
+		const date = new Date("2026-01-01T00:00:00Z");
+		expect(formatICalDate(date)).toBe("20260101T000000Z");
+	});
+
+	it("formats end-of-day correctly", () => {
+		const date = new Date("2026-12-31T23:59:59Z");
+		expect(formatICalDate(date)).toBe("20261231T235959Z");
+	});
+});
+
+describe("escapeICalText", () => {
+	it("escapes backslashes", () => {
+		expect(escapeICalText("back\\slash")).toBe("back\\\\slash");
+	});
+
+	it("escapes semicolons", () => {
+		expect(escapeICalText("semi;colon")).toBe("semi\\;colon");
+	});
+
+	it("escapes commas", () => {
+		expect(escapeICalText("com,ma")).toBe("com\\,ma");
+	});
+
+	it("escapes newlines", () => {
+		expect(escapeICalText("line\nbreak")).toBe("line\\nbreak");
+	});
+
+	it("escapes multiple special characters", () => {
+		expect(escapeICalText("a;b,c\\d\ne")).toBe("a\\;b\\,c\\\\d\\ne");
+	});
+
+	it("returns plain text unchanged", () => {
+		expect(escapeICalText("Hello World")).toBe("Hello World");
+	});
+});
+
+describe("foldLine", () => {
+	it("returns short lines unchanged", () => {
+		expect(foldLine("SHORT LINE")).toBe("SHORT LINE");
+	});
+
+	it("returns a line of exactly 75 chars unchanged", () => {
+		const line = "A".repeat(75);
+		expect(foldLine(line)).toBe(line);
+	});
+
+	it("folds long lines at 75 chars with continuation space", () => {
+		const line = "A".repeat(150);
+		const folded = foldLine(line);
+		// First line: 75 chars, then continuation lines start with space
+		const parts = folded.split("\r\n");
+		expect(parts[0]).toHaveLength(75);
+		expect(parts[1]).toMatch(/^ /);
+	});
+
+	it("unfolding reconstructs the original line", () => {
+		const line = "B".repeat(200);
+		const folded = foldLine(line);
+		// RFC 5545: unfold by removing CRLF + single whitespace
+		const unfolded = folded.replace(/\r\n /g, "");
+		expect(unfolded).toBe(line);
+	});
+});
+
+describe("generateCalendarFeed", () => {
+	const baseEvent: CalendarEvent = {
+		id: "event-1",
+		title: "Friday Rehearsal",
+		description: "Weekly practice",
+		location: "Main Theater",
+		startTime: new Date("2026-03-15T19:00:00Z"),
+		endTime: new Date("2026-03-15T21:00:00Z"),
+		callTime: null,
+		eventType: "rehearsal",
+		groupName: "Team Alpha",
+		userRole: null,
+		updatedAt: new Date("2026-03-10T12:00:00Z"),
+	};
+
+	it("generates valid VCALENDAR structure", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("BEGIN:VCALENDAR");
+		expect(feed).toContain("END:VCALENDAR");
+		expect(feed).toContain("VERSION:2.0");
+		expect(feed).toContain("METHOD:PUBLISH");
+		expect(feed).toContain("X-WR-CALNAME:My Call Time");
+	});
+
+	it("generates VEVENT for each event", () => {
+		const events = [baseEvent, { ...baseEvent, id: "event-2", title: "Saturday Show" }];
+		const feed = generateCalendarFeed(events);
+		const beginCount = (feed.match(/BEGIN:VEVENT/g) || []).length;
+		const endCount = (feed.match(/END:VEVENT/g) || []).length;
+		expect(beginCount).toBe(2);
+		expect(endCount).toBe(2);
+	});
+
+	it("uses correct UID format", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("UID:event-1@mycalltime.app");
+	});
+
+	it("includes SUMMARY, DESCRIPTION, LOCATION", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("SUMMARY:Friday Rehearsal");
+		expect(feed).toContain("DESCRIPTION:");
+		expect(feed).toContain("LOCATION:Main Theater");
+	});
+
+	it("includes group name in description", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("Group: Team Alpha");
+	});
+
+	it("includes group name as CATEGORIES", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("CATEGORIES:Team Alpha");
+	});
+
+	it("includes LAST-MODIFIED from updatedAt", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("LAST-MODIFIED:20260310T120000Z");
+	});
+
+	it("uses startTime for non-performer events", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("DTSTART:20260315T190000Z");
+		expect(feed).toContain("DTEND:20260315T210000Z");
+	});
+
+	it("uses callTime for performers at shows", () => {
+		const showEvent: CalendarEvent = {
+			...baseEvent,
+			eventType: "show",
+			callTime: new Date("2026-03-15T18:00:00Z"),
+			userRole: "Performer",
+		};
+		const feed = generateCalendarFeed([showEvent]);
+		expect(feed).toContain("DTSTART:20260315T180000Z");
+	});
+
+	it("uses startTime for non-performers at shows with callTime", () => {
+		const showEvent: CalendarEvent = {
+			...baseEvent,
+			eventType: "show",
+			callTime: new Date("2026-03-15T18:00:00Z"),
+			userRole: "Viewer",
+		};
+		const feed = generateCalendarFeed([showEvent]);
+		expect(feed).toContain("DTSTART:20260315T190000Z");
+	});
+
+	it("uses startTime for performers at non-show events", () => {
+		const event: CalendarEvent = {
+			...baseEvent,
+			eventType: "rehearsal",
+			callTime: new Date("2026-03-15T18:00:00Z"),
+			userRole: "Performer",
+		};
+		const feed = generateCalendarFeed([event]);
+		expect(feed).toContain("DTSTART:20260315T190000Z");
+	});
+
+	it("omits DESCRIPTION when no description and no group name", () => {
+		const event: CalendarEvent = {
+			...baseEvent,
+			description: null,
+			groupName: "",
+		};
+		const feed = generateCalendarFeed([event]);
+		expect(feed).not.toContain("DESCRIPTION:");
+	});
+
+	it("omits LOCATION when not set", () => {
+		const event: CalendarEvent = {
+			...baseEvent,
+			location: null,
+		};
+		const feed = generateCalendarFeed([event]);
+		expect(feed).not.toContain("LOCATION:");
+	});
+
+	it("generates empty feed with no events", () => {
+		const feed = generateCalendarFeed([]);
+		expect(feed).toContain("BEGIN:VCALENDAR");
+		expect(feed).toContain("END:VCALENDAR");
+		expect(feed).not.toContain("BEGIN:VEVENT");
+	});
+
+	it("uses CRLF line endings", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		expect(feed).toContain("\r\n");
+		// Should not have bare LF (all LF should be preceded by CR)
+		const lines = feed.split("\r\n");
+		for (const line of lines) {
+			expect(line).not.toContain("\n");
+		}
+	});
+});

--- a/app/lib/ical-utils.test.ts
+++ b/app/lib/ical-utils.test.ts
@@ -203,6 +203,13 @@ describe("generateCalendarFeed", () => {
 		expect(feed).not.toContain("BEGIN:VEVENT");
 	});
 
+	it("separates group name and description with iCal newline", () => {
+		const feed = generateCalendarFeed([baseEvent]);
+		// iCal newline is \n escaped as \\n in the raw text
+		expect(feed).toContain("Group: Team Alpha\\nWeekly practice");
+		expect(feed).not.toContain("Group: Team Alpha\\\\nWeekly practice");
+	});
+
 	it("uses CRLF line endings", () => {
 		const feed = generateCalendarFeed([baseEvent]);
 		expect(feed).toContain("\r\n");

--- a/app/lib/ical-utils.ts
+++ b/app/lib/ical-utils.ts
@@ -87,7 +87,7 @@ export function generateCalendarFeed(calendarEvents: CalendarEvent[]): string {
 			descParts.push(event.description);
 		}
 		if (descParts.length > 0) {
-			eventLines.push(foldLine(`DESCRIPTION:${escapeICalText(descParts.join("\\n"))}`));
+			eventLines.push(foldLine(`DESCRIPTION:${escapeICalText(descParts.join("\n"))}`));
 		}
 
 		if (event.location) {

--- a/app/lib/ical-utils.ts
+++ b/app/lib/ical-utils.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared iCalendar (RFC 5545) utility functions.
+ */
+
+/** Format a Date to iCalendar UTC date-time string (e.g. 20260315T190000Z). */
+export function formatICalDate(date: Date): string {
+	return date
+		.toISOString()
+		.replace(/[-:]/g, "")
+		.replace(/\.\d{3}/, "");
+}
+
+/** Escape text for iCalendar property values (RFC 5545 §3.3.11). */
+export function escapeICalText(text: string): string {
+	return text
+		.replace(/\\/g, "\\\\")
+		.replace(/;/g, "\\;")
+		.replace(/,/g, "\\,")
+		.replace(/\n/g, "\\n");
+}
+
+/** Fold a content line to 75 octets per RFC 5545 §3.1. */
+export function foldLine(line: string): string {
+	const maxLen = 75;
+	if (line.length <= maxLen) return line;
+	const parts: string[] = [];
+	parts.push(line.slice(0, maxLen));
+	let i = maxLen;
+	while (i < line.length) {
+		parts.push(` ${line.slice(i, i + maxLen - 1)}`);
+		i += maxLen - 1;
+	}
+	return parts.join("\r\n");
+}
+
+export interface CalendarEvent {
+	id: string;
+	title: string;
+	description: string | null;
+	location: string | null;
+	startTime: Date;
+	endTime: Date;
+	callTime: Date | null;
+	eventType: string;
+	groupName: string;
+	userRole: string | null;
+	updatedAt: Date;
+}
+
+/**
+ * Generate a multi-event iCalendar feed (VCALENDAR with multiple VEVENTs).
+ * Uses UTC times throughout (no VTIMEZONE needed).
+ */
+export function generateCalendarFeed(calendarEvents: CalendarEvent[]): string {
+	const now = new Date();
+	const lines: string[] = [
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"PRODID:-//My Call Time//Calendar Feed//EN",
+		"CALSCALE:GREGORIAN",
+		"METHOD:PUBLISH",
+		foldLine("X-WR-CALNAME:My Call Time"),
+	];
+
+	for (const event of calendarEvents) {
+		const isPerformerAtShow =
+			event.userRole === "Performer" && event.eventType === "show" && event.callTime;
+		const startTime = isPerformerAtShow ? (event.callTime as Date) : event.startTime;
+		const uid = `${event.id}@mycalltime.app`;
+
+		const eventLines: string[] = [
+			"BEGIN:VEVENT",
+			foldLine(`UID:${uid}`),
+			`DTSTAMP:${formatICalDate(now)}`,
+			`DTSTART:${formatICalDate(startTime)}`,
+			`DTEND:${formatICalDate(event.endTime)}`,
+			`LAST-MODIFIED:${formatICalDate(event.updatedAt)}`,
+			foldLine(`SUMMARY:${escapeICalText(event.title)}`),
+		];
+
+		// Include group name in description
+		const descParts: string[] = [];
+		if (event.groupName) {
+			descParts.push(`Group: ${event.groupName}`);
+		}
+		if (event.description) {
+			descParts.push(event.description);
+		}
+		if (descParts.length > 0) {
+			eventLines.push(foldLine(`DESCRIPTION:${escapeICalText(descParts.join("\\n"))}`));
+		}
+
+		if (event.location) {
+			eventLines.push(foldLine(`LOCATION:${escapeICalText(event.location)}`));
+		}
+
+		if (event.groupName) {
+			eventLines.push(foldLine(`CATEGORIES:${escapeICalText(event.groupName)}`));
+		}
+
+		eventLines.push("END:VEVENT");
+		lines.push(...eventLines);
+	}
+
+	lines.push("END:VCALENDAR");
+	return lines.join("\r\n");
+}

--- a/app/routes/api.calendar.$token.ics.test.ts
+++ b/app/routes/api.calendar.$token.ics.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock calendar token service
+vi.mock("~/services/calendar-token.server", () => ({
+	getUserByCalendarToken: vi.fn(),
+}));
+
+// Mock events service
+vi.mock("~/services/events.server", () => ({
+	getUserCalendarEvents: vi.fn(),
+}));
+
+// Mock logger
+vi.mock("~/services/logger.server", () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}));
+
+// Mock db
+vi.mock("../../src/db/index.js", () => ({
+	db: {},
+}));
+
+import { getUserByCalendarToken } from "~/services/calendar-token.server";
+import { getUserCalendarEvents } from "~/services/events.server";
+import { loader } from "./api.calendar.$token.ics";
+
+describe("GET /api/calendar/:token.ics", () => {
+	const mockEvents = [
+		{
+			id: "event-1",
+			groupId: "group-1",
+			title: "Friday Rehearsal",
+			description: "Weekly practice",
+			eventType: "rehearsal",
+			startTime: new Date("2026-03-15T19:00:00Z"),
+			endTime: new Date("2026-03-15T21:00:00Z"),
+			callTime: null,
+			location: "Main Theater",
+			timezone: "America/Los_Angeles",
+			createdById: "user-1",
+			createdFromRequestId: null,
+			reminderSentAt: null,
+			confirmationReminderSentAt: null,
+			createdAt: new Date("2026-03-01T00:00:00Z"),
+			updatedAt: new Date("2026-03-10T12:00:00Z"),
+			groupName: "Team Alpha",
+			userRole: null,
+		},
+		{
+			id: "event-2",
+			groupId: "group-2",
+			title: "Saturday Show",
+			description: "Big show night",
+			eventType: "show",
+			startTime: new Date("2026-03-16T20:00:00Z"),
+			endTime: new Date("2026-03-16T22:00:00Z"),
+			callTime: new Date("2026-03-16T19:00:00Z"),
+			location: "Grand Stage",
+			timezone: "America/New_York",
+			createdById: "user-2",
+			createdFromRequestId: null,
+			reminderSentAt: null,
+			confirmationReminderSentAt: null,
+			createdAt: new Date("2026-03-05T00:00:00Z"),
+			updatedAt: new Date("2026-03-12T12:00:00Z"),
+			groupName: "Team Beta",
+			userRole: "Performer",
+		},
+	];
+
+	it("returns valid iCal feed for valid token", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: "America/Los_Angeles",
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).toContain("BEGIN:VCALENDAR");
+		expect(body).toContain("END:VCALENDAR");
+		expect(body).toContain("METHOD:PUBLISH");
+		expect(body).toContain("X-WR-CALNAME:My Call Time");
+	});
+
+	it("returns correct Content-Type header", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		expect(response.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
+	});
+
+	it("does not include Content-Disposition header", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		expect(response.headers.get("Content-Disposition")).toBeNull();
+	});
+
+	it("sets cache control to private, no-store", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+	});
+
+	it("sets X-Robots-Tag to prevent indexing", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		expect(response.headers.get("X-Robots-Tag")).toBe("noindex, nofollow");
+	});
+
+	it("returns 404 for invalid token", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+		await expect(
+			loader({
+				request: new Request("http://localhost/api/calendar/badtoken.ics"),
+				params: { token: "badtoken" },
+				context: {},
+			}),
+		).rejects.toThrow();
+	});
+
+	it("returns 404 when token param is missing", async () => {
+		await expect(
+			loader({
+				request: new Request("http://localhost/api/calendar/.ics"),
+				params: {},
+				context: {},
+			}),
+		).rejects.toThrow();
+	});
+
+	it("includes events from multiple groups", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		const body = await response.text();
+		expect(body).toContain("SUMMARY:Friday Rehearsal");
+		expect(body).toContain("SUMMARY:Saturday Show");
+		expect(body).toContain("CATEGORIES:Team Alpha");
+		expect(body).toContain("CATEGORIES:Team Beta");
+	});
+
+	it("uses callTime for performers at shows", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		const body = await response.text();
+		// Event 2 is a show with Performer role — should use callTime (19:00Z)
+		expect(body).toContain("DTSTART:20260316T190000Z");
+	});
+
+	it("returns empty feed for user with no events", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request("http://localhost/api/calendar/validtoken.ics"),
+			params: { token: "validtoken" },
+			context: {},
+		});
+
+		const body = await response.text();
+		expect(body).toContain("BEGIN:VCALENDAR");
+		expect(body).toContain("END:VCALENDAR");
+		expect(body).not.toContain("BEGIN:VEVENT");
+	});
+});

--- a/app/routes/api.calendar.$token.ics.tsx
+++ b/app/routes/api.calendar.$token.ics.tsx
@@ -1,0 +1,43 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { generateCalendarFeed } from "~/lib/ical-utils";
+import { getUserByCalendarToken } from "~/services/calendar-token.server";
+import { getUserCalendarEvents } from "~/services/events.server";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+	const token = params.token;
+	if (!token) {
+		throw new Response("Not Found", { status: 404 });
+	}
+
+	const user = await getUserByCalendarToken(token);
+	if (!user) {
+		throw new Response("Not Found", { status: 404 });
+	}
+
+	const events = await getUserCalendarEvents(user.id);
+
+	const calendarEvents = events.map((event) => ({
+		id: event.id,
+		title: event.title,
+		description: event.description,
+		location: event.location,
+		startTime: new Date(event.startTime as unknown as string),
+		endTime: new Date(event.endTime as unknown as string),
+		callTime: event.callTime ? new Date(event.callTime as unknown as string) : null,
+		eventType: event.eventType,
+		groupName: event.groupName,
+		userRole: event.userRole,
+		updatedAt: new Date(event.updatedAt as unknown as string),
+	}));
+
+	const icsContent = generateCalendarFeed(calendarEvents);
+
+	return new Response(icsContent, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/calendar; charset=utf-8",
+			"Cache-Control": "private, no-store",
+			"X-Robots-Tag": "noindex, nofollow",
+		},
+	});
+}

--- a/app/routes/api.events.$eventId.ics.tsx
+++ b/app/routes/api.events.$eventId.ics.tsx
@@ -1,35 +1,8 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import { escapeICalText, foldLine, formatICalDate } from "~/lib/ical-utils";
 import { requireUser } from "~/services/auth.server";
 import { getEventWithAssignments } from "~/services/events.server";
 import { requireGroupMember } from "~/services/groups.server";
-
-function formatICalDate(date: Date): string {
-	return date
-		.toISOString()
-		.replace(/[-:]/g, "")
-		.replace(/\.\d{3}/, "");
-}
-
-function escapeICalText(text: string): string {
-	return text
-		.replace(/\\/g, "\\\\")
-		.replace(/;/g, "\\;")
-		.replace(/,/g, "\\,")
-		.replace(/\n/g, "\\n");
-}
-
-function foldLine(line: string): string {
-	const maxLen = 75;
-	if (line.length <= maxLen) return line;
-	const parts: string[] = [];
-	parts.push(line.slice(0, maxLen));
-	let i = maxLen;
-	while (i < line.length) {
-		parts.push(` ${line.slice(i, i + maxLen - 1)}`);
-		i += maxLen - 1;
-	}
-	return parts.join("\r\n");
-}
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	await requireUser(request);

--- a/app/routes/settings.test.ts
+++ b/app/routes/settings.test.ts
@@ -18,8 +18,15 @@ vi.mock("~/services/csrf.server", () => ({
 	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock calendar token service
+vi.mock("~/services/calendar-token.server", () => ({
+	getCalendarToken: vi.fn().mockResolvedValue(null),
+	regenerateCalendarToken: vi.fn().mockResolvedValue("new-generated-token-hex"),
+}));
+
 import { action, loader } from "~/routes/settings";
 import { requireUser, updateUserName, updateUserTimezone } from "~/services/auth.server";
+import { getCalendarToken, regenerateCalendarToken } from "~/services/calendar-token.server";
 
 function makeFormData(data: Record<string, string>): FormData {
 	const formData = new FormData();
@@ -46,10 +53,15 @@ describe("settings route", () => {
 			profileImage: null,
 			timezone: "America/New_York",
 		});
+		(getCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+		(regenerateCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue(
+			"new-generated-token-hex",
+		);
 	});
 
 	describe("loader", () => {
-		it("returns the authenticated user", async () => {
+		it("returns the authenticated user and calendar token", async () => {
+			(getCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue("existing-token-abc");
 			const request = new Request("http://localhost/settings");
 			const result = await loader({ request, params: {}, context: {} });
 			expect(result).toEqual({
@@ -60,7 +72,15 @@ describe("settings route", () => {
 					profileImage: null,
 					timezone: "America/New_York",
 				},
+				calendarToken: "existing-token-abc",
+				baseUrl: "http://localhost",
 			});
+		});
+
+		it("returns null calendarToken when user has no token", async () => {
+			const request = new Request("http://localhost/settings");
+			const result = await loader({ request, params: {}, context: {} });
+			expect(result.calendarToken).toBeNull();
 		});
 	});
 
@@ -212,6 +232,40 @@ describe("settings route", () => {
 			});
 			expect(result).toEqual({ success: true, message: "Timezone updated!" });
 			expect(updateUserTimezone).toHaveBeenCalledWith("user-1", "UTC");
+		});
+	});
+
+	describe("action — generate-calendar-token", () => {
+		it("generates a new calendar token", async () => {
+			const formData = makeFormData({ intent: "generate-calendar-token" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({
+				success: true,
+				message: "Calendar feed URL generated!",
+				calendarToken: "new-generated-token-hex",
+			});
+			expect(regenerateCalendarToken).toHaveBeenCalledWith("user-1");
+		});
+	});
+
+	describe("action — regenerate-calendar-token", () => {
+		it("regenerates the calendar token", async () => {
+			const formData = makeFormData({ intent: "regenerate-calendar-token" });
+			const result = await action({
+				request: makeRequest(formData),
+				params: {},
+				context: {},
+			});
+			expect(result).toEqual({
+				success: true,
+				message: "Calendar feed URL regenerated! Update the URL in your calendar app.",
+				calendarToken: "new-generated-token-hex",
+			});
+			expect(regenerateCalendarToken).toHaveBeenCalledWith("user-1");
 		});
 	});
 

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -262,7 +262,14 @@ export default function Settings() {
 							/>
 						</details>
 
-						<Form method="post">
+						<Form
+							method="post"
+							onSubmit={(e) => {
+								if (!confirm("Regenerate your calendar URL? Your current URL will stop working.")) {
+									e.preventDefault();
+								}
+							}}
+						>
 							<CsrfInput />
 							<input type="hidden" name="intent" value="regenerate-calendar-token" />
 							<button

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,11 +1,22 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { Form, Link, useActionData, useLoaderData, useNavigation } from "@remix-run/react";
-import { AlertTriangle, Globe, Save, User } from "lucide-react";
+import {
+	AlertTriangle,
+	CalendarSync,
+	Check,
+	Copy,
+	Globe,
+	RefreshCw,
+	Save,
+	User,
+} from "lucide-react";
+import { useState } from "react";
 import { CsrfInput } from "~/components/csrf-input";
 import { DangerZone } from "~/components/danger-zone";
 import { COMMON_TIMEZONES, getTimezoneLabel } from "~/components/timezone-selector";
 import { isValidTimezone } from "~/lib/date-utils";
 import { requireUser, updateUserName, updateUserTimezone } from "~/services/auth.server";
+import { getCalendarToken, regenerateCalendarToken } from "~/services/calendar-token.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 
 export const meta: MetaFunction = () => {
@@ -14,7 +25,10 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const user = await requireUser(request);
-	return { user };
+	const calendarToken = await getCalendarToken(user.id);
+	const url = new URL(request.url);
+	const baseUrl = `${url.protocol}//${url.host}`;
+	return { user, calendarToken, baseUrl };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -49,14 +63,44 @@ export async function action({ request }: ActionFunctionArgs) {
 		return { success: true, message: "Timezone updated!" };
 	}
 
+	if (intent === "generate-calendar-token") {
+		const token = await regenerateCalendarToken(user.id);
+		return { success: true, message: "Calendar feed URL generated!", calendarToken: token };
+	}
+
+	if (intent === "regenerate-calendar-token") {
+		const token = await regenerateCalendarToken(user.id);
+		return {
+			success: true,
+			message: "Calendar feed URL regenerated! Update the URL in your calendar app.",
+			calendarToken: token,
+		};
+	}
+
 	return { error: "Invalid action." };
 }
 
 export default function Settings() {
-	const { user } = useLoaderData<typeof loader>();
+	const { user, calendarToken, baseUrl } = useLoaderData<typeof loader>();
 	const actionData = useActionData<typeof action>();
 	const navigation = useNavigation();
 	const isSubmitting = navigation.state === "submitting";
+	const [copied, setCopied] = useState(false);
+
+	// Use the token from action response (after generate/regenerate) or from loader
+	const activeToken =
+		actionData && "calendarToken" in actionData ? actionData.calendarToken : calendarToken;
+
+	const feedHttpsUrl = activeToken ? `${baseUrl}/api/calendar/${activeToken}.ics` : null;
+	const feedWebcalUrl = feedHttpsUrl ? feedHttpsUrl.replace(/^https?:\/\//, "webcal://") : null;
+
+	function handleCopy() {
+		if (feedWebcalUrl) {
+			navigator.clipboard.writeText(feedWebcalUrl);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
+	}
 
 	return (
 		<div className="mx-auto max-w-2xl">
@@ -159,6 +203,96 @@ export default function Settings() {
 						</button>
 					</div>
 				</Form>
+			</div>
+
+			{/* Calendar Feed */}
+			<div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+				<h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+					<CalendarSync className="h-5 w-5 text-slate-400" />
+					Calendar Feed
+				</h2>
+				<p className="mt-1 text-sm text-slate-600">
+					Subscribe to your events in Apple Calendar, Google Calendar, or Outlook. Events from all
+					your groups appear automatically.
+				</p>
+
+				{activeToken ? (
+					<div className="mt-4 space-y-4">
+						<div>
+							<label htmlFor="webcal-url" className="block text-sm font-medium text-slate-700">
+								Calendar URL (webcal)
+							</label>
+							<div className="mt-1 flex gap-2">
+								<input
+									type="text"
+									id="webcal-url"
+									readOnly
+									value={feedWebcalUrl ?? ""}
+									className="block flex-1 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 font-mono text-sm text-slate-700 shadow-sm"
+								/>
+								<button
+									type="button"
+									onClick={handleCopy}
+									className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50"
+								>
+									{copied ? (
+										<>
+											<Check className="h-4 w-4 text-emerald-600" />
+											Copied
+										</>
+									) : (
+										<>
+											<Copy className="h-4 w-4" />
+											Copy
+										</>
+									)}
+								</button>
+							</div>
+						</div>
+
+						<details className="text-sm text-slate-600">
+							<summary className="cursor-pointer font-medium text-slate-700 hover:text-slate-900">
+								HTTPS URL (for Google Calendar)
+							</summary>
+							<input
+								type="text"
+								readOnly
+								value={feedHttpsUrl ?? ""}
+								className="mt-2 block w-full rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 font-mono text-sm text-slate-700 shadow-sm"
+							/>
+						</details>
+
+						<Form method="post">
+							<CsrfInput />
+							<input type="hidden" name="intent" value="regenerate-calendar-token" />
+							<button
+								type="submit"
+								disabled={isSubmitting}
+								className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 disabled:opacity-50"
+							>
+								<RefreshCw className="h-4 w-4" />
+								{isSubmitting ? "Regenerating..." : "Regenerate URL"}
+							</button>
+							<p className="mt-1.5 text-xs text-slate-500">
+								Regenerating will invalidate your current URL. You'll need to re-add the new URL to
+								your calendar app.
+							</p>
+						</Form>
+					</div>
+				) : (
+					<Form method="post" className="mt-4">
+						<CsrfInput />
+						<input type="hidden" name="intent" value="generate-calendar-token" />
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+						>
+							<CalendarSync className="h-4 w-4" />
+							{isSubmitting ? "Generating..." : "Generate Calendar URL"}
+						</button>
+					</Form>
+				)}
 			</div>
 
 			{/* Account Info (read-only) */}

--- a/app/services/calendar-token.server.ts
+++ b/app/services/calendar-token.server.ts
@@ -3,12 +3,6 @@ import { eq } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import { calendarTokens, users } from "../../src/db/schema.js";
 
-export async function createCalendarToken(userId: string): Promise<string> {
-	const token = crypto.randomBytes(32).toString("hex");
-	await db.insert(calendarTokens).values({ userId, token });
-	return token;
-}
-
 export async function getCalendarToken(userId: string): Promise<string | null> {
 	const [row] = await db
 		.select({ token: calendarTokens.token })
@@ -45,22 +39,14 @@ export async function getUserByCalendarToken(
 		.select({
 			id: users.id,
 			timezone: users.timezone,
+			deletedAt: users.deletedAt,
 		})
 		.from(calendarTokens)
 		.innerJoin(users, eq(calendarTokens.userId, users.id))
 		.where(eq(calendarTokens.token, token))
 		.limit(1);
 
-	if (!row) return null;
+	if (!row || row.deletedAt) return null;
 
-	// Check if user is soft-deleted
-	const [userRow] = await db
-		.select({ deletedAt: users.deletedAt })
-		.from(users)
-		.where(eq(users.id, row.id))
-		.limit(1);
-
-	if (userRow?.deletedAt) return null;
-
-	return row;
+	return { id: row.id, timezone: row.timezone };
 }

--- a/app/services/calendar-token.server.ts
+++ b/app/services/calendar-token.server.ts
@@ -1,0 +1,66 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { calendarTokens, users } from "../../src/db/schema.js";
+
+export async function createCalendarToken(userId: string): Promise<string> {
+	const token = crypto.randomBytes(32).toString("hex");
+	await db.insert(calendarTokens).values({ userId, token });
+	return token;
+}
+
+export async function getCalendarToken(userId: string): Promise<string | null> {
+	const [row] = await db
+		.select({ token: calendarTokens.token })
+		.from(calendarTokens)
+		.where(eq(calendarTokens.userId, userId))
+		.limit(1);
+	return row?.token ?? null;
+}
+
+export async function regenerateCalendarToken(userId: string): Promise<string> {
+	const token = crypto.randomBytes(32).toString("hex");
+	const [existing] = await db
+		.select({ id: calendarTokens.id })
+		.from(calendarTokens)
+		.where(eq(calendarTokens.userId, userId))
+		.limit(1);
+
+	if (existing) {
+		await db
+			.update(calendarTokens)
+			.set({ token, createdAt: new Date() })
+			.where(eq(calendarTokens.userId, userId));
+	} else {
+		await db.insert(calendarTokens).values({ userId, token });
+	}
+
+	return token;
+}
+
+export async function getUserByCalendarToken(
+	token: string,
+): Promise<{ id: string; timezone: string | null } | null> {
+	const [row] = await db
+		.select({
+			id: users.id,
+			timezone: users.timezone,
+		})
+		.from(calendarTokens)
+		.innerJoin(users, eq(calendarTokens.userId, users.id))
+		.where(eq(calendarTokens.token, token))
+		.limit(1);
+
+	if (!row) return null;
+
+	// Check if user is soft-deleted
+	const [userRow] = await db
+		.select({ deletedAt: users.deletedAt })
+		.from(users)
+		.where(eq(users.id, row.id))
+		.limit(1);
+
+	if (userRow?.deletedAt) return null;
+
+	return row;
+}

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, or, sql } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import {
 	availabilityRequests,
@@ -465,6 +465,9 @@ export async function getUserCalendarEvents(
 	const thirtyDaysAgo = new Date();
 	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
+	const sixMonthsOut = new Date();
+	sixMonthsOut.setMonth(sixMonthsOut.getMonth() + 6);
+
 	const rows = await db
 		.select({
 			id: events.id,
@@ -496,7 +499,7 @@ export async function getUserCalendarEvents(
 			groupMemberships,
 			and(eq(groupMemberships.groupId, groups.id), eq(groupMemberships.userId, userId)),
 		)
-		.where(gte(events.startTime, thirtyDaysAgo))
+		.where(and(gte(events.startTime, thirtyDaysAgo), lte(events.startTime, sixMonthsOut)))
 		.orderBy(events.startTime);
 
 	return rows;

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -457,6 +457,51 @@ export async function getUserUpcomingEvents(
 	return rows;
 }
 
+// --- Calendar feed events (upcoming + recent past, with user's assignment role) ---
+
+export async function getUserCalendarEvents(
+	userId: string,
+): Promise<Array<Event & { groupName: string; userRole: string | null }>> {
+	const thirtyDaysAgo = new Date();
+	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+	const rows = await db
+		.select({
+			id: events.id,
+			groupId: events.groupId,
+			title: events.title,
+			description: events.description,
+			eventType: events.eventType,
+			startTime: events.startTime,
+			endTime: events.endTime,
+			location: events.location,
+			createdById: events.createdById,
+			createdFromRequestId: events.createdFromRequestId,
+			callTime: events.callTime,
+			timezone: events.timezone,
+			reminderSentAt: events.reminderSentAt,
+			confirmationReminderSentAt: events.confirmationReminderSentAt,
+			createdAt: events.createdAt,
+			updatedAt: events.updatedAt,
+			groupName: groups.name,
+			userRole: sql<string | null>`(
+				SELECT ea.role FROM event_assignments ea
+				WHERE ea.event_id = events.id AND ea.user_id = ${userId}
+				LIMIT 1
+			)`,
+		})
+		.from(events)
+		.innerJoin(groups, eq(events.groupId, groups.id))
+		.innerJoin(
+			groupMemberships,
+			and(eq(groupMemberships.groupId, groups.id), eq(groupMemberships.userId, userId)),
+		)
+		.where(gte(events.startTime, thirtyDaysAgo))
+		.orderBy(events.startTime);
+
+	return rows;
+}
+
 // --- Availability request ownership check ---
 
 export async function getAvailabilityRequestGroupId(requestId: string): Promise<string | null> {

--- a/drizzle/0015_sticky_leper_queen.sql
+++ b/drizzle/0015_sticky_leper_queen.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "calendar_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token" varchar(64) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "calendar_tokens_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "calendar_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "calendar_tokens" ADD CONSTRAINT "calendar_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "4957071d-a56a-4cca-a29d-5c6d576419c3",
-  "prevId": "8b50307a-a350-493d-bd01-e40f36acb2dc",
+  "id": "02f0375f-b431-4d20-80a7-e3004248a26e",
+  "prevId": "4957071d-a56a-4cca-a29d-5c6d576419c3",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ccbed80a-ebe5-47e2-a199-5f478b445393",
-  "prevId": "02f0375f-b431-4d20-80a7-e3004248a26e",
+  "id": "53c8c260-ca19-4bee-b10b-788224acdb4e",
+  "prevId": "ccbed80a-ebe5-47e2-a199-5f478b445393",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -251,6 +251,74 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_tokens": {
+      "name": "calendar_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_tokens_user_id_users_id_fk": {
+          "name": "calendar_tokens_user_id_users_id_fk",
+          "tableFrom": "calendar_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_tokens_user_id_unique": {
+          "name": "calendar_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "calendar_tokens_token_unique": {
+          "name": "calendar_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775939366697,
       "tag": "0014_chief_ser_duncan",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777905664500,
+      "tag": "0015_sticky_leper_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -210,6 +210,17 @@ export const rsvpChanges = pgTable(
 	],
 );
 
+// Calendar Tokens (for subscribable iCal feeds — token-based auth since calendar apps can't use cookies)
+export const calendarTokens = pgTable("calendar_tokens", {
+	id: uuid("id").defaultRandom().primaryKey(),
+	userId: uuid("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" })
+		.unique(),
+	token: varchar("token", { length: 64 }).notNull().unique(),
+	createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 // Event Assignments
 export const eventAssignments = pgTable(
 	"event_assignments",


### PR DESCRIPTION
## Summary

Adds a subscribable iCalendar feed feature so users can add a `webcal://` URL to their calendar app (Apple Calendar, Google Calendar, Outlook) and automatically see all upcoming events across all their groups.

## What Changed

### Schema
- **`calendar_tokens` table** — one token per user (`userId` unique), 64-char hex token, cascade on user delete
- Migration: `drizzle/0015_sticky_leper_queen.sql`

### Shared iCal Utilities (`app/lib/ical-utils.ts`)
- Extracted `formatICalDate`, `escapeICalText`, `foldLine` from the single-event .ics route
- Added `generateCalendarFeed()` for multi-event VCALENDAR output with `LAST-MODIFIED`, `CATEGORIES`, group name in description
- Updated existing single-event route to import from shared module

### Calendar Feed Route (`GET /api/calendar/:token.ics`)
- Token-based auth (calendar apps can't use cookies) — token in URL IS the credential
- Fetches upcoming + past 30 days of events across all user's groups
- Smart `DTSTART`: performers at shows use `callTime`, others use `startTime`
- Security headers: `Cache-Control: private, no-store`, `X-Robots-Tag: noindex, nofollow`
- No `Content-Disposition` (subscription, not download)

### Calendar Token Service (`app/services/calendar-token.server.ts`)
- `createCalendarToken()`, `getCalendarToken()`, `regenerateCalendarToken()`, `getUserByCalendarToken()`
- Token generation via `crypto.randomBytes(32).toString('hex')`
- Soft-deleted users are excluded from token lookup

### Settings UI
- New "Calendar Feed" section with `CalendarSync` icon
- Generate button (creates token on first use via POST, not GET side effect)
- Copy button for webcal:// URL (with clipboard feedback)
- Collapsible HTTPS URL for Google Calendar
- Regenerate button with warning about invalidation

### New Query
- `getUserCalendarEvents(userId)` in `events.server.ts` — separate from `getUserUpcomingEvents` since it needs different time window (past 30 days + all upcoming) and includes user's assignment role

## Tests
- **`app/lib/ical-utils.test.ts`** — 22 unit tests for all iCal utilities and feed generation
- **`app/routes/api.calendar.$token.ics.test.ts`** — 9 integration tests (valid/invalid token, multi-group, performer callTime, headers)
- **`app/routes/settings.test.ts`** — Updated with calendar token tests (generate, regenerate, loader returns token)
- All 712 tests pass ✅

## Quality Gates
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` — 712/712 passing ✅