### PR TITLE
fix: calendar feed route returns HTML instead of iCal content

### DIFF
--- a/app/routes/api.calendar.$token.test.ts
+++ b/app/routes/api.calendar.$token.test.ts
@@ -26,9 +26,11 @@ vi.mock("../../src/db/index.js", () => ({
 
 import { getUserByCalendarToken } from "~/services/calendar-token.server";
 import { getUserCalendarEvents } from "~/services/events.server";
-import { loader } from "./api.calendar.$token.ics";
+import { loader } from "./api.calendar.$token";
 
 describe("GET /api/calendar/:token.ics", () => {
+	const validHexToken = "aabb1122ccdd3344eeff5566aabb1122";
+	const unknownHexToken = "deadbeefdeadbeefdeadbeefdeadbeef";
 	const mockEvents = [
 		{
 			id: "event-1",
@@ -80,8 +82,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -101,8 +103,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -117,8 +119,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -133,8 +135,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -149,21 +151,21 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
 		expect(response.headers.get("X-Robots-Tag")).toBe("noindex, nofollow");
 	});
 
-	it("returns 404 for invalid token", async () => {
+	it("returns 404 for unknown token", async () => {
 		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
 		await expect(
 			loader({
-				request: new Request("http://localhost/api/calendar/badtoken.ics"),
-				params: { token: "badtoken" },
+				request: new Request(`http://localhost/api/calendar/${unknownHexToken}.ics`),
+				params: { token: `${unknownHexToken}.ics` },
 				context: {},
 			}),
 		).rejects.toThrow();
@@ -179,6 +181,26 @@ describe("GET /api/calendar/:token.ics", () => {
 		).rejects.toThrow();
 	});
 
+	it("returns 404 when URL does not end in .ics", async () => {
+		await expect(
+			loader({
+				request: new Request(`http://localhost/api/calendar/${validHexToken}`),
+				params: { token: validHexToken },
+				context: {},
+			}),
+		).rejects.toThrow();
+	});
+
+	it("returns 404 for non-hex token", async () => {
+		await expect(
+			loader({
+				request: new Request("http://localhost/api/calendar/not-a-hex-token.ics"),
+				params: { token: "not-a-hex-token.ics" },
+				context: {},
+			}),
+		).rejects.toThrow();
+	});
+
 	it("includes events from multiple groups", async () => {
 		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
 			id: "user-1",
@@ -187,8 +209,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -207,8 +229,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 
@@ -225,8 +247,8 @@ describe("GET /api/calendar/:token.ics", () => {
 		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
 		const response = await loader({
-			request: new Request("http://localhost/api/calendar/validtoken.ics"),
-			params: { token: "validtoken" },
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
 			context: {},
 		});
 

--- a/app/routes/api.calendar.$token.tsx
+++ b/app/routes/api.calendar.$token.tsx
@@ -4,8 +4,19 @@ import { getUserByCalendarToken } from "~/services/calendar-token.server";
 import { getUserCalendarEvents } from "~/services/events.server";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-	const token = params.token;
-	if (!token) {
+	const rawToken = params.token;
+	if (!rawToken) {
+		throw new Response("Not Found", { status: 404 });
+	}
+
+	// The URL is /api/calendar/TOKEN.ics but Remix flat routing captures the
+	// full path segment (including ".ics") in the $token param. Strip the
+	// extension so we can look up the bare hex token.
+	if (!rawToken.endsWith(".ics")) {
+		throw new Response("Not Found", { status: 404 });
+	}
+	const token = rawToken.slice(0, -4);
+	if (!token || !/^[a-f0-9]+$/.test(token)) {
 		throw new Response("Not Found", { status: 404 });
 	}
 


### PR DESCRIPTION
## Problem

The calendar feed URL (`/api/calendar/TOKEN.ics`) returned HTML instead of iCal content in production. The iCalendar validator at icalendar.org received 5536 bytes but reported "This is not an iCalendar file" and "Missing VCALENDAR object".

## Root Cause

**Remix flat file routing treats dots (`.`) as path separators.** The route file `api.calendar.$token.ics.tsx` mapped to the URL pattern `/api/calendar/:token/ics` (4 path segments). But the feed URL generated in `settings.tsx` was `/api/calendar/TOKEN.ics` (3 segments — `.ics` is part of the token segment, not a separate path).

No route matched the actual URL, so Remix rendered the root `ErrorBoundary` — a full HTML page with nav bar, "Page not found" message, etc. This is the ~5536 bytes of HTML the validator saw.

The existing single-event route (`api.events.$eventId.ics.tsx` → `/api/events/:eventId/ics`) works because its URLs are correctly constructed as `/api/events/ID/ics` with `/ics` as a separate segment.

## Fix

Renamed the route file from `api.calendar.$token.ics.tsx` → `api.calendar.$token.tsx`, which maps to `/api/calendar/:token`. The `$token` param now captures the full URL segment including `.ics` (e.g., `TOKEN.ics`). The loader:

1. Requires the `.ics` extension (404 otherwise)
2. Strips the `.ics` suffix to get the bare token
3. Validates the token is a hex string (tokens are `crypto.randomBytes(32).toString("hex")`)
4. Looks up the token in the database

## Deployment Note

The `calendarTokens` table must exist in production. Verify that the migration creating this table has been deployed. Migrations auto-run on container startup, so this should happen automatically on the next deploy.

## Quality Gates

- ✅ TypeScript strict mode (`pnpm typecheck`)
- ✅ Biome lint (`pnpm lint`)
- ✅ All 733 tests pass (`pnpm test`)
- ✅ Production build succeeds (`pnpm build`)