### PR TITLE
fix: filter calendar feed to only assigned events

### DIFF
--- a/app/routes/api.calendar.$token.test.ts
+++ b/app/routes/api.calendar.$token.test.ts
@@ -257,4 +257,89 @@ describe("GET /api/calendar/:token.ics", () => {
 		expect(body).toContain("END:VCALENDAR");
 		expect(body).not.toContain("BEGIN:VEVENT");
 	});
+
+	it("only includes assigned events (declined events excluded by service)", async () => {
+		// getUserCalendarEvents now filters by assignment status (pending/confirmed).
+		// Declined or unassigned events are never returned by the service layer.
+		const assignedEvents = [
+			{
+				id: "event-assigned",
+				groupId: "group-1",
+				title: "Confirmed Rehearsal",
+				description: null,
+				eventType: "rehearsal",
+				startTime: new Date("2026-03-20T19:00:00Z"),
+				endTime: new Date("2026-03-20T21:00:00Z"),
+				callTime: null,
+				location: null,
+				timezone: "America/Los_Angeles",
+				createdById: "user-2",
+				createdFromRequestId: null,
+				reminderSentAt: null,
+				confirmationReminderSentAt: null,
+				createdAt: new Date("2026-03-01T00:00:00Z"),
+				updatedAt: new Date("2026-03-10T12:00:00Z"),
+				groupName: "Team Alpha",
+				userRole: "Performer",
+			},
+		];
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(assignedEvents);
+
+		const response = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		const body = await response.text();
+		expect(body).toContain("SUMMARY:Confirmed Rehearsal");
+		// No declined or unassigned events should appear
+		expect(body).not.toContain("Declined");
+	});
+
+	it("handles events with null userRole", async () => {
+		// Some assignments may have no explicit role set
+		const eventsWithNullRole = [
+			{
+				id: "event-no-role",
+				groupId: "group-1",
+				title: "Team Meeting",
+				description: null,
+				eventType: "other",
+				startTime: new Date("2026-03-22T18:00:00Z"),
+				endTime: new Date("2026-03-22T19:00:00Z"),
+				callTime: null,
+				location: null,
+				timezone: "America/Los_Angeles",
+				createdById: "user-2",
+				createdFromRequestId: null,
+				reminderSentAt: null,
+				confirmationReminderSentAt: null,
+				createdAt: new Date("2026-03-01T00:00:00Z"),
+				updatedAt: new Date("2026-03-10T12:00:00Z"),
+				groupName: "Team Alpha",
+				userRole: null,
+			},
+		];
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue(eventsWithNullRole);
+
+		const response = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		const body = await response.text();
+		expect(body).toContain("SUMMARY:Team Meeting");
+		// With null role and no callTime, should use regular startTime
+		expect(body).toContain("DTSTART:20260322T180000Z");
+	});
 });

--- a/app/services/__integration__/events.integration.test.ts
+++ b/app/services/__integration__/events.integration.test.ts
@@ -8,7 +8,7 @@
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "../../../src/db/index.js";
-import { eventAssignments, events, rsvpChanges } from "../../../src/db/schema.js";
+import { eventAssignments, events, groupMemberships, rsvpChanges } from "../../../src/db/schema.js";
 import {
 	assignToEvent,
 	bulkAssignToEvent,
@@ -17,6 +17,7 @@ import {
 	getEventActivityFeed,
 	getEventWithAssignments,
 	getGroupEvents,
+	getUserCalendarEvents,
 	getUserUpcomingEvents,
 	recordRsvpChange,
 	removeAssignment,
@@ -781,6 +782,101 @@ describe("events.server integration", () => {
 			const feed2 = await getEventActivityFeed(event2.id);
 			expect(feed2).toHaveLength(1);
 			expect(feed2[0].newStatus).toBe("declined");
+		});
+	});
+
+	// --- getUserCalendarEvents ---
+
+	describe("getUserCalendarEvents", () => {
+		it("returns only events with pending or confirmed assignments", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			const confirmedEvent = await createTestEvent(group.id, user.id, {
+				title: "Confirmed Event",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			const pendingEvent = await createTestEvent(group.id, user.id, {
+				title: "Pending Event",
+				startTime: new Date(now.getTime() + 2 * 86400000),
+				endTime: new Date(now.getTime() + 2 * 86400000 + 7200000),
+			});
+			const declinedEvent = await createTestEvent(group.id, user.id, {
+				title: "Declined Event",
+				startTime: new Date(now.getTime() + 3 * 86400000),
+				endTime: new Date(now.getTime() + 3 * 86400000 + 7200000),
+			});
+			// Create an event with no assignment for this user
+			await createTestEvent(group.id, user.id, {
+				title: "Unassigned Event",
+				startTime: new Date(now.getTime() + 4 * 86400000),
+				endTime: new Date(now.getTime() + 4 * 86400000 + 7200000),
+			});
+
+			await createTestAssignment(confirmedEvent.id, user.id, { status: "confirmed" });
+			await createTestAssignment(pendingEvent.id, user.id, { status: "pending" });
+			await createTestAssignment(declinedEvent.id, user.id, { status: "declined" });
+			// unassignedEvent has no assignment
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+			const titles = calendarEvents.map((e) => e.title);
+
+			expect(titles).toContain("Confirmed Event");
+			expect(titles).toContain("Pending Event");
+			expect(titles).not.toContain("Declined Event");
+			expect(titles).not.toContain("Unassigned Event");
+			expect(calendarEvents).toHaveLength(2);
+		});
+
+		it("returns userRole from event_assignments", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			const showEvent = await createTestEvent(group.id, user.id, {
+				title: "Show Night",
+				eventType: "show",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+				callTime: new Date(now.getTime() + 86400000 - 3600000),
+			});
+			await createTestAssignment(showEvent.id, user.id, {
+				role: "Performer",
+				status: "confirmed",
+			});
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+
+			expect(calendarEvents).toHaveLength(1);
+			expect(calendarEvents[0].userRole).toBe("Performer");
+		});
+
+		it("excludes events from groups the user is no longer a member of", async () => {
+			const admin = await createTestUser({ name: "Admin" });
+			const member = await createTestUser({ name: "Member" });
+			const group = await createTestGroup(admin.id);
+			await addGroupMember(group.id, member.id);
+			const now = new Date();
+
+			const event = await createTestEvent(group.id, admin.id, {
+				title: "Group Event",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			await createTestAssignment(event.id, member.id, { status: "confirmed" });
+
+			// Verify event appears while member
+			let calendarEvents = await getUserCalendarEvents(member.id);
+			expect(calendarEvents).toHaveLength(1);
+
+			// Remove membership (simulates admin removing the member)
+			await db.delete(groupMemberships).where(eq(groupMemberships.userId, member.id));
+
+			// Event should no longer appear even though assignment still exists
+			calendarEvents = await getUserCalendarEvents(member.id);
+			expect(calendarEvents).toHaveLength(0);
 		});
 	});
 });

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -487,11 +487,7 @@ export async function getUserCalendarEvents(
 			createdAt: events.createdAt,
 			updatedAt: events.updatedAt,
 			groupName: groups.name,
-			userRole: sql<string | null>`(
-				SELECT ea.role FROM event_assignments ea
-				WHERE ea.event_id = events.id AND ea.user_id = ${userId}
-				LIMIT 1
-			)`,
+			userRole: eventAssignments.role,
 		})
 		.from(events)
 		.innerJoin(groups, eq(events.groupId, groups.id))
@@ -499,7 +495,17 @@ export async function getUserCalendarEvents(
 			groupMemberships,
 			and(eq(groupMemberships.groupId, groups.id), eq(groupMemberships.userId, userId)),
 		)
-		.where(and(gte(events.startTime, thirtyDaysAgo), lte(events.startTime, sixMonthsOut)))
+		.innerJoin(
+			eventAssignments,
+			and(eq(eventAssignments.eventId, events.id), eq(eventAssignments.userId, userId)),
+		)
+		.where(
+			and(
+				gte(events.startTime, thirtyDaysAgo),
+				lte(events.startTime, sixMonthsOut),
+				inArray(eventAssignments.status, ["pending", "confirmed"]),
+			),
+		)
 		.orderBy(events.startTime);
 
 	return rows;


### PR DESCRIPTION
## Problem

The calendar feed (`/api/calendar/:token.ics`) showed ALL events from a user's groups, including events they declined or weren't assigned to.

## Root Cause

`getUserCalendarEvents` in `events.server.ts` joined on `groupMemberships` (showing all group events) instead of filtering by `eventAssignments`. No status filter excluded declined events.

## Fix

- Added `eventAssignments` inner join filtered by `userId` alongside the existing `groupMemberships` join (kept for security — prevents ex-members with lingering assignments from seeing events)
- Added `inArray(eventAssignments.status, ['pending', 'confirmed'])` to the WHERE clause
- Replaced the correlated `userRole` subquery with a direct `eventAssignments.role` read

## Tests

- Added route-level tests verifying assigned-only events and null userRole handling
- Added integration tests covering:
  - Only pending/confirmed assignments appear (declined and unassigned excluded)
  - `userRole` populated from `eventAssignments.role`
  - Ex-members with lingering assignments don't see events

## Quality Gates

- [x] `pnpm run typecheck` ✅
- [x] `pnpm run lint` ✅
- [x] `pnpm test` ✅ (735 tests)
- [x] `pnpm run build` ✅