### PR TITLE
fix: use LEFT JOIN for eventAssignments in calendar feed query

### DIFF
--- a/app/routes/api.calendar.$token.test.ts
+++ b/app/routes/api.calendar.$token.test.ts
@@ -258,9 +258,10 @@ describe("GET /api/calendar/:token.ics", () => {
 		expect(body).not.toContain("BEGIN:VEVENT");
 	});
 
-	it("only includes assigned events (declined events excluded by service)", async () => {
-		// getUserCalendarEvents now filters by assignment status (pending/confirmed).
-		// Declined or unassigned events are never returned by the service layer.
+	it("only includes non-declined events (declined events excluded by service)", async () => {
+		// getUserCalendarEvents includes all group events except those the user
+		// explicitly declined. Events with no assignment are included (LEFT JOIN).
+		// Declined assignments are the only ones filtered out.
 		const assignedEvents = [
 			{
 				id: "event-assigned",

--- a/app/services/__integration__/events.integration.test.ts
+++ b/app/services/__integration__/events.integration.test.ts
@@ -788,7 +788,7 @@ describe("events.server integration", () => {
 	// --- getUserCalendarEvents ---
 
 	describe("getUserCalendarEvents", () => {
-		it("returns only events with pending or confirmed assignments", async () => {
+		it("returns events with pending/confirmed assignments and events with no assignment", async () => {
 			const user = await createTestUser();
 			const group = await createTestGroup(user.id);
 			const now = new Date();
@@ -826,8 +826,27 @@ describe("events.server integration", () => {
 			expect(titles).toContain("Confirmed Event");
 			expect(titles).toContain("Pending Event");
 			expect(titles).not.toContain("Declined Event");
-			expect(titles).not.toContain("Unassigned Event");
-			expect(calendarEvents).toHaveLength(2);
+			expect(titles).toContain("Unassigned Event");
+			expect(calendarEvents).toHaveLength(3);
+		});
+
+		it("returns null userRole for events with no assignment", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			await createTestEvent(group.id, user.id, {
+				title: "Rehearsal No Assignment",
+				eventType: "rehearsal",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+
+			expect(calendarEvents).toHaveLength(1);
+			expect(calendarEvents[0].title).toBe("Rehearsal No Assignment");
+			expect(calendarEvents[0].userRole).toBeNull();
 		});
 
 		it("returns userRole from event_assignments", async () => {

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import {
 	availabilityRequests,
@@ -495,7 +495,7 @@ export async function getUserCalendarEvents(
 			groupMemberships,
 			and(eq(groupMemberships.groupId, groups.id), eq(groupMemberships.userId, userId)),
 		)
-		.innerJoin(
+		.leftJoin(
 			eventAssignments,
 			and(eq(eventAssignments.eventId, events.id), eq(eventAssignments.userId, userId)),
 		)
@@ -503,7 +503,10 @@ export async function getUserCalendarEvents(
 			and(
 				gte(events.startTime, thirtyDaysAgo),
 				lte(events.startTime, sixMonthsOut),
-				inArray(eventAssignments.status, ["pending", "confirmed"]),
+				or(
+					isNull(eventAssignments.status),
+					inArray(eventAssignments.status, ["pending", "confirmed"]),
+				),
 			),
 		)
 		.orderBy(events.startTime);


### PR DESCRIPTION
## Problem

The calendar feed (PR #194) used an `INNER JOIN` on `eventAssignments`, which caused the feed to return **zero events** for most users. Rehearsals, "other" events, and shows without performer assignments never create `eventAssignment` rows, so the INNER JOIN filtered them all out.

## Fix

- Changed `innerJoin` → `leftJoin` on `eventAssignments` in `getUserCalendarEvents`
- Updated WHERE clause: include events with no assignment row (`isNull`) or `pending`/`confirmed` status; exclude only `declined`
- Updated integration tests to verify unassigned events are included
- Added test for null `userRole` on unassigned events
- Updated unit test description to reflect new semantics

## Quality Gates
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes  
- [x] `pnpm test` — 735/735 tests pass
- [x] `pnpm run build` — succeeds