### PR TITLE
feat: add caching, rate limiting, and ETag support to calendar feed

### DIFF
--- a/app/routes/api.calendar.$token.test.ts
+++ b/app/routes/api.calendar.$token.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock calendar token service
 vi.mock("~/services/calendar-token.server", () => ({
@@ -26,11 +26,17 @@ vi.mock("../../src/db/index.js", () => ({
 
 import { getUserByCalendarToken } from "~/services/calendar-token.server";
 import { getUserCalendarEvents } from "~/services/events.server";
+import { _resetForTests } from "~/services/rate-limit.server";
 import { loader } from "./api.calendar.$token";
 
 describe("GET /api/calendar/:token.ics", () => {
 	const validHexToken = "aabb1122ccdd3344eeff5566aabb1122";
 	const unknownHexToken = "deadbeefdeadbeefdeadbeefdeadbeef";
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		_resetForTests();
+	});
 	const mockEvents = [
 		{
 			id: "event-1",
@@ -127,7 +133,7 @@ describe("GET /api/calendar/:token.ics", () => {
 		expect(response.headers.get("Content-Disposition")).toBeNull();
 	});
 
-	it("sets cache control to private, no-store", async () => {
+	it("sets Cache-Control to public, max-age=300", async () => {
 		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
 			id: "user-1",
 			timezone: null,
@@ -140,7 +146,7 @@ describe("GET /api/calendar/:token.ics", () => {
 			context: {},
 		});
 
-		expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+		expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
 	});
 
 	it("sets X-Robots-Tag to prevent indexing", async () => {
@@ -342,5 +348,99 @@ describe("GET /api/calendar/:token.ics", () => {
 		expect(body).toContain("SUMMARY:Team Meeting");
 		// With null role and no callTime, should use regular startTime
 		expect(body).toContain("DTSTART:20260322T180000Z");
+	});
+
+	it("includes ETag header in response", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		const etag = response.headers.get("ETag");
+		expect(etag).toBeTruthy();
+		expect(etag).toMatch(/^"[a-f0-9]{64}"$/);
+	});
+
+	it("returns 304 Not Modified when If-None-Match matches ETag", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		// First request to get the ETag
+		const first = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+		const etag = first.headers.get("ETag") as string;
+
+		// Second request with If-None-Match
+		const second = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`, {
+				headers: { "If-None-Match": etag },
+			}),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		expect(second.status).toBe(304);
+		const body = await second.text();
+		expect(body).toBe("");
+	});
+
+	it("returns 200 with full content when If-None-Match does not match", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		const response = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`, {
+				headers: { "If-None-Match": '"stale-etag-value"' },
+			}),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).toContain("BEGIN:VCALENDAR");
+	});
+
+	it("returns 429 when rate limited", async () => {
+		(getUserByCalendarToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			timezone: null,
+		});
+		(getUserCalendarEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+		// Exhaust the 30-request limit
+		for (let i = 0; i < 30; i++) {
+			await loader({
+				request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+				params: { token: `${validHexToken}.ics` },
+				context: {},
+			});
+		}
+
+		// 31st request should be rate limited
+		const response = await loader({
+			request: new Request(`http://localhost/api/calendar/${validHexToken}.ics`),
+			params: { token: `${validHexToken}.ics` },
+			context: {},
+		});
+
+		expect(response.status).toBe(429);
+		expect(response.headers.get("Retry-After")).toBeTruthy();
 	});
 });

--- a/app/routes/api.calendar.$token.tsx
+++ b/app/routes/api.calendar.$token.tsx
@@ -1,9 +1,11 @@
+import { createHash } from "node:crypto";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { generateCalendarFeed } from "~/lib/ical-utils";
 import { getUserByCalendarToken } from "~/services/calendar-token.server";
 import { getUserCalendarEvents } from "~/services/events.server";
+import { checkCalendarFeedRateLimit } from "~/services/rate-limit.server";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
 	const rawToken = params.token;
 	if (!rawToken) {
 		throw new Response("Not Found", { status: 404 });
@@ -18,6 +20,15 @@ export async function loader({ params }: LoaderFunctionArgs) {
 	const token = rawToken.slice(0, -4);
 	if (!token || !/^[a-f0-9]+$/.test(token)) {
 		throw new Response("Not Found", { status: 404 });
+	}
+
+	// Rate limit by token — 30 requests per hour
+	const rateLimit = checkCalendarFeedRateLimit(token);
+	if (rateLimit.limited) {
+		return new Response("Too Many Requests", {
+			status: 429,
+			headers: { "Retry-After": String(rateLimit.retryAfter) },
+		});
 	}
 
 	const user = await getUserByCalendarToken(token);
@@ -43,11 +54,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
 	const icsContent = generateCalendarFeed(calendarEvents);
 
+	// ETag for conditional request support
+	const etag = `"${createHash("sha256").update(icsContent).digest("hex")}"`;
+	const ifNoneMatch = request.headers.get("If-None-Match");
+	if (ifNoneMatch === etag) {
+		return new Response(null, {
+			status: 304,
+			headers: {
+				ETag: etag,
+				"Cache-Control": "public, max-age=300",
+			},
+		});
+	}
+
 	return new Response(icsContent, {
 		status: 200,
 		headers: {
 			"Content-Type": "text/calendar; charset=utf-8",
-			"Cache-Control": "private, no-store",
+			"Cache-Control": "public, max-age=300",
+			ETag: etag,
 			"X-Robots-Tag": "noindex, nofollow",
 		},
 	});

--- a/app/services/rate-limit.server.ts
+++ b/app/services/rate-limit.server.ts
@@ -110,6 +110,10 @@ export function checkGroupJoinRateLimit(userId: string) {
 	return checkRateLimit(`group-join:${userId}`, 100, ONE_DAY_MS);
 }
 
+export function checkCalendarFeedRateLimit(token: string) {
+	return checkRateLimit(`calendar-feed:${token}`, 30, ONE_HOUR_MS);
+}
+
 /** Visible for testing */
 export function _resetForTests() {
 	windows.clear();


### PR DESCRIPTION
## What

Hardens the calendar feed endpoint (`/api/calendar/:token.ics`) with three improvements:

### 1. Cache-Control
Changed from `private, no-store` → `public, max-age=300` (5 minutes). Calendar apps poll every 30min–24h, so a 5-minute cache avoids unnecessary DB hits.

### 2. Rate Limiting
Added per-token rate limiting (30 requests/hour) using the existing `checkRateLimit()` infrastructure. Returns 429 with `Retry-After` header when exceeded.

### 3. ETag / Conditional Requests
Computes SHA-256 hash of the iCal content as an ETag. Supports `If-None-Match` → returns 304 Not Modified when content hasn't changed, saving bandwidth.

## Tests
- Cache-Control header updated
- ETag present and valid SHA-256 format
- If-None-Match match → 304
- If-None-Match mismatch → 200 with full body
- Rate limiting → 429 after 30 requests

## Quality Gates
- ✅ typecheck
- ✅ lint
- ✅ 739/739 tests pass
- ✅ build