### PR TITLE
fix: calendar feed filtering — only show cast events to assigned users

### DIFF
--- a/app/routes/api.calendar.$token.test.ts
+++ b/app/routes/api.calendar.$token.test.ts
@@ -264,10 +264,11 @@ describe("GET /api/calendar/:token.ics", () => {
 		expect(body).not.toContain("BEGIN:VEVENT");
 	});
 
-	it("only includes non-declined events (declined events excluded by service)", async () => {
-		// getUserCalendarEvents includes all group events except those the user
-		// explicitly declined. Events with no assignment are included (LEFT JOIN).
-		// Declined assignments are the only ones filtered out.
+	it("only includes events the user should see (cast-filtered by service)", async () => {
+		// getUserCalendarEvents only includes events where:
+		// 1. The event has no assignments at all (open event → shown to all members)
+		// 2. The user is assigned with status 'pending' or 'confirmed'
+		// Events with a cast list where the user is not assigned are excluded.
 		const assignedEvents = [
 			{
 				id: "event-assigned",

--- a/app/services/__integration__/events.integration.test.ts
+++ b/app/services/__integration__/events.integration.test.ts
@@ -788,46 +788,134 @@ describe("events.server integration", () => {
 	// --- getUserCalendarEvents ---
 
 	describe("getUserCalendarEvents", () => {
-		it("returns events with pending/confirmed assignments and events with no assignment", async () => {
+		it("includes event with no assignments at all (open event)", async () => {
 			const user = await createTestUser();
 			const group = await createTestGroup(user.id);
 			const now = new Date();
 
-			const confirmedEvent = await createTestEvent(group.id, user.id, {
-				title: "Confirmed Event",
+			await createTestEvent(group.id, user.id, {
+				title: "Open Rehearsal",
 				startTime: new Date(now.getTime() + 86400000),
 				endTime: new Date(now.getTime() + 86400000 + 7200000),
 			});
-			const pendingEvent = await createTestEvent(group.id, user.id, {
-				title: "Pending Event",
-				startTime: new Date(now.getTime() + 2 * 86400000),
-				endTime: new Date(now.getTime() + 2 * 86400000 + 7200000),
-			});
-			const declinedEvent = await createTestEvent(group.id, user.id, {
-				title: "Declined Event",
-				startTime: new Date(now.getTime() + 3 * 86400000),
-				endTime: new Date(now.getTime() + 3 * 86400000 + 7200000),
-			});
-			// Create an event with no assignment for this user
-			await createTestEvent(group.id, user.id, {
-				title: "Unassigned Event",
-				startTime: new Date(now.getTime() + 4 * 86400000),
-				endTime: new Date(now.getTime() + 4 * 86400000 + 7200000),
-			});
-
-			await createTestAssignment(confirmedEvent.id, user.id, { status: "confirmed" });
-			await createTestAssignment(pendingEvent.id, user.id, { status: "pending" });
-			await createTestAssignment(declinedEvent.id, user.id, { status: "declined" });
-			// unassignedEvent has no assignment
 
 			const calendarEvents = await getUserCalendarEvents(user.id);
-			const titles = calendarEvents.map((e) => e.title);
 
-			expect(titles).toContain("Confirmed Event");
-			expect(titles).toContain("Pending Event");
-			expect(titles).not.toContain("Declined Event");
-			expect(titles).toContain("Unassigned Event");
-			expect(calendarEvents).toHaveLength(3);
+			expect(calendarEvents).toHaveLength(1);
+			expect(calendarEvents[0].title).toBe("Open Rehearsal");
+			expect(calendarEvents[0].userRole).toBeNull();
+		});
+
+		it("includes event where user is assigned with status pending", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			const event = await createTestEvent(group.id, user.id, {
+				title: "Pending Show",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			await createTestAssignment(event.id, user.id, { status: "pending" });
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+
+			expect(calendarEvents).toHaveLength(1);
+			expect(calendarEvents[0].title).toBe("Pending Show");
+		});
+
+		it("includes event where user is assigned with status confirmed", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			const event = await createTestEvent(group.id, user.id, {
+				title: "Confirmed Show",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			await createTestAssignment(event.id, user.id, {
+				role: "Performer",
+				status: "confirmed",
+			});
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+
+			expect(calendarEvents).toHaveLength(1);
+			expect(calendarEvents[0].title).toBe("Confirmed Show");
+			expect(calendarEvents[0].userRole).toBe("Performer");
+		});
+
+		it("excludes event where user is assigned with status declined", async () => {
+			const user = await createTestUser();
+			const group = await createTestGroup(user.id);
+			const now = new Date();
+
+			const event = await createTestEvent(group.id, user.id, {
+				title: "Declined Show",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			await createTestAssignment(event.id, user.id, { status: "declined" });
+
+			const calendarEvents = await getUserCalendarEvents(user.id);
+
+			expect(calendarEvents).toHaveLength(0);
+		});
+
+		it("excludes event with assignments when user is NOT assigned", async () => {
+			const admin = await createTestUser({ name: "Admin" });
+			const member = await createTestUser({ name: "Member" });
+			const otherMember = await createTestUser({ name: "Other" });
+			const group = await createTestGroup(admin.id);
+			await addGroupMember(group.id, member.id);
+			await addGroupMember(group.id, otherMember.id);
+			const now = new Date();
+
+			// Event has a cast list but member is not on it
+			const event = await createTestEvent(group.id, admin.id, {
+				title: "Show With Cast",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			await createTestAssignment(event.id, otherMember.id, {
+				role: "Performer",
+				status: "confirmed",
+			});
+
+			const calendarEvents = await getUserCalendarEvents(member.id);
+
+			expect(calendarEvents).toHaveLength(0);
+		});
+
+		it("excludes event with assignments for OTHER users but not this user", async () => {
+			const admin = await createTestUser({ name: "Admin" });
+			const memberA = await createTestUser({ name: "Member A" });
+			const memberB = await createTestUser({ name: "Member B" });
+			const group = await createTestGroup(admin.id);
+			await addGroupMember(group.id, memberA.id);
+			await addGroupMember(group.id, memberB.id);
+			const now = new Date();
+
+			const event = await createTestEvent(group.id, admin.id, {
+				title: "Cast Show",
+				startTime: new Date(now.getTime() + 86400000),
+				endTime: new Date(now.getTime() + 86400000 + 7200000),
+			});
+			// Only memberA is assigned
+			await createTestAssignment(event.id, memberA.id, {
+				role: "Performer",
+				status: "confirmed",
+			});
+
+			// memberA should see it
+			const memberAEvents = await getUserCalendarEvents(memberA.id);
+			expect(memberAEvents).toHaveLength(1);
+			expect(memberAEvents[0].title).toBe("Cast Show");
+
+			// memberB should NOT see it (cast list exists, they're not on it)
+			const memberBEvents = await getUserCalendarEvents(memberB.id);
+			expect(memberBEvents).toHaveLength(0);
 		});
 
 		it("returns null userRole for events with no assignment", async () => {

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, or, sql } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import {
 	availabilityRequests,
@@ -503,10 +503,18 @@ export async function getUserCalendarEvents(
 			and(
 				gte(events.startTime, thirtyDaysAgo),
 				lte(events.startTime, sixMonthsOut),
-				or(
-					isNull(eventAssignments.status),
-					inArray(eventAssignments.status, ["pending", "confirmed"]),
-				),
+				sql`(
+					NOT EXISTS (
+						SELECT 1 FROM event_assignments
+						WHERE event_id = ${events.id}
+					)
+					OR EXISTS (
+						SELECT 1 FROM event_assignments
+						WHERE event_id = ${events.id}
+						AND user_id = ${userId}
+						AND status IN ('pending', 'confirmed')
+					)
+				)`,
 			),
 		)
 		.orderBy(events.startTime);


### PR DESCRIPTION
## Problem

The `getUserCalendarEvents` query used a LEFT JOIN on `eventAssignments` and included events where the assignment status was NULL (no row). But "no assignment row" could mean either:

1. **Event has no cast list at all** — should be shown to all group members (e.g., a manually created rehearsal)
2. **Event has a cast list but this user isn't on it** — should NOT be shown (e.g., a show where only specific performers were assigned)

The old logic couldn't distinguish between these two cases.

## Fix

Replaced the `OR isNull(status)` WHERE clause with EXISTS/NOT EXISTS subqueries:

- `NOT EXISTS (SELECT 1 FROM event_assignments WHERE event_id = events.id)` — event has no assignments at all → show to all group members
- `EXISTS (SELECT 1 FROM event_assignments WHERE event_id = events.id AND user_id = :userId AND status IN ('pending', 'confirmed'))` — user is assigned and hasn't declined → show

The LEFT JOIN on `eventAssignments` is kept to populate `userRole` for the performer/callTime logic.

## Tests

Updated integration tests with explicit coverage for all scenarios:
- ✅ Event with no assignments → included for group members
- ✅ Event with assignments, user IS assigned (pending) → included
- ✅ Event with assignments, user IS assigned (confirmed) → included
- ✅ Event with assignments, user IS assigned (declined) → excluded
- ✅ Event with assignments, user is NOT assigned → excluded
- ✅ Event with assignments for OTHER users but not this user → excluded

## Quality Gates
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm test` ✅ (739 passed)
- `pnpm run build` ✅