### PR TITLE
fix: show declined members in cast list, exclude from count only

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -354,18 +354,16 @@ export default function EventDetail() {
 	const unassignedMembers = members.filter((m) => !assignedUserIds.has(m.id));
 
 	const isShow = event.eventType === "show";
-	const performers = isShow
-		? assignments.filter((a) => a.role === "Performer" && a.status !== "declined")
-		: [];
-	const viewers = isShow
-		? assignments.filter((a) => a.role === "Viewer" && a.status !== "declined")
-		: [];
+	const performers = isShow ? assignments.filter((a) => a.role === "Performer") : [];
+	const viewers = isShow ? assignments.filter((a) => a.role === "Viewer") : [];
 	const otherAssignments = isShow
-		? assignments.filter(
-				(a) => a.role !== "Performer" && a.role !== "Viewer" && a.status !== "declined",
-			)
-		: assignments.filter((a) => a.status !== "declined");
-	const activeCastAssignments = assignments.filter((a) => a.status !== "declined");
+		? assignments.filter((a) => a.role !== "Performer" && a.role !== "Viewer")
+		: assignments;
+	// Counts exclude declined members; lists still render everyone
+	const activePerformerCount = performers.filter((a) => a.status !== "declined").length;
+	const activeViewerCount = viewers.filter((a) => a.status !== "declined").length;
+	const activeOtherCount = otherAssignments.filter((a) => a.status !== "declined").length;
+	const activeCastCount = assignments.filter((a) => a.status !== "declined").length;
 	const canSelfRegister = !myAssignment && !isAdmin;
 	const canDelete = isAdmin || event.createdById === userId;
 	const canEdit = isAdmin || event.createdById === userId;
@@ -510,7 +508,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-purple-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-purple-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5 text-purple-500" /> Cast ({performers.length})
+									<Users className="h-5 w-5 text-purple-500" /> Cast ({activePerformerCount})
 								</h3>
 								{isAdmin && unassignedMembers.length > 0 && (
 									<button
@@ -682,7 +680,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Eye className="h-5 w-5 text-slate-400" /> Attending ({viewers.length})
+									<Eye className="h-5 w-5 text-slate-400" /> Attending ({activeViewerCount})
 								</h3>
 							</div>
 							{viewers.length === 0 && !canSelfRegister ? (
@@ -757,7 +755,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5" /> Cast ({activeCastAssignments.length})
+									<Users className="h-5 w-5" /> Cast ({activeCastCount})
 								</h3>
 								{isAdmin && unassignedMembers.length > 0 && (
 									<button
@@ -771,7 +769,7 @@ export default function EventDetail() {
 								)}
 							</div>
 
-							{activeCastAssignments.length === 0 ? (
+							{otherAssignments.length === 0 ? (
 								<div className="p-6 text-center text-sm text-slate-500">
 									No one assigned yet.{" "}
 									{isAdmin && (
@@ -786,7 +784,7 @@ export default function EventDetail() {
 								</div>
 							) : (
 								<ul className="divide-y divide-slate-100">
-									{activeCastAssignments.map((a) => {
+									{otherAssignments.map((a) => {
 										const statusCfg = STATUS_CONFIG[a.status] ?? STATUS_CONFIG.pending;
 										return (
 											<li key={a.userId} className="flex items-center justify-between px-6 py-3">
@@ -937,7 +935,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5" /> Other Roles ({otherAssignments.length})
+									<Users className="h-5 w-5" /> Other Roles ({activeOtherCount})
 								</h3>
 							</div>
 							<ul className="divide-y divide-slate-100">
@@ -1089,17 +1087,17 @@ export default function EventDetail() {
 								<>
 									<div className="flex justify-between">
 										<dt className="text-sm text-purple-600">Performers</dt>
-										<dd className="text-sm font-medium text-purple-600">{performers.length}</dd>
+										<dd className="text-sm font-medium text-purple-600">{activePerformerCount}</dd>
 									</div>
 									<div className="flex justify-between">
 										<dt className="text-sm text-slate-500">Viewers</dt>
-										<dd className="text-sm font-medium text-slate-600">{viewers.length}</dd>
+										<dd className="text-sm font-medium text-slate-600">{activeViewerCount}</dd>
 									</div>
 								</>
 							) : (
 								<div className="flex justify-between">
 									<dt className="text-sm text-slate-500">Total Assigned</dt>
-									<dd className="text-sm font-medium text-slate-900">{assignments.length}</dd>
+									<dd className="text-sm font-medium text-slate-900">{activeCastCount}</dd>
 								</div>
 							)}
 							<div className="flex justify-between">


### PR DESCRIPTION
## Problem

PR #198 filtered declined members out of **both** the count headers and the rendered lists. The CEO wants declined members to still appear in the list (so you can see who declined) but not be counted in the header totals.

## Changes

- **Reverted** `performers`, `viewers`, `otherAssignments` to filter by role only (no status filtering)
- **Added** separate count variables (`activePerformerCount`, `activeViewerCount`, `activeOtherCount`, `activeCastCount`) that exclude declined members
- **Header counts** (Cast, Attending, Other Roles, Total Assigned, sidebar stats) use filtered counts
- **List rendering** and empty-state checks use unfiltered arrays — declined members are visible with their "Declined" badge

## Result

| Area | Before (PR #198) | After |
|------|-------------------|-------|
| Cast (N) header | Excludes declined ✅ | Excludes declined ✅ |
| Cast list items | Hides declined ❌ | Shows declined with badge ✅ |
| Sidebar stats | Excludes declined ✅ | Excludes declined ✅ |

Quality gates: typecheck ✅ lint ✅ build ✅