### PR TITLE
fix: include event creator in auto-assignment from availability

### DIFF
--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -354,18 +354,16 @@ export default function EventDetail() {
 	const unassignedMembers = members.filter((m) => !assignedUserIds.has(m.id));
 
 	const isShow = event.eventType === "show";
-	const performers = isShow
-		? assignments.filter((a) => a.role === "Performer" && a.status !== "declined")
-		: [];
-	const viewers = isShow
-		? assignments.filter((a) => a.role === "Viewer" && a.status !== "declined")
-		: [];
+	const performers = isShow ? assignments.filter((a) => a.role === "Performer") : [];
+	const viewers = isShow ? assignments.filter((a) => a.role === "Viewer") : [];
 	const otherAssignments = isShow
-		? assignments.filter(
-				(a) => a.role !== "Performer" && a.role !== "Viewer" && a.status !== "declined",
-			)
-		: assignments.filter((a) => a.status !== "declined");
-	const activeCastAssignments = assignments.filter((a) => a.status !== "declined");
+		? assignments.filter((a) => a.role !== "Performer" && a.role !== "Viewer")
+		: assignments;
+	// Counts exclude declined members; lists still render everyone
+	const activePerformerCount = performers.filter((a) => a.status !== "declined").length;
+	const activeViewerCount = viewers.filter((a) => a.status !== "declined").length;
+	const activeOtherCount = otherAssignments.filter((a) => a.status !== "declined").length;
+	const activeCastCount = assignments.filter((a) => a.status !== "declined").length;
 	const canSelfRegister = !myAssignment && !isAdmin;
 	const canDelete = isAdmin || event.createdById === userId;
 	const canEdit = isAdmin || event.createdById === userId;
@@ -510,7 +508,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-purple-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-purple-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5 text-purple-500" /> Cast ({performers.length})
+									<Users className="h-5 w-5 text-purple-500" /> Cast ({activePerformerCount})
 								</h3>
 								{isAdmin && unassignedMembers.length > 0 && (
 									<button
@@ -682,7 +680,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Eye className="h-5 w-5 text-slate-400" /> Attending ({viewers.length})
+									<Eye className="h-5 w-5 text-slate-400" /> Attending ({activeViewerCount})
 								</h3>
 							</div>
 							{viewers.length === 0 && !canSelfRegister ? (
@@ -757,7 +755,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5" /> Cast ({activeCastAssignments.length})
+									<Users className="h-5 w-5" /> Cast ({activeCastCount})
 								</h3>
 								{isAdmin && unassignedMembers.length > 0 && (
 									<button
@@ -771,7 +769,7 @@ export default function EventDetail() {
 								)}
 							</div>
 
-							{activeCastAssignments.length === 0 ? (
+							{otherAssignments.length === 0 ? (
 								<div className="p-6 text-center text-sm text-slate-500">
 									No one assigned yet.{" "}
 									{isAdmin && (
@@ -786,7 +784,7 @@ export default function EventDetail() {
 								</div>
 							) : (
 								<ul className="divide-y divide-slate-100">
-									{activeCastAssignments.map((a) => {
+									{otherAssignments.map((a) => {
 										const statusCfg = STATUS_CONFIG[a.status] ?? STATUS_CONFIG.pending;
 										return (
 											<li key={a.userId} className="flex items-center justify-between px-6 py-3">
@@ -937,7 +935,7 @@ export default function EventDetail() {
 						<div className="rounded-xl border border-slate-200 bg-white shadow-sm">
 							<div className="border-b border-slate-100 px-6 py-4">
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-									<Users className="h-5 w-5" /> Other Roles ({otherAssignments.length})
+									<Users className="h-5 w-5" /> Other Roles ({activeOtherCount})
 								</h3>
 							</div>
 							<ul className="divide-y divide-slate-100">
@@ -1089,17 +1087,17 @@ export default function EventDetail() {
 								<>
 									<div className="flex justify-between">
 										<dt className="text-sm text-purple-600">Performers</dt>
-										<dd className="text-sm font-medium text-purple-600">{performers.length}</dd>
+										<dd className="text-sm font-medium text-purple-600">{activePerformerCount}</dd>
 									</div>
 									<div className="flex justify-between">
 										<dt className="text-sm text-slate-500">Viewers</dt>
-										<dd className="text-sm font-medium text-slate-600">{viewers.length}</dd>
+										<dd className="text-sm font-medium text-slate-600">{activeViewerCount}</dd>
 									</div>
 								</>
 							) : (
 								<div className="flex justify-between">
 									<dt className="text-sm text-slate-500">Total Assigned</dt>
-									<dd className="text-sm font-medium text-slate-900">{assignments.length}</dd>
+									<dd className="text-sm font-medium text-slate-900">{activeCastCount}</dd>
 								</div>
 							)}
 							<div className="flex justify-between">

--- a/app/routes/groups.$groupId.events.new.test.ts
+++ b/app/routes/groups.$groupId.events.new.test.ts
@@ -199,12 +199,7 @@ describe("events.new validation", () => {
 		expect(result).toBeInstanceOf(Response);
 		expect((result as Response).status).toBe(302);
 
-		expect(autoAssignFromAvailability).toHaveBeenCalledWith(
-			"event-1",
-			"req-1",
-			"2099-06-15",
-			"user-1", // creator excluded
-		);
+		expect(autoAssignFromAvailability).toHaveBeenCalledWith("event-1", "req-1", "2099-06-15");
 	});
 
 	it("does not auto-assign when not creating from availability request", async () => {
@@ -235,12 +230,7 @@ describe("events.new validation", () => {
 				context: {},
 			});
 			expect(result).toBeInstanceOf(Response);
-			expect(autoAssignFromAvailability).toHaveBeenCalledWith(
-				"event-1",
-				"req-1",
-				"2099-06-15",
-				"user-1",
-			);
+			expect(autoAssignFromAvailability).toHaveBeenCalledWith("event-1", "req-1", "2099-06-15");
 		}
 	});
 
@@ -320,12 +310,7 @@ describe("events.new validation", () => {
 		);
 
 		// Verify auto-assign was also called
-		expect(autoAssignFromAvailability).toHaveBeenCalledWith(
-			"event-1",
-			"req-1",
-			"2099-06-15",
-			"user-1",
-		);
+		expect(autoAssignFromAvailability).toHaveBeenCalledWith("event-1", "req-1", "2099-06-15");
 
 		// Critical: performer assignment must happen BEFORE auto-assign
 		// so that onConflictDoNothing in auto-assign skips already-assigned performers

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -176,7 +176,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		// Validate the availability request belongs to this group (IDOR prevention)
 		const requestGroupId = await getAvailabilityRequestGroupId(validFromRequestIdForAssign);
 		if (requestGroupId === groupId) {
-			await autoAssignFromAvailability(event.id, validFromRequestIdForAssign, date, user.id);
+			await autoAssignFromAvailability(event.id, validFromRequestIdForAssign, date);
 		}
 	}
 

--- a/app/services/events.server.test.ts
+++ b/app/services/events.server.test.ts
@@ -1071,7 +1071,7 @@ describe("events.server", () => {
 			const respChain = chainMock(null);
 			respChain.where = vi.fn().mockResolvedValue([
 				{
-					userId: "user-1", // creator — should be excluded
+					userId: "user-1", // creator — no longer excluded
 					responses: { "2026-03-15": "available" },
 				},
 				{
@@ -1106,8 +1106,9 @@ describe("events.server", () => {
 				createdById: "user-1",
 			});
 
-			// Should assign user-2 (available) and user-3 (maybe), NOT user-1 (creator) or user-4 (not_available)
+			// Should assign user-1 (available), user-2 (available), and user-3 (maybe), NOT user-4 (not_available)
 			expect(mockValues).toHaveBeenLastCalledWith([
+				expect.objectContaining({ userId: "user-1" }),
 				expect.objectContaining({ userId: "user-2" }),
 				expect.objectContaining({ userId: "user-3" }),
 			]);
@@ -1155,7 +1156,7 @@ describe("events.server", () => {
 	// autoAssignFromAvailability
 	// ============================================================
 	describe("autoAssignFromAvailability", () => {
-		it("assigns available and maybe members, excludes creator", async () => {
+		it("assigns available and maybe members including the creator", async () => {
 			const respChain = chainMock(null);
 			respChain.where = vi.fn().mockResolvedValue([
 				{ userId: "creator-1", responses: { "2026-03-15": "available" } },
@@ -1173,15 +1174,11 @@ describe("events.server", () => {
 				onConflictDoNothing,
 			});
 
-			const result = await autoAssignFromAvailability(
-				"event-1",
-				"req-1",
-				"2026-03-15",
-				"creator-1",
-			);
+			const result = await autoAssignFromAvailability("event-1", "req-1", "2026-03-15");
 
-			expect(result).toEqual(["user-2", "user-3"]);
+			expect(result).toEqual(["creator-1", "user-2", "user-3"]);
 			expect(mockValues).toHaveBeenLastCalledWith([
+				expect.objectContaining({ eventId: "event-1", userId: "creator-1", status: "pending" }),
 				expect.objectContaining({ eventId: "event-1", userId: "user-2", status: "pending" }),
 				expect.objectContaining({ eventId: "event-1", userId: "user-3", status: "pending" }),
 			]);
@@ -1196,31 +1193,7 @@ describe("events.server", () => {
 			respChain.from = vi.fn().mockReturnValue(respChain);
 			mockSelect.mockReturnValueOnce(respChain);
 
-			const result = await autoAssignFromAvailability(
-				"event-1",
-				"req-1",
-				"2026-03-15",
-				"creator-1",
-			);
-
-			expect(result).toEqual([]);
-			expect(mockInsert).not.toHaveBeenCalled();
-		});
-
-		it("excludes only the specified creator from assignment", async () => {
-			const respChain = chainMock(null);
-			respChain.where = vi
-				.fn()
-				.mockResolvedValue([{ userId: "the-creator", responses: { "2026-03-15": "available" } }]);
-			respChain.from = vi.fn().mockReturnValue(respChain);
-			mockSelect.mockReturnValueOnce(respChain);
-
-			const result = await autoAssignFromAvailability(
-				"event-1",
-				"req-1",
-				"2026-03-15",
-				"the-creator",
-			);
+			const result = await autoAssignFromAvailability("event-1", "req-1", "2026-03-15");
 
 			expect(result).toEqual([]);
 			expect(mockInsert).not.toHaveBeenCalled();
@@ -1232,12 +1205,7 @@ describe("events.server", () => {
 			respChain.from = vi.fn().mockReturnValue(respChain);
 			mockSelect.mockReturnValueOnce(respChain);
 
-			const result = await autoAssignFromAvailability(
-				"event-1",
-				"req-1",
-				"2026-03-15",
-				"creator-1",
-			);
+			const result = await autoAssignFromAvailability("event-1", "req-1", "2026-03-15");
 
 			expect(result).toEqual([]);
 			expect(mockInsert).not.toHaveBeenCalled();
@@ -1264,12 +1232,7 @@ describe("events.server", () => {
 				onConflictDoNothing,
 			});
 
-			const result = await autoAssignFromAvailability(
-				"event-1",
-				"req-1",
-				"2026-03-16",
-				"creator-1",
-			);
+			const result = await autoAssignFromAvailability("event-1", "req-1", "2026-03-16");
 
 			// Only user-3 is available on 2026-03-16
 			expect(result).toEqual(["user-3"]);

--- a/app/services/events.server.ts
+++ b/app/services/events.server.ts
@@ -85,7 +85,7 @@ export async function createEventsFromAvailability(data: {
 				: undefined,
 		});
 
-		await autoAssignFromAvailability(event.id, data.requestId, dateInfo.date, data.createdById);
+		await autoAssignFromAvailability(event.id, data.requestId, dateInfo.date);
 
 		createdEvents.push(event);
 	}
@@ -95,13 +95,12 @@ export async function createEventsFromAvailability(data: {
 
 /**
  * Auto-assign members who said "available" or "maybe" for a specific date
- * to an event as pending cast members. Excludes the event creator.
+ * to an event as pending cast members.
  */
 export async function autoAssignFromAvailability(
 	eventId: string,
 	requestId: string,
 	date: string,
-	excludeUserId: string,
 ): Promise<string[]> {
 	const responses = await db
 		.select({
@@ -113,7 +112,6 @@ export async function autoAssignFromAvailability(
 
 	const eligibleUserIds = responses
 		.filter((r) => {
-			if (r.userId === excludeUserId) return false;
 			const resp = r.responses as Record<string, string>;
 			return resp[date] === "available" || resp[date] === "maybe";
 		})


### PR DESCRIPTION
## Problem

The `autoAssignFromAvailability` function explicitly excluded the event creator from auto-cast assignment via an `excludeUserId` parameter. This meant creators who responded "available" or "maybe" on an availability request would not be added to the cast when creating events from that request.

## Fix

Removed the `excludeUserId` parameter and the creator-filtering logic. The creator is now treated like any other group member — if they responded "available" or "maybe", they get assigned; if they didn't respond or said "not_available", they don't.

### Changes
- **`app/services/events.server.ts`**: Removed `excludeUserId` param from `autoAssignFromAvailability` and the filter that used it. Updated JSDoc. Updated the call in `createEventsFromAvailability`.
- **`app/routes/groups.$groupId.events.new.tsx`**: Removed the `user.id` argument from the call site.
- **Test files**: Updated all tests to reflect that the creator is no longer excluded.

### Quality gates
- ✅ typecheck
- ✅ lint
- ✅ build
- ✅ 738/738 tests passing