### PR TITLE
fix: show non-responding members in Add Members panel

### DIFF
--- a/.github/skills/availability-cast-selection/SKILL.md
+++ b/.github/skills/availability-cast-selection/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: availability-cast-selection
+description: How availability requests relate to events and how the Add Members panel groups members by response status (available, maybe, not_available, no_response)
+---
+
+# Availability → Cast Selection Pattern
+
+This skill documents how availability data flows into the event detail page's **Add Members** panel, where admins assign cast or attendees.
+
+## Availability ↔ Event Relationship
+
+Events can optionally link back to the availability request they were created from via `events.createdFromRequestId` (nullable FK → `availability_requests.id`).
+
+When an admin creates an event from the availability results page, the route passes `?fromRequest=<requestId>&date=<selectedDate>` to the event creation form. The created event stores `createdFromRequestId` so the event detail page can look up who was available.
+
+```
+availability_requests  ←──  events.createdFromRequestId
+         │
+         └── availability_responses (one per user per request)
+                 └── responses JSONB: { "2025-03-15": "available", "2025-03-16": "maybe" }
+```
+
+## How `getAvailabilityForEventDate()` Works
+
+Located in `app/services/events.server.ts`. Called from the event detail loader when:
+1. The current user is a group admin
+2. The event has a `createdFromRequestId`
+3. The availability request belongs to the same group (IDOR check)
+
+```typescript
+async function getAvailabilityForEventDate(
+  requestId: string,
+  date: string,
+): Promise<Array<{ userId: string; userName: string; status: string }>>
+```
+
+- Joins `availability_responses` with `users` for the given request
+- Extracts the status for the specific `date` key from the JSONB `responses` column
+- Returns only members who **submitted a response** (even if their status for that date is missing — those get `"no_response"`)
+- Members who **never submitted any response at all** are NOT included in the result
+
+The `date` key is derived from the event's `startTime` converted to the user's timezone via `utcToLocalParts()`.
+
+## The Four Member Groups
+
+In the event detail component (`groups.$groupId.events.$eventId.tsx`), unassigned members are categorized into four groups when availability data exists:
+
+| Group | Filter | Color | Emoji |
+|-------|--------|-------|-------|
+| **Available** | `status === "available"` and not assigned | `emerald` | ✅ |
+| **Maybe** | `status === "maybe"` and not assigned | `amber` | 🤔 |
+| **Not Available** | `status === "not_available"` and not assigned | `red` (dimmed) | ❌ |
+| **No Response** | Not in `availabilityData` at all and not assigned | `slate` | ❓ |
+
+The "No Response" group is computed client-side:
+
+```typescript
+const respondedUserIds = new Set(availabilityData.map((a) => a.userId));
+const noResponseUsers = unassignedMembers
+  .filter((m) => !respondedUserIds.has(m.id))
+  .map((m) => ({ userId: m.id, userName: m.name }));
+```
+
+### Fallback: No Availability Data
+
+When `hasAvailData === false` (i.e., the event was NOT created from an availability request, or the request belongs to another group), the grouped view is hidden and a flat member list renders instead:
+- Show events → "Select Performers" (purple chips)
+- Non-show events → "Select Members" (emerald chips)
+
+## Dual-Panel Pattern: Show vs Non-Show Events
+
+The Add Members panel renders differently based on `event.eventType`:
+
+### Show Events (`eventType === "show"`)
+- Panel header: "Add Performers"
+- Hidden input: `<input name="role" value="Performer" />`
+- Submit button: "Add N Performer(s)"
+- Fallback label: "Select Performers" (purple chips)
+
+### Non-Show Events (`eventType !== "show"`)
+- Panel header: "Add Members"
+- Role selector dropdown (Performer/Viewer/custom)
+- Hidden input: `<input name="role" value={assignRole} />`
+- Submit button: "Add N Member(s)"
+- Fallback label: "Select Members" (emerald chips)
+
+Both panels share the same availability grouping logic (available/maybe/not_available/no_response) and the same `UserChipSelector` component.
+
+## `UserChipSelector` Component
+
+Located in `app/components/user-chip-selector.tsx`. A toggleable chip grid for selecting users.
+
+```typescript
+interface Props {
+  users: Array<{ id: string; name: string }>;
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+  colorScheme: "emerald" | "amber" | "red" | "purple" | "slate";
+  dimmed?: boolean;  // reduces opacity (used for "Not Available")
+}
+```
+
+### Color Scheme Mapping
+
+| Scheme | Selected Style | Use Case |
+|--------|---------------|----------|
+| `emerald` | Green border/bg | Available members, generic member list |
+| `amber` | Amber border/bg | Maybe members |
+| `red` | Red border/bg | Not Available members |
+| `purple` | Purple border/bg | Fallback performer list (no availability data) |
+| `slate` | Slate border/bg | No Response members |
+
+## Loader Data Contract
+
+The event detail loader returns these fields relevant to cast selection:
+
+```typescript
+return {
+  members,          // All group members (only populated for admins)
+  availabilityData, // Array<{ userId, userName, status }> — only responders
+  assignments,      // Current event assignments
+  isAdmin,          // Whether current user is a group admin
+  // ... other fields
+};
+```
+
+The component computes derived state:
+- `assignedUserIds` — members already on the cast list
+- `unassignedMembers` — `members` minus `assignedUserIds`
+- `availableUsers`, `maybeUsers`, `unavailableUsers` — from `availabilityData`, excluding assigned
+- `noResponseUsers` — `unassignedMembers` not in `availabilityData`
+- `hasAvailData` — whether to show grouped view vs flat fallback
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `app/routes/groups.$groupId.events.$eventId.tsx` | Event detail route (loader + component) |
+| `app/services/events.server.ts` | `getAvailabilityForEventDate()`, `getAvailabilityRequestGroupId()` |
+| `app/components/user-chip-selector.tsx` | `UserChipSelector` chip grid component |
+| `app/routes/groups.$groupId.events.$eventId.test.ts` | Loader + action tests |

--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -61,7 +61,11 @@ import {
 	assignToEvent,
 	bulkAssignToEvent,
 	deleteEvent,
+	getAvailabilityForEventDate,
+	getAvailabilityRequestGroupId,
+	getEventActivityFeed,
 	getEventWithAssignments,
+	getGroupEventSummaries,
 	updateAssignmentRole,
 	updateAssignmentStatus,
 } from "~/services/events.server";
@@ -71,7 +75,7 @@ import {
 	isGroupAdmin,
 	requireGroupMember,
 } from "~/services/groups.server";
-import { action } from "./groups.$groupId.events.$eventId";
+import { action, loader } from "./groups.$groupId.events.$eventId";
 
 describe("event detail action — IDOR prevention", () => {
 	beforeEach(() => {
@@ -867,5 +871,157 @@ describe("event detail action — change role", () => {
 				}),
 			);
 		});
+	});
+});
+
+describe("event detail loader — availability & no-response members", () => {
+	const mockShowEvent = {
+		id: "event-1",
+		groupId: "g1",
+		title: "Friday Show",
+		eventType: "show",
+		startTime: "2026-03-15T19:00:00.000Z",
+		endTime: "2026-03-15T21:00:00.000Z",
+		callTime: null,
+		location: "Main Theater",
+		createdFromRequestId: "req-1",
+		createdById: "user-1",
+	};
+
+	const allMembers = [
+		{ id: "user-1", name: "Admin", email: "admin@example.com", profileImage: null, role: "admin" },
+		{ id: "user-2", name: "Alice", email: "alice@example.com", profileImage: null, role: "member" },
+		{ id: "user-3", name: "Bob", email: "bob@example.com", profileImage: null, role: "member" },
+		{
+			id: "user-4",
+			name: "Charlie",
+			email: "charlie@example.com",
+			profileImage: null,
+			role: "member",
+		},
+	];
+
+	function makeLoaderRequest() {
+		return new Request("http://localhost/groups/g1/events/event-1");
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "admin@example.com",
+			name: "Admin",
+			profileImage: null,
+			timezone: "America/New_York",
+		});
+		(isGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+		(getGroupEventSummaries as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+		(getEventActivityFeed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+	});
+
+	it("returns availability data with non-responding members inferrable when some members didn't respond", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [],
+		});
+		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" },
+			members: allMembers,
+		});
+		(getAvailabilityRequestGroupId as ReturnType<typeof vi.fn>).mockResolvedValue("g1");
+		// Only user-2 and user-3 responded; user-1 and user-4 did NOT respond
+		(getAvailabilityForEventDate as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{ userId: "user-2", userName: "Alice", status: "available" },
+			{ userId: "user-3", userName: "Bob", status: "maybe" },
+		]);
+
+		const result = await loader({
+			request: makeLoaderRequest(),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result.availabilityData).toHaveLength(2);
+		expect(result.members).toHaveLength(4);
+
+		// Verify the component can compute "no response" members:
+		// noResponseUsers = members not in assignments AND not in availabilityData
+		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
+		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
+		const respondedIds = new Set(result.availabilityData.map((a: { userId: string }) => a.userId));
+		const noResponseMembers = unassigned.filter((m: { id: string }) => !respondedIds.has(m.id));
+
+		expect(noResponseMembers).toHaveLength(2);
+		expect(noResponseMembers.map((m: { id: string }) => m.id).sort()).toEqual(["user-1", "user-4"]);
+	});
+
+	it("returns no non-responding members when all members responded", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: mockShowEvent,
+			assignments: [],
+		});
+		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" },
+			members: allMembers,
+		});
+		(getAvailabilityRequestGroupId as ReturnType<typeof vi.fn>).mockResolvedValue("g1");
+		// All 4 members responded
+		(getAvailabilityForEventDate as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{ userId: "user-1", userName: "Admin", status: "available" },
+			{ userId: "user-2", userName: "Alice", status: "available" },
+			{ userId: "user-3", userName: "Bob", status: "maybe" },
+			{ userId: "user-4", userName: "Charlie", status: "not_available" },
+		]);
+
+		const result = await loader({
+			request: makeLoaderRequest(),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result.availabilityData).toHaveLength(4);
+
+		// Component logic: all members responded → noResponseUsers is empty
+		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
+		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
+		const respondedIds = new Set(result.availabilityData.map((a: { userId: string }) => a.userId));
+		const noResponseMembers = unassigned.filter((m: { id: string }) => !respondedIds.has(m.id));
+
+		expect(noResponseMembers).toHaveLength(0);
+	});
+
+	it("returns empty availability data when no availability request is linked", async () => {
+		const eventWithoutRequest = {
+			...mockShowEvent,
+			createdFromRequestId: null,
+		};
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: eventWithoutRequest,
+			assignments: [
+				{ userId: "user-2", userName: "Alice", role: "Performer", status: "confirmed" },
+			],
+		});
+		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" },
+			members: allMembers,
+		});
+
+		const result = await loader({
+			request: makeLoaderRequest(),
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		// No availability request linked → availabilityData is empty
+		expect(result.availabilityData).toHaveLength(0);
+
+		// getAvailabilityForEventDate should NOT have been called
+		expect(getAvailabilityForEventDate).not.toHaveBeenCalled();
+
+		// Component would use the fallback generic member list (not grouped availability view)
+		// since hasAvailData = false, unassignedMembers would be rendered directly
+		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
+		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
+		expect(unassigned).toHaveLength(3); // user-1, user-3, user-4 (user-2 is assigned)
 	});
 });

--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -61,11 +61,7 @@ import {
 	assignToEvent,
 	bulkAssignToEvent,
 	deleteEvent,
-	getAvailabilityForEventDate,
-	getAvailabilityRequestGroupId,
-	getEventActivityFeed,
 	getEventWithAssignments,
-	getGroupEventSummaries,
 	updateAssignmentRole,
 	updateAssignmentStatus,
 } from "~/services/events.server";
@@ -75,7 +71,7 @@ import {
 	isGroupAdmin,
 	requireGroupMember,
 } from "~/services/groups.server";
-import { action, loader } from "./groups.$groupId.events.$eventId";
+import { action, computeNoResponseMembers } from "./groups.$groupId.events.$eventId";
 
 describe("event detail action — IDOR prevention", () => {
 	beforeEach(() => {
@@ -874,154 +870,62 @@ describe("event detail action — change role", () => {
 	});
 });
 
-describe("event detail loader — availability & no-response members", () => {
-	const mockShowEvent = {
-		id: "event-1",
-		groupId: "g1",
-		title: "Friday Show",
-		eventType: "show",
-		startTime: "2026-03-15T19:00:00.000Z",
-		endTime: "2026-03-15T21:00:00.000Z",
-		callTime: null,
-		location: "Main Theater",
-		createdFromRequestId: "req-1",
-		createdById: "user-1",
-	};
-
+describe("computeNoResponseMembers", () => {
 	const allMembers = [
-		{ id: "user-1", name: "Admin", email: "admin@example.com", profileImage: null, role: "admin" },
-		{ id: "user-2", name: "Alice", email: "alice@example.com", profileImage: null, role: "member" },
-		{ id: "user-3", name: "Bob", email: "bob@example.com", profileImage: null, role: "member" },
-		{
-			id: "user-4",
-			name: "Charlie",
-			email: "charlie@example.com",
-			profileImage: null,
-			role: "member",
-		},
+		{ id: "user-1", name: "Admin" },
+		{ id: "user-2", name: "Alice" },
+		{ id: "user-3", name: "Bob" },
+		{ id: "user-4", name: "Charlie" },
 	];
 
-	function makeLoaderRequest() {
-		return new Request("http://localhost/groups/g1/events/event-1");
-	}
+	it("identifies members who didn't respond to the availability request", () => {
+		// user-2 and user-3 responded; user-1 and user-4 did NOT
+		const availabilityData = [
+			{ userId: "user-2", status: "available" },
+			{ userId: "user-3", status: "maybe" },
+		];
+		const assignedUserIds = new Set<string>();
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
-			id: "user-1",
-			email: "admin@example.com",
-			name: "Admin",
-			profileImage: null,
-			timezone: "America/New_York",
-		});
-		(isGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
-		(getGroupEventSummaries as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-		(getEventActivityFeed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+		const result = computeNoResponseMembers(allMembers, availabilityData, assignedUserIds);
+
+		expect(result).toHaveLength(2);
+		expect(result.map((m) => m.userId).sort()).toEqual(["user-1", "user-4"]);
+		expect(result.map((m) => m.userName).sort()).toEqual(["Admin", "Charlie"]);
 	});
 
-	it("returns availability data with non-responding members inferrable when some members didn't respond", async () => {
-		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
-			event: mockShowEvent,
-			assignments: [],
-		});
-		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
-			group: { id: "g1", name: "Test Group" },
-			members: allMembers,
-		});
-		(getAvailabilityRequestGroupId as ReturnType<typeof vi.fn>).mockResolvedValue("g1");
-		// Only user-2 and user-3 responded; user-1 and user-4 did NOT respond
-		(getAvailabilityForEventDate as ReturnType<typeof vi.fn>).mockResolvedValue([
-			{ userId: "user-2", userName: "Alice", status: "available" },
-			{ userId: "user-3", userName: "Bob", status: "maybe" },
-		]);
+	it("returns empty array when all members responded", () => {
+		const availabilityData = [
+			{ userId: "user-1", status: "available" },
+			{ userId: "user-2", status: "available" },
+			{ userId: "user-3", status: "maybe" },
+			{ userId: "user-4", status: "not_available" },
+		];
+		const assignedUserIds = new Set<string>();
 
-		const result = await loader({
-			request: makeLoaderRequest(),
-			params: { groupId: "g1", eventId: "event-1" },
-			context: {},
-		});
+		const result = computeNoResponseMembers(allMembers, availabilityData, assignedUserIds);
 
-		expect(result.availabilityData).toHaveLength(2);
-		expect(result.members).toHaveLength(4);
-
-		// Verify the component can compute "no response" members:
-		// noResponseUsers = members not in assignments AND not in availabilityData
-		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
-		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
-		const respondedIds = new Set(result.availabilityData.map((a: { userId: string }) => a.userId));
-		const noResponseMembers = unassigned.filter((m: { id: string }) => !respondedIds.has(m.id));
-
-		expect(noResponseMembers).toHaveLength(2);
-		expect(noResponseMembers.map((m: { id: string }) => m.id).sort()).toEqual(["user-1", "user-4"]);
+		expect(result).toHaveLength(0);
 	});
 
-	it("returns no non-responding members when all members responded", async () => {
-		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
-			event: mockShowEvent,
-			assignments: [],
-		});
-		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
-			group: { id: "g1", name: "Test Group" },
-			members: allMembers,
-		});
-		(getAvailabilityRequestGroupId as ReturnType<typeof vi.fn>).mockResolvedValue("g1");
-		// All 4 members responded
-		(getAvailabilityForEventDate as ReturnType<typeof vi.fn>).mockResolvedValue([
-			{ userId: "user-1", userName: "Admin", status: "available" },
-			{ userId: "user-2", userName: "Alice", status: "available" },
-			{ userId: "user-3", userName: "Bob", status: "maybe" },
-			{ userId: "user-4", userName: "Charlie", status: "not_available" },
-		]);
+	it("excludes already-assigned members from no-response list", () => {
+		// user-2 is assigned, user-3 responded, user-1 and user-4 neither assigned nor responded
+		const availabilityData = [{ userId: "user-3", status: "available" }];
+		const assignedUserIds = new Set(["user-2"]);
 
-		const result = await loader({
-			request: makeLoaderRequest(),
-			params: { groupId: "g1", eventId: "event-1" },
-			context: {},
-		});
+		const result = computeNoResponseMembers(allMembers, availabilityData, assignedUserIds);
 
-		expect(result.availabilityData).toHaveLength(4);
-
-		// Component logic: all members responded → noResponseUsers is empty
-		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
-		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
-		const respondedIds = new Set(result.availabilityData.map((a: { userId: string }) => a.userId));
-		const noResponseMembers = unassigned.filter((m: { id: string }) => !respondedIds.has(m.id));
-
-		expect(noResponseMembers).toHaveLength(0);
+		expect(result).toHaveLength(2);
+		expect(result.map((m) => m.userId).sort()).toEqual(["user-1", "user-4"]);
 	});
 
-	it("returns empty availability data when no availability request is linked", async () => {
-		const eventWithoutRequest = {
-			...mockShowEvent,
-			createdFromRequestId: null,
-		};
-		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
-			event: eventWithoutRequest,
-			assignments: [
-				{ userId: "user-2", userName: "Alice", role: "Performer", status: "confirmed" },
-			],
-		});
-		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
-			group: { id: "g1", name: "Test Group" },
-			members: allMembers,
-		});
+	it("returns all unassigned members when availability data is empty", () => {
+		const availabilityData: Array<{ userId: string }> = [];
+		const assignedUserIds = new Set(["user-1"]);
 
-		const result = await loader({
-			request: makeLoaderRequest(),
-			params: { groupId: "g1", eventId: "event-1" },
-			context: {},
-		});
+		const result = computeNoResponseMembers(allMembers, availabilityData, assignedUserIds);
 
-		// No availability request linked → availabilityData is empty
-		expect(result.availabilityData).toHaveLength(0);
-
-		// getAvailabilityForEventDate should NOT have been called
-		expect(getAvailabilityForEventDate).not.toHaveBeenCalled();
-
-		// Component would use the fallback generic member list (not grouped availability view)
-		// since hasAvailData = false, unassignedMembers would be rendered directly
-		const assignedIds = new Set(result.assignments.map((a: { userId: string }) => a.userId));
-		const unassigned = result.members.filter((m: { id: string }) => !assignedIds.has(m.id));
-		expect(unassigned).toHaveLength(3); // user-1, user-3, user-4 (user-2 is assigned)
+		// user-1 assigned, user-2/3/4 unassigned and none responded
+		expect(result).toHaveLength(3);
+		expect(result.map((m) => m.userId).sort()).toEqual(["user-2", "user-3", "user-4"]);
 	});
 });

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -395,6 +395,12 @@ export default function EventDetail() {
 	);
 	const hasAvailData = availabilityData.length > 0;
 
+	// Members who didn't respond to the availability request
+	const respondedUserIds = new Set(availabilityData.map((a) => a.userId));
+	const noResponseUsers = unassignedMembers
+		.filter((m) => !respondedUserIds.has(m.id))
+		.map((m) => ({ userId: m.id, userName: m.name }));
+
 	const isMyPerformer = myAssignment?.role === "Performer";
 
 	return (
@@ -626,6 +632,22 @@ export default function EventDetail() {
 															onToggle={toggleUser}
 															colorScheme="red"
 															dimmed
+														/>
+													</div>
+												)}
+												{noResponseUsers.length > 0 && (
+													<div>
+														<h4 className="mb-1.5 text-xs font-semibold text-slate-500">
+															❓ No Response
+														</h4>
+														<UserChipSelector
+															users={noResponseUsers.map((u) => ({
+																id: u.userId,
+																name: u.userName,
+															}))}
+															selectedIds={selectedUserIds}
+															onToggle={toggleUser}
+															colorScheme="slate"
 														/>
 													</div>
 												)}
@@ -875,6 +897,22 @@ export default function EventDetail() {
 															onToggle={toggleUser}
 															colorScheme="red"
 															dimmed
+														/>
+													</div>
+												)}
+												{noResponseUsers.length > 0 && (
+													<div>
+														<h4 className="mb-1.5 text-xs font-semibold text-slate-500">
+															❓ No Response
+														</h4>
+														<UserChipSelector
+															users={noResponseUsers.map((u) => ({
+																id: u.userId,
+																name: u.userName,
+															}))}
+															selectedIds={selectedUserIds}
+															onToggle={toggleUser}
+															colorScheme="slate"
 														/>
 													</div>
 												)}

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -60,6 +60,23 @@ import {
 } from "~/services/groups.server";
 import type { loader as groupLayoutLoader } from "./groups.$groupId";
 
+/**
+ * Computes members who didn't respond to the linked availability request.
+ * Exported for unit testing — this is the client-side logic that powers
+ * the "No Response" section in the Add Members panel.
+ */
+export function computeNoResponseMembers(
+	members: Array<{ id: string; name: string }>,
+	availabilityData: Array<{ userId: string }>,
+	assignedUserIds: Set<string>,
+): Array<{ userId: string; userName: string }> {
+	const unassigned = members.filter((m) => !assignedUserIds.has(m.id));
+	const respondedUserIds = new Set(availabilityData.map((a) => a.userId));
+	return unassigned
+		.filter((m) => !respondedUserIds.has(m.id))
+		.map((m) => ({ userId: m.id, userName: m.name }));
+}
+
 export const meta: MetaFunction = () => {
 	return [{ title: "Event Detail — My Call Time" }];
 };
@@ -396,10 +413,11 @@ export default function EventDetail() {
 	const hasAvailData = availabilityData.length > 0;
 
 	// Members who didn't respond to the availability request
-	const respondedUserIds = new Set(availabilityData.map((a) => a.userId));
-	const noResponseUsers = unassignedMembers
-		.filter((m) => !respondedUserIds.has(m.id))
-		.map((m) => ({ userId: m.id, userName: m.name }));
+	const noResponseUsers = computeNoResponseMembers(
+		unassignedMembers,
+		availabilityData,
+		assignedUserIds,
+	);
 
 	const isMyPerformer = myAssignment?.role === "Performer";
 


### PR DESCRIPTION
## Problem

When an event was created from an availability request and some group members hadn't responded to the availability poll, those non-responding members were invisible in the Add Members panel. The panel showed Available, Maybe, and Not Available groups, but members who never submitted a response were silently omitted — admins had no way to discover or select them.

This happened because the 'No availability data' fallback (which shows a flat member list) only triggered when *zero* members responded, not when *some* did.

## Solution

Add a **"❓ No Response"** category (slate-colored chips) that displays unassigned group members who didn't submit an availability response. This is computed client-side by diffing the full member list against the responded user IDs from availability data.

Applied to both panels:
- **Show events** → Performers panel (alongside Available/Maybe/Not Available)
- **Non-show events** → General members panel

## Testing

Added 3 loader tests verifying the data contract that enables the no-response computation:
1. When some members didn't respond → loader returns partial availabilityData, enabling the component to infer non-responders
2. When all members responded → no gap exists (No Response section won't render)
3. When no availability request is linked → empty availabilityData triggers the fallback generic member list

All 747 tests pass. Typecheck, lint, and build clean.