### PR TITLE
Fix: event creator can manage performers and roles on their own event (#205)

### DIFF
--- a/.github/skills/greenroom-security/SKILL.md
+++ b/.github/skills/greenroom-security/SKILL.md
@@ -69,6 +69,58 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 ---
 
+## Resource-Owner Access: Admin OR Creator
+
+Some actions are not purely "admin-only" — the **creator of a resource** should have full
+control over it even if they are only a plain group member. In My Call Time this applies to
+**events**: the person who created an event can edit it, delete it, **and manage its
+participants/roles** — the same as a group admin.
+
+There is no `requireGroupAdmin`-style helper for this because ownership depends on the loaded
+resource (its `createdById`), not just the group. Compute a `canManage` flag once and reuse it
+for the loader, the UI, and every mutating intent in the action:
+
+```typescript
+// loader — decide access after loading the resource
+const admin = await isGroupAdmin(user.id, groupId);
+const data = await getEventWithAssignments(eventId);
+if (!data || data.event.groupId !== groupId) throw new Response("Not Found", { status: 404 });
+
+// Admins AND the creator can manage participants/roles on this event.
+const canManage = admin || data.event.createdById === user.id;
+
+// Only load management data (member list, availability) when the user can manage,
+// so the UI can render the "Add Performers" panel / participant menus.
+if (canManage) {
+  /* load members, availability suggestions, etc. */
+}
+return { ...data, isAdmin: admin, canManage };
+```
+
+```typescript
+// action — gate the mutating intents on canManage, NOT isAdmin
+const admin = await isGroupAdmin(user.id, groupId);
+const canManage = admin || eventData.event.createdById === user.id;
+if (!canManage) throw new Response("Forbidden", { status: 403 });
+// intents: "assign", "change-role", "remove-assignment"
+```
+
+**Gotchas / checklist when you touch owner-scoped actions:**
+
+- The check has **three coupled sites** — the action guard, the loader data-loading branch, and
+  the JSX gate (`{canManage && ...}`). If you only fix the action, the creator gets a 403-free
+  request but never sees the button; if you only fix the UI, they see the button and get a 403.
+  Keep all three in sync.
+- Always keep the group-scope/IDOR check (`resource.groupId === params.groupId`) **before** the
+  ownership check — a creator of an event in another group must still 404.
+- Mirror the existing `canEdit` / `canDelete` pattern (`isAdmin || resource.createdById === userId`)
+  rather than inventing a new rule.
+- Regression bug this prevents: [#205](https://github.com/TylerLeonhardt/greenroom/issues/205) —
+  the event creator couldn't add performers or change roles because the action gated `assign` /
+  `change-role` on `isGroupAdmin` alone.
+
+---
+
 ## Multi-Tenancy Isolation
 
 My Call Time enforces data isolation at the application layer, not through PostgreSQL Row-Level Security. This means every query must explicitly filter by group.

--- a/app/routes/groups.$groupId.events.$eventId.test.ts
+++ b/app/routes/groups.$groupId.events.$eventId.test.ts
@@ -62,6 +62,7 @@ import {
 	bulkAssignToEvent,
 	deleteEvent,
 	getEventWithAssignments,
+	removeAssignment,
 	updateAssignmentRole,
 	updateAssignmentStatus,
 } from "~/services/events.server";
@@ -71,7 +72,7 @@ import {
 	isGroupAdmin,
 	requireGroupMember,
 } from "~/services/groups.server";
-import { action, computeNoResponseMembers } from "./groups.$groupId.events.$eventId";
+import { action, computeNoResponseMembers, loader } from "./groups.$groupId.events.$eventId";
 
 describe("event detail action — IDOR prevention", () => {
 	beforeEach(() => {
@@ -867,6 +868,202 @@ describe("event detail action — change role", () => {
 				}),
 			);
 		});
+	});
+});
+
+describe("event detail — event creator manages participants", () => {
+	// Non-admin group member who created the event.
+	const CREATOR_ID = "user-1";
+
+	const creatorShowEvent = {
+		id: "event-1",
+		groupId: "g1",
+		title: "Creator's Show",
+		description: null,
+		eventType: "show",
+		startTime: "2026-03-15T19:00:00.000Z",
+		endTime: "2026-03-15T21:00:00.000Z",
+		location: null,
+		createdById: CREATOR_ID,
+		createdFromRequestId: null,
+		callTime: null,
+		timezone: "UTC",
+		createdByName: "Test User",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// The signed-in user is a plain member (NOT an admin) who created the event.
+		(requireGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: CREATOR_ID,
+			email: "test@example.com",
+			name: "Test User",
+			profileImage: null,
+			timezone: "UTC",
+		});
+		(isGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+		(getGroupWithMembers as ReturnType<typeof vi.fn>).mockResolvedValue({
+			group: { id: "g1", name: "Test Group" },
+			members: [
+				{ id: CREATOR_ID, name: "Test User", email: "test@example.com", role: "member" },
+				{ id: "user-2", name: "New Performer", email: "new@example.com", role: "member" },
+			],
+		});
+		(getGroupMembersWithPreferences as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+	});
+
+	// --- Loader: creator sees the management affordances ---
+
+	it("loader exposes management controls (canManage + members) to the non-admin creator", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: creatorShowEvent,
+			assignments: [],
+		});
+
+		const request = new Request("http://localhost/groups/g1/events/event-1");
+		const data = await loader({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(data.isAdmin).toBe(false);
+		expect(data.canManage).toBe(true);
+		// Members must be loaded so the "Add Performers" panel can render.
+		expect(data.members.length).toBeGreaterThan(0);
+	});
+
+	it("loader does NOT expose management controls to a non-admin, non-creator member", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: { ...creatorShowEvent, createdById: "someone-else" },
+			assignments: [],
+		});
+
+		const request = new Request("http://localhost/groups/g1/events/event-1");
+		const data = await loader({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(data.canManage).toBe(false);
+		expect(data.members).toEqual([]);
+	});
+
+	// --- Action: creator can add a performer (acceptance) ---
+
+	it("lets the non-admin creator add a performer to their own event", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: creatorShowEvent,
+			assignments: [],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "assign");
+		formData.append("userIds", "user-2");
+		formData.set("role", "Performer");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		const result = await action({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(bulkAssignToEvent).toHaveBeenCalledWith("event-1", ["user-2"], "Performer");
+	});
+
+	// --- Action: creator can change a role (acceptance) ---
+
+	it("lets the non-admin creator change a participant's role on their own event", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: creatorShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "New Performer", role: "Viewer", status: "confirmed" },
+			],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "change-role");
+		formData.set("userId", "user-2");
+		formData.set("newRole", "Performer");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		const result = await action({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(updateAssignmentRole).toHaveBeenCalledWith("event-1", "user-2", "Performer");
+	});
+
+	it("lets the non-admin creator remove an assignment on their own event", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: creatorShowEvent,
+			assignments: [
+				{ userId: "user-2", userName: "New Performer", role: "Performer", status: "confirmed" },
+			],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "remove-assignment");
+		formData.set("userId", "user-2");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		const result = await action({
+			request,
+			params: { groupId: "g1", eventId: "event-1" },
+			context: {},
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(removeAssignment).toHaveBeenCalledWith("event-1", "user-2");
+	});
+
+	it("still rejects a non-admin, non-creator member from adding a performer (403)", async () => {
+		(getEventWithAssignments as ReturnType<typeof vi.fn>).mockResolvedValue({
+			event: { ...creatorShowEvent, createdById: "someone-else" },
+			assignments: [],
+		});
+
+		const formData = new FormData();
+		formData.set("intent", "assign");
+		formData.append("userIds", "user-2");
+		formData.set("role", "Performer");
+
+		const request = new Request("http://localhost/groups/g1/events/event-1", {
+			method: "POST",
+			body: formData,
+		});
+
+		try {
+			await action({
+				request,
+				params: { groupId: "g1", eventId: "event-1" },
+				context: {},
+			});
+			expect.fail("Should have thrown 403");
+		} catch (response) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(403);
+		}
+
+		expect(bulkAssignToEvent).not.toHaveBeenCalled();
 	});
 });
 

--- a/app/routes/groups.$groupId.events.$eventId.tsx
+++ b/app/routes/groups.$groupId.events.$eventId.tsx
@@ -92,6 +92,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		throw new Response("Not Found", { status: 404 });
 	}
 
+	// Admins and the event's creator can manage participants/roles on this event.
+	const canManage = admin || data.event.createdById === user.id;
+
 	const siblingEvents = await getGroupEventSummaries(groupId, eventId);
 
 	let members: Array<{
@@ -102,7 +105,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		role: string;
 	}> = [];
 	let availabilityData: Array<{ userId: string; userName: string; status: string }> = [];
-	if (admin) {
+	if (canManage) {
 		const groupData = await getGroupWithMembers(groupId);
 		members = groupData?.members ?? [];
 
@@ -125,6 +128,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		event: data.event,
 		assignments: data.assignments,
 		isAdmin: admin,
+		canManage,
 		userId: user.id,
 		members,
 		availabilityData,
@@ -195,9 +199,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		return redirect(`/groups/${groupId}/events`);
 	}
 
-	// Admin-only actions
+	// Participant-management actions (assign, change-role, remove-assignment):
+	// allowed for group admins OR the event's creator.
 	const admin = await isGroupAdmin(user.id, groupId);
-	if (!admin) throw new Response("Forbidden", { status: 403 });
+	const canManage = admin || eventData.event.createdById === user.id;
+	if (!canManage) throw new Response("Forbidden", { status: 403 });
 
 	if (intent === "assign") {
 		const userIds = formData.getAll("userIds");
@@ -347,6 +353,7 @@ export default function EventDetail() {
 		event,
 		assignments,
 		isAdmin,
+		canManage,
 		userId,
 		members,
 		availabilityData,
@@ -381,7 +388,7 @@ export default function EventDetail() {
 	const activeViewerCount = viewers.filter((a) => a.status !== "declined").length;
 	const activeOtherCount = otherAssignments.filter((a) => a.status !== "declined").length;
 	const activeCastCount = assignments.filter((a) => a.status !== "declined").length;
-	const canSelfRegister = !myAssignment && !isAdmin;
+	const canSelfRegister = !myAssignment && !canManage;
 	const canDelete = isAdmin || event.createdById === userId;
 	const canEdit = isAdmin || event.createdById === userId;
 	const confirmedCount = assignments.filter((a) => a.status === "confirmed").length;
@@ -534,7 +541,7 @@ export default function EventDetail() {
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
 									<Users className="h-5 w-5 text-purple-500" /> Cast ({activePerformerCount})
 								</h3>
-								{isAdmin && unassignedMembers.length > 0 && (
+								{canManage && unassignedMembers.length > 0 && (
 									<button
 										type="button"
 										onClick={() => setShowAddMembers(!showAddMembers)}
@@ -549,7 +556,7 @@ export default function EventDetail() {
 							{performers.length === 0 ? (
 								<div className="p-6 text-center text-sm text-slate-500">
 									No performers assigned yet.{" "}
-									{isAdmin && (
+									{canManage && (
 										<button
 											type="button"
 											onClick={() => setShowAddMembers(true)}
@@ -572,7 +579,7 @@ export default function EventDetail() {
 													>
 														{statusCfg.label}
 													</span>
-													{isAdmin && (
+													{canManage && (
 														<ParticipantMenu
 															userId={a.userId}
 															currentRole={a.role}
@@ -588,7 +595,7 @@ export default function EventDetail() {
 							)}
 
 							{/* Add Members Panel */}
-							{showAddMembers && isAdmin && (
+							{showAddMembers && canManage && (
 								<div className="border-t border-purple-200 bg-purple-50/50 p-6">
 									<Form
 										method="post"
@@ -703,7 +710,7 @@ export default function EventDetail() {
 					)}
 
 					{/* Notify on role change toggle (admin only) */}
-					{isAdmin && assignments.length > 0 && (
+					{canManage && assignments.length > 0 && (
 						<label className="flex items-center gap-2 text-xs text-slate-500">
 							<input
 								type="checkbox"
@@ -743,7 +750,7 @@ export default function EventDetail() {
 															>
 																{statusCfg.label}
 															</span>
-															{isAdmin && (
+															{canManage && (
 																<ParticipantMenu
 																	userId={a.userId}
 																	currentRole={a.role}
@@ -797,7 +804,7 @@ export default function EventDetail() {
 								<h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
 									<Users className="h-5 w-5" /> Cast ({activeCastCount})
 								</h3>
-								{isAdmin && unassignedMembers.length > 0 && (
+								{canManage && unassignedMembers.length > 0 && (
 									<button
 										type="button"
 										onClick={() => setShowAddMembers(!showAddMembers)}
@@ -812,7 +819,7 @@ export default function EventDetail() {
 							{otherAssignments.length === 0 ? (
 								<div className="p-6 text-center text-sm text-slate-500">
 									No one assigned yet.{" "}
-									{isAdmin && (
+									{canManage && (
 										<button
 											type="button"
 											onClick={() => setShowAddMembers(true)}
@@ -830,7 +837,7 @@ export default function EventDetail() {
 											<li key={a.userId} className="flex items-center justify-between px-6 py-3">
 												<div className="flex items-center gap-2">
 													<span className="text-sm font-medium text-slate-900">{a.userName}</span>
-													{!isAdmin && <RoleBadge role={a.role} />}
+													{!canManage && <RoleBadge role={a.role} />}
 												</div>
 												<div className="flex items-center gap-2">
 													<span
@@ -838,7 +845,7 @@ export default function EventDetail() {
 													>
 														{statusCfg.label}
 													</span>
-													{isAdmin && (
+													{canManage && (
 														<ParticipantMenu
 															userId={a.userId}
 															currentRole={a.role}
@@ -854,7 +861,7 @@ export default function EventDetail() {
 							)}
 
 							{/* Add Members Panel (non-show) */}
-							{showAddMembers && isAdmin && (
+							{showAddMembers && canManage && (
 								<div className="border-t border-slate-200 bg-slate-50 p-6">
 									<Form
 										method="post"
@@ -1001,7 +1008,7 @@ export default function EventDetail() {
 										<li key={a.userId} className="flex items-center justify-between px-6 py-3">
 											<div className="flex items-center gap-2">
 												<span className="text-sm font-medium text-slate-900">{a.userName}</span>
-												{!isAdmin && <RoleBadge role={a.role} />}
+												{!canManage && <RoleBadge role={a.role} />}
 											</div>
 											<div className="flex items-center gap-2">
 												<span
@@ -1009,7 +1016,7 @@ export default function EventDetail() {
 												>
 													{statusCfg.label}
 												</span>
-												{isAdmin && (
+												{canManage && (
 													<ParticipantMenu
 														userId={a.userId}
 														currentRole={a.role}

--- a/e2e/event-creator-manage.spec.ts
+++ b/e2e/event-creator-manage.spec.ts
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import { expect, test } from "@playwright/test";
+import pg from "pg";
+import { loadTestData, MEMBER_STATE } from "./helpers/test-data";
+
+const td = loadTestData();
+
+function getPool(): pg.Pool {
+	return new pg.Pool({
+		connectionString:
+			process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/greenroom",
+	});
+}
+
+/**
+ * Regression coverage for the bug where an event's creator, if they were only a
+ * plain group member (not an admin), could not manage participants on the event
+ * they created. The creator should have full access to add performers and change
+ * roles — the same as edit/delete already allowed.
+ *
+ * We seed a "show" event created by the seeded (non-admin) member and then drive
+ * the browser as that member.
+ */
+test.describe("Event creator manages participants (non-admin)", () => {
+	test.use({ storageState: MEMBER_STATE });
+
+	let eventId: string;
+
+	test.beforeAll(async () => {
+		const pool = getPool();
+		try {
+			eventId = crypto.randomUUID();
+			const start = new Date();
+			start.setDate(start.getDate() + 21);
+			start.setHours(19, 0, 0, 0);
+			const end = new Date(start);
+			end.setHours(21, 0, 0, 0);
+
+			await pool.query(
+				`INSERT INTO events
+					(id, group_id, title, event_type, start_time, end_time, created_by_id, timezone, created_at, updated_at)
+				 VALUES ($1, $2, $3, 'show', $4, $5, $6, 'UTC', NOW(), NOW())`,
+				[
+					eventId,
+					td.group.id,
+					"Creator-Managed Show",
+					start.toISOString(),
+					end.toISOString(),
+					td.member.id, // created by the non-admin member
+				],
+			);
+		} finally {
+			await pool.end();
+		}
+	});
+
+	test.afterAll(async () => {
+		const pool = getPool();
+		try {
+			await pool.query(`DELETE FROM event_assignments WHERE event_id = $1`, [eventId]);
+			await pool.query(`DELETE FROM events WHERE id = $1`, [eventId]);
+		} finally {
+			await pool.end();
+		}
+	});
+
+	test("creator can add a performer and change their role", async ({ page }) => {
+		await page.goto(`/groups/${td.group.id}/events/${eventId}`);
+		await page.waitForLoadState("networkidle");
+
+		// The non-admin creator sees the management affordance (this was hidden before the fix).
+		const addPerformers = page.getByRole("button", { name: /^Add Performers$/ });
+		await expect(addPerformers).toBeVisible();
+		await addPerformers.click();
+
+		// Add the admin (an unassigned member) as a Performer.
+		await page.locator("label", { hasText: td.admin.name }).first().click();
+		await page.getByRole("button", { name: /^Add 1 Performer$/ }).click();
+
+		// The performer now shows up in the Cast and the count is 1.
+		await expect(page.getByRole("heading", { name: /Cast \(1\)/ })).toBeVisible();
+		await expect(page.getByText(td.admin.name).first()).toBeVisible();
+
+		// Change that performer's role to Viewer via the participant menu.
+		await page.getByRole("button", { name: "Participant actions" }).first().click();
+		await page.getByRole("menuitem", { name: /Change Role/ }).click();
+		await page.getByRole("menuitem", { name: /^👀 Viewer$/ }).click();
+
+		// The member moves to the Attending (Viewers) section — role change succeeded.
+		await expect(page.getByRole("heading", { name: /Attending \(1\)/ })).toBeVisible();
+		await expect(page.getByRole("heading", { name: /Cast \(0\)/ })).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #205 — a non-admin **event creator** could not add performers or change participant roles on an event they created. They received a **403 Forbidden**, and the management UI (Add Performers panel, participant menus) was never rendered for them.

## Root cause

In `app/routes/groups.$groupId.events.$eventId.tsx`, the `assign`, `change-role`, and `remove-assignment` intents were gated on **admin-only**:

```ts
// Admin-only actions
const admin = await isGroupAdmin(user.id, groupId);
if (!admin) throw new Response("Forbidden", { status: 403 });
```

The event's creator was never considered. On top of that, the `loader` only loaded the group member list / availability suggestions for admins, and the component gated every management control on `isAdmin`, so a non-admin creator couldn't even see the controls.

This diverged from the route's own edit/delete behavior, which already granted access to `isAdmin || event.createdById === userId` (`canEdit` / `canDelete`).

## Fix

Introduce a single `canManage = isAdmin || event.createdById === user.id` concept and use it consistently across the three coupled sites:

1. **Action guard** — the participant-management intents now allow admins **or** the creator.
2. **Loader** — members/availability data are loaded whenever `canManage`, and `canManage` is returned.
3. **UI** — the Add Performers panel and participant menus are gated on `canManage`.

Group-scope / IDOR checks (`event.groupId === params.groupId`) still run **before** the ownership check, so a creator of an event in another group still gets a 404.

## Tests

- **Acceptance (server handlers)** — `groups.$groupId.events.$eventId.test.ts` drives the real `loader` and `action`:
  - non-admin creator: loader exposes `canManage: true` + member list; action lets them **add a performer**, **change a role**, and **remove an assignment**.
  - non-admin **non-creator**: loader hides controls; action still returns **403**.
- **Acceptance (browser E2E)** — `e2e/event-creator-manage.spec.ts` logs in as the seeded non-admin member who created a show, then **adds a performer and changes their role** through the UI.

## Validation

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm test` ✅ (772 tests)
- `pnpm run build` ✅
- `pnpm exec playwright test e2e/event-creator-manage.spec.ts` ✅ (Desktop Chrome)

## Docs

Documented the reusable **admin-OR-creator** ownership pattern (and the three-site gotcha) in the `greenroom-security` skill.

Closes #205
