### PR TITLE
Phase 1: add passwordless magic-link login

### DIFF
--- a/.github/skills/greenroom-testing/SKILL.md
+++ b/.github/skills/greenroom-testing/SKILL.md
@@ -542,6 +542,15 @@ Any test calling these (directly or indirectly) needs timezone-controlled fixtur
 
 My Call Time has the `playwright-cli` skill (`.github/skills/playwright-cli/`) for browser automation.
 
+### Accessible Locators
+
+- Give controls on the same page unique, user-friendly accessible names. Two fields labelled
+  `Email` are ambiguous to assistive technology and cause Playwright strict-mode failures.
+- Scope locators to a named form or region when a page has multiple workflows, then use an exact
+  label: `page.getByRole("form", { name: "Sign in with password" }).getByLabel("Email", { exact: true })`.
+- Fix ambiguous labels or regions in the UI instead of using `.first()`, `.nth()`, or a broad CSS
+  selector to silence the test.
+
 ### Login Flow
 
 ```typescript
@@ -549,9 +558,10 @@ My Call Time has the `playwright-cli` skill (`.github/skills/playwright-cli/`) f
 await page.goto("http://localhost:5173/login");
 
 // Fill in credentials
-await page.fill('input[name="email"]', "test@example.com");
-await page.fill('input[name="password"]', "password123");
-await page.click('button[type="submit"]');
+const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+await passwordForm.getByLabel("Email", { exact: true }).fill("test@example.com");
+await passwordForm.getByLabel("Password", { exact: true }).fill("password123");
+await passwordForm.getByRole("button", { name: "Sign in", exact: true }).click();
 
 // Verify redirect to dashboard
 await page.waitForURL("**/dashboard");

--- a/app/routes/auth.magic-link.consume.test.ts
+++ b/app/routes/auth.magic-link.consume.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/services/magic-link.server", () => ({
+	consumeLoginMagicLink: vi.fn(),
+	hashMagicLinkToken: vi.fn((token: string) => `hash:${token}`),
+	isValidMagicLinkToken: vi.fn((token: string) => /^[A-Za-z0-9_-]{43}$/.test(token)),
+}));
+vi.mock("~/services/session.server", () => ({
+	createUserSession: vi.fn().mockImplementation((_userId: string, redirectPath: string) => {
+		return new Response(null, {
+			status: 302,
+			headers: { Location: redirectPath, "Set-Cookie": "__greenroom_session=fresh" },
+		});
+	}),
+}));
+
+import { action, loader } from "~/routes/auth.magic-link.consume";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { consumeLoginMagicLink } from "~/services/magic-link.server";
+import { magicLinkHandoffCookie } from "~/services/magic-link-handoff.server";
+import { createUserSession } from "~/services/session.server";
+
+const RAW_TOKEN = "a".repeat(43);
+
+async function handoffCookieHeader(): Promise<string> {
+	const serialized = await magicLinkHandoffCookie.serialize(RAW_TOKEN);
+	return serialized.split(";")[0];
+}
+
+function postRequest(cookie: string) {
+	return new Request("http://localhost/auth/magic-link/consume", {
+		method: "POST",
+		body: new URLSearchParams({ _csrf: "test" }),
+		headers: { Cookie: cookie },
+	});
+}
+
+describe("magic-link consume route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(validateCsrfToken as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+	});
+
+	it("GET stashes the token without consuming or authenticating", async () => {
+		const response = await loader({
+			request: new Request(`http://localhost/auth/magic-link/consume?token=${RAW_TOKEN}`),
+			params: {},
+			context: {},
+		});
+
+		expect(response).toBeInstanceOf(Response);
+		expect((response as Response).status).toBe(302);
+		expect((response as Response).headers.get("Location")).toBe("/auth/magic-link/consume");
+		expect((response as Response).headers.get("Set-Cookie")).toContain("__magic_link_handoff=");
+		expect(consumeLoginMagicLink).not.toHaveBeenCalled();
+		expect(createUserSession).not.toHaveBeenCalled();
+	});
+
+	it("POST consumes once, creates a fresh session, and clears the handoff cookie", async () => {
+		(consumeLoginMagicLink as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ userId: "user-1", redirectPath: "/dashboard" })
+			.mockResolvedValueOnce(null);
+		const cookie = await handoffCookieHeader();
+
+		const first = await action({ request: postRequest(cookie), params: {}, context: {} });
+		const second = await action({ request: postRequest(cookie), params: {}, context: {} });
+
+		expect(first.status).toBe(302);
+		expect(first.headers.get("Location")).toBe("/dashboard");
+		expect(first.headers.get("Set-Cookie")).toContain("__magic_link_handoff=");
+		expect(first.headers.get("Set-Cookie")).toContain("Max-Age=0");
+		expect(createUserSession).toHaveBeenCalledTimes(1);
+		expect(createUserSession).toHaveBeenCalledWith("user-1", "/dashboard");
+		expect(second.status).toBe(400);
+		expect(await second.json()).toEqual({
+			error: "This sign-in link is invalid or has expired.",
+		});
+		expect(second.headers.get("Set-Cookie")).toContain("Max-Age=0");
+	});
+});

--- a/app/routes/auth.magic-link.consume.tsx
+++ b/app/routes/auth.magic-link.consume.tsx
@@ -1,0 +1,142 @@
+import type {
+	ActionFunctionArgs,
+	HeadersFunction,
+	LoaderFunctionArgs,
+	MetaFunction,
+} from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form, Link, useActionData, useLoaderData, useNavigation } from "@remix-run/react";
+import { CsrfInput } from "~/components/csrf-input";
+import { validateCsrfToken } from "~/services/csrf.server";
+import {
+	consumeLoginMagicLink,
+	hashMagicLinkToken,
+	isValidMagicLinkToken,
+} from "~/services/magic-link.server";
+import {
+	clearMagicLinkHandoff,
+	parseMagicLinkHandoff,
+	serializeMagicLinkHandoff,
+} from "~/services/magic-link-handoff.server";
+import { createUserSession } from "~/services/session.server";
+
+export const meta: MetaFunction = () => [
+	{ title: "Continue Sign-In — My Call Time" },
+	{ name: "referrer", content: "no-referrer" },
+];
+
+export const headers: HeadersFunction = () => ({
+	"Referrer-Policy": "no-referrer",
+});
+
+const CONSUME_PATH = "/auth/magic-link/consume";
+const GENERIC_ERROR = "This sign-in link is invalid or has expired.";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+	const url = new URL(request.url);
+	const token = url.searchParams.get("token");
+
+	if (token !== null) {
+		const cookie = isValidMagicLinkToken(token)
+			? await serializeMagicLinkHandoff(token)
+			: await clearMagicLinkHandoff();
+		return redirect(CONSUME_PATH, {
+			headers: {
+				"Referrer-Policy": "no-referrer",
+				"Set-Cookie": cookie,
+			},
+		});
+	}
+
+	const handoff = await parseMagicLinkHandoff(request);
+	const hasToken = typeof handoff === "string" && isValidMagicLinkToken(handoff);
+	return Response.json({ hasToken }, { headers: { "Referrer-Policy": "no-referrer" } });
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+	const formData = await request.formData();
+	await validateCsrfToken(request, formData);
+
+	const clearCookie = await clearMagicLinkHandoff();
+	const handoff = await parseMagicLinkHandoff(request);
+	if (typeof handoff !== "string" || !isValidMagicLinkToken(handoff)) {
+		return Response.json(
+			{ error: GENERIC_ERROR },
+			{
+				status: 400,
+				headers: {
+					"Referrer-Policy": "no-referrer",
+					"Set-Cookie": clearCookie,
+				},
+			},
+		);
+	}
+
+	const consumed = await consumeLoginMagicLink(hashMagicLinkToken(handoff));
+	if (!consumed) {
+		return Response.json(
+			{ error: GENERIC_ERROR },
+			{
+				status: 400,
+				headers: {
+					"Referrer-Policy": "no-referrer",
+					"Set-Cookie": clearCookie,
+				},
+			},
+		);
+	}
+
+	const response = await createUserSession(consumed.userId, consumed.redirectPath);
+	response.headers.append("Set-Cookie", clearCookie);
+	response.headers.set("Referrer-Policy", "no-referrer");
+	return response;
+}
+
+export default function MagicLinkConsumePage() {
+	const { hasToken } = useLoaderData<typeof loader>();
+	const actionData = useActionData<typeof action>();
+	const navigation = useNavigation();
+	const isSubmitting = navigation.state === "submitting";
+	const error =
+		actionData && "error" in actionData ? actionData.error : !hasToken ? GENERIC_ERROR : null;
+
+	return (
+		<div className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center py-12">
+			<div className="w-full max-w-md text-center">
+				<div className="text-3xl">🎭</div>
+				<h1 className="mt-3 text-3xl font-bold text-slate-900">Continue to My Call Time</h1>
+				<div className="mt-8 rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+					{error ? (
+						<>
+							<div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+								{error}
+							</div>
+							<Link
+								to="/login"
+								className="mt-6 inline-flex font-medium text-emerald-600 hover:text-emerald-700"
+							>
+								Request a new link
+							</Link>
+						</>
+					) : (
+						<>
+							<p className="mb-6 text-sm text-slate-600">
+								Select continue to securely finish signing in.
+							</p>
+							<Form method="post">
+								<CsrfInput />
+								<button
+									type="submit"
+									disabled={isSubmitting}
+									className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+								>
+									{isSubmitting ? "Signing in…" : "Continue to My Call Time"}
+								</button>
+							</Form>
+						</>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/routes/auth.magic-link.request.test.ts
+++ b/app/routes/auth.magic-link.request.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/auth-timing.server", () => ({
+	performDummyHashComparison: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/services/auth.server", () => ({
+	getUserByEmail: vi.fn(),
+}));
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/services/email.server", () => ({
+	sendMagicLinkEmail: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock("~/services/logger.server", () => ({
+	logger: { error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("~/services/magic-link.server", () => ({
+	issueLoginMagicLink: vi.fn().mockResolvedValue({
+		rawToken: "a".repeat(43),
+		expiresAt: new Date(),
+	}),
+	validateMagicLinkRedirectPath: vi.fn((value: string | null) => value ?? "/dashboard"),
+}));
+vi.mock("~/services/rate-limit.server", () => ({
+	checkLoginRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	checkRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	getClientIp: vi.fn().mockReturnValue("127.0.0.1"),
+}));
+
+import { action, MAGIC_LINK_GENERIC_RESPONSE } from "~/routes/auth.magic-link.request";
+import { getUserByEmail } from "~/services/auth.server";
+import { performDummyHashComparison } from "~/services/auth-timing.server";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { sendMagicLinkEmail } from "~/services/email.server";
+import { issueLoginMagicLink } from "~/services/magic-link.server";
+import { checkLoginRateLimit, checkRateLimit } from "~/services/rate-limit.server";
+
+function makeRequest(email = "user@example.com") {
+	return new Request("http://localhost/auth/magic-link/request", {
+		method: "POST",
+		body: new URLSearchParams({ email }),
+		headers: { "x-forwarded-for": "127.0.0.1" },
+	});
+}
+
+describe("magic-link request route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(checkLoginRateLimit as ReturnType<typeof vi.fn>).mockReturnValue({ limited: false });
+		(checkRateLimit as ReturnType<typeof vi.fn>).mockReturnValue({ limited: false });
+		(validateCsrfToken as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+	});
+
+	it("returns the same generic response for known and unknown emails", async () => {
+		(getUserByEmail as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({
+				id: "user-1",
+				email: "user@example.com",
+				name: "User",
+				emailVerified: true,
+				deletedAt: null,
+			})
+			.mockResolvedValueOnce(undefined);
+
+		const known = await action({ request: makeRequest(), params: {}, context: {} });
+		const unknown = await action({
+			request: makeRequest("unknown@example.com"),
+			params: {},
+			context: {},
+		});
+
+		expect(known).toEqual({ success: true, message: MAGIC_LINK_GENERIC_RESPONSE });
+		expect(unknown).toEqual({ success: true, message: MAGIC_LINK_GENERIC_RESPONSE });
+		expect(performDummyHashComparison).toHaveBeenCalledTimes(2);
+		expect(issueLoginMagicLink).toHaveBeenCalledTimes(1);
+		expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1);
+	});
+
+	it("requires CSRF validation", async () => {
+		const csrfError = new Response("Invalid CSRF token", { status: 403 });
+		(validateCsrfToken as ReturnType<typeof vi.fn>).mockRejectedValue(csrfError);
+
+		await expect(action({ request: makeRequest(), params: {}, context: {} })).rejects.toBe(
+			csrfError,
+		);
+		expect(getUserByEmail).not.toHaveBeenCalled();
+	});
+
+	it("enforces the email-digest rate limit", async () => {
+		(checkRateLimit as ReturnType<typeof vi.fn>)
+			.mockReturnValueOnce({ limited: false })
+			.mockReturnValueOnce({ limited: true, retryAfter: 60 });
+
+		const response = await action({ request: makeRequest(), params: {}, context: {} });
+
+		expect(response).toBeInstanceOf(Response);
+		expect((response as Response).status).toBe(429);
+		expect((response as Response).headers.get("Retry-After")).toBe("60");
+		expect(performDummyHashComparison).not.toHaveBeenCalled();
+		expect(getUserByEmail).not.toHaveBeenCalled();
+	});
+});

--- a/app/routes/auth.magic-link.request.test.ts
+++ b/app/routes/auth.magic-link.request.test.ts
@@ -16,6 +16,7 @@ vi.mock("~/services/logger.server", () => ({
 	logger: { error: vi.fn(), warn: vi.fn() },
 }));
 vi.mock("~/services/magic-link.server", () => ({
+	cleanupExpiredMagicLinks: vi.fn().mockResolvedValue(0),
 	issueLoginMagicLink: vi.fn().mockResolvedValue({
 		rawToken: "a".repeat(43),
 		expiresAt: new Date(),
@@ -33,7 +34,7 @@ import { getUserByEmail } from "~/services/auth.server";
 import { performDummyHashComparison } from "~/services/auth-timing.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { sendMagicLinkEmail } from "~/services/email.server";
-import { issueLoginMagicLink } from "~/services/magic-link.server";
+import { cleanupExpiredMagicLinks, issueLoginMagicLink } from "~/services/magic-link.server";
 import { checkLoginRateLimit, checkRateLimit } from "~/services/rate-limit.server";
 
 function makeRequest(email = "user@example.com") {
@@ -50,9 +51,20 @@ describe("magic-link request route", () => {
 		(checkLoginRateLimit as ReturnType<typeof vi.fn>).mockReturnValue({ limited: false });
 		(checkRateLimit as ReturnType<typeof vi.fn>).mockReturnValue({ limited: false });
 		(validateCsrfToken as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+		(issueLoginMagicLink as ReturnType<typeof vi.fn>).mockResolvedValue({
+			rawToken: "a".repeat(43),
+			expiresAt: new Date(),
+		});
+		(sendMagicLinkEmail as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		(cleanupExpiredMagicLinks as ReturnType<typeof vi.fn>).mockResolvedValue(0);
 	});
 
-	it("returns the same generic response for known and unknown emails", async () => {
+	it("returns the same response without awaiting email delivery for known and unknown emails", async () => {
+		let resolveEmail: ((value: { success: true }) => void) | undefined;
+		const pendingEmail = new Promise<{ success: true }>((resolve) => {
+			resolveEmail = resolve;
+		});
+		(sendMagicLinkEmail as ReturnType<typeof vi.fn>).mockReturnValue(pendingEmail);
 		(getUserByEmail as ReturnType<typeof vi.fn>)
 			.mockResolvedValueOnce({
 				id: "user-1",
@@ -75,6 +87,50 @@ describe("magic-link request route", () => {
 		expect(performDummyHashComparison).toHaveBeenCalledTimes(2);
 		expect(issueLoginMagicLink).toHaveBeenCalledTimes(1);
 		expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1);
+		expect(cleanupExpiredMagicLinks).toHaveBeenCalledTimes(1);
+
+		resolveEmail?.({ success: true });
+	});
+
+	it("does not fail the request when expired-token cleanup fails", async () => {
+		(getUserByEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "user@example.com",
+			name: "User",
+			emailVerified: true,
+			deletedAt: null,
+		});
+		(cleanupExpiredMagicLinks as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("cleanup failed"),
+		);
+
+		const response = await action({ request: makeRequest(), params: {}, context: {} });
+
+		expect(response).toEqual({ success: true, message: MAGIC_LINK_GENERIC_RESPONSE });
+		await vi.waitFor(() => {
+			expect(cleanupExpiredMagicLinks).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("returns without awaiting token persistence", async () => {
+		let resolveIssue: ((value: { rawToken: string; expiresAt: Date }) => void) | undefined;
+		const pendingIssue = new Promise<{ rawToken: string; expiresAt: Date }>((resolve) => {
+			resolveIssue = resolve;
+		});
+		(issueLoginMagicLink as ReturnType<typeof vi.fn>).mockReturnValue(pendingIssue);
+		(getUserByEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "user-1",
+			email: "user@example.com",
+			name: "User",
+			emailVerified: true,
+			deletedAt: null,
+		});
+
+		const response = await action({ request: makeRequest(), params: {}, context: {} });
+
+		expect(response).toEqual({ success: true, message: MAGIC_LINK_GENERIC_RESPONSE });
+		expect(sendMagicLinkEmail).not.toHaveBeenCalled();
+		resolveIssue?.({ rawToken: "a".repeat(43), expiresAt: new Date() });
 	});
 
 	it("requires CSRF validation", async () => {

--- a/app/routes/auth.magic-link.request.tsx
+++ b/app/routes/auth.magic-link.request.tsx
@@ -7,7 +7,11 @@ import { performDummyHashComparison } from "~/services/auth-timing.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { sendMagicLinkEmail } from "~/services/email.server";
 import { logger } from "~/services/logger.server";
-import { issueLoginMagicLink, validateMagicLinkRedirectPath } from "~/services/magic-link.server";
+import {
+	cleanupExpiredMagicLinks,
+	issueLoginMagicLink,
+	validateMagicLinkRedirectPath,
+} from "~/services/magic-link.server";
 import { checkLoginRateLimit, checkRateLimit, getClientIp } from "~/services/rate-limit.server";
 
 export const meta: MetaFunction = () => {
@@ -65,31 +69,40 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const user = await getUserByEmail(email);
 	if (user?.emailVerified && !user.deletedAt) {
-		try {
-			const redirectPath = validateMagicLinkRedirectPath(
-				typeof formData.get("redirectTo") === "string"
-					? (formData.get("redirectTo") as string)
-					: null,
-			);
-			const { rawToken } = await issueLoginMagicLink({
-				userId: user.id,
-				redirectPath,
+		const redirectPath = validateMagicLinkRedirectPath(
+			typeof formData.get("redirectTo") === "string"
+				? (formData.get("redirectTo") as string)
+				: null,
+		);
+		void issueLoginMagicLink({
+			userId: user.id,
+			redirectPath,
+		})
+			.then(({ rawToken }) => {
+				const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+				void sendMagicLinkEmail({
+					email: user.email,
+					name: user.name,
+					magicLinkUrl: `${appUrl}/auth/magic-link/consume?token=${encodeURIComponent(rawToken)}`,
+				})
+					.then((emailResult) => {
+						if (!emailResult.success) {
+							logger.warn(
+								{ userId: user.id, errorKind: emailResult.errorKind },
+								"Magic-link email delivery failed",
+							);
+						}
+					})
+					.catch((error) => {
+						logger.warn({ err: error, userId: user.id }, "Magic-link email delivery rejected");
+					});
+				void cleanupExpiredMagicLinks().catch((error) => {
+					logger.warn({ err: error }, "Failed to clean up expired magic links");
+				});
+			})
+			.catch((error) => {
+				logger.error({ err: error, userId: user.id }, "Failed to issue magic-link login");
 			});
-			const appUrl = process.env.APP_URL ?? "http://localhost:5173";
-			const emailResult = await sendMagicLinkEmail({
-				email: user.email,
-				name: user.name,
-				magicLinkUrl: `${appUrl}/auth/magic-link/consume?token=${encodeURIComponent(rawToken)}`,
-			});
-			if (!emailResult.success) {
-				logger.warn(
-					{ userId: user.id, errorKind: emailResult.errorKind },
-					"Magic-link email delivery failed",
-				);
-			}
-		} catch (error) {
-			logger.error({ err: error, userId: user.id }, "Failed to issue magic-link login");
-		}
 	}
 
 	return { success: true, message: MAGIC_LINK_GENERIC_RESPONSE };

--- a/app/routes/auth.magic-link.request.tsx
+++ b/app/routes/auth.magic-link.request.tsx
@@ -1,0 +1,163 @@
+import { createHash } from "node:crypto";
+import type { ActionFunctionArgs, MetaFunction } from "@remix-run/node";
+import { Form, Link, useActionData, useNavigation } from "@remix-run/react";
+import { CsrfInput } from "~/components/csrf-input";
+import { getUserByEmail } from "~/services/auth.server";
+import { performDummyHashComparison } from "~/services/auth-timing.server";
+import { validateCsrfToken } from "~/services/csrf.server";
+import { sendMagicLinkEmail } from "~/services/email.server";
+import { logger } from "~/services/logger.server";
+import { issueLoginMagicLink, validateMagicLinkRedirectPath } from "~/services/magic-link.server";
+import { checkLoginRateLimit, checkRateLimit, getClientIp } from "~/services/rate-limit.server";
+
+export const meta: MetaFunction = () => {
+	return [{ title: "Email Sign-In Link — My Call Time" }];
+};
+
+export const MAGIC_LINK_GENERIC_RESPONSE =
+	"If an account exists for that email, we sent a sign-in link. It expires in 10 minutes.";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+function normalizeEmail(value: FormDataEntryValue | null): string {
+	return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function digest(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function rateLimitedResponse(retryAfter: number): Response {
+	return Response.json(
+		{ error: "Too many sign-in link requests. Please try again later." },
+		{ status: 429, headers: { "Retry-After": String(retryAfter) } },
+	);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+	const loginRateLimit = checkLoginRateLimit(request);
+	if (loginRateLimit.limited) {
+		return rateLimitedResponse(loginRateLimit.retryAfter);
+	}
+
+	const formData = await request.formData();
+	await validateCsrfToken(request, formData);
+
+	const email = normalizeEmail(formData.get("email"));
+	const emailDigest = digest(email);
+	const ipDigest = digest(getClientIp(request));
+	const ipRateLimit = checkRateLimit(`magic-link-ip:${ipDigest}`, 5, RATE_LIMIT_WINDOW_MS);
+	const emailRateLimit = checkRateLimit(`magic-link-email:${emailDigest}`, 3, RATE_LIMIT_WINDOW_MS);
+	if (ipRateLimit.limited || emailRateLimit.limited) {
+		const retryAfter = Math.max(
+			ipRateLimit.limited ? ipRateLimit.retryAfter : 0,
+			emailRateLimit.limited ? emailRateLimit.retryAfter : 0,
+		);
+		return rateLimitedResponse(retryAfter);
+	}
+
+	await performDummyHashComparison(email);
+
+	if (!EMAIL_PATTERN.test(email) || email.length > 255) {
+		return { success: true, message: MAGIC_LINK_GENERIC_RESPONSE };
+	}
+
+	const user = await getUserByEmail(email);
+	if (user?.emailVerified && !user.deletedAt) {
+		try {
+			const redirectPath = validateMagicLinkRedirectPath(
+				typeof formData.get("redirectTo") === "string"
+					? (formData.get("redirectTo") as string)
+					: null,
+			);
+			const { rawToken } = await issueLoginMagicLink({
+				userId: user.id,
+				redirectPath,
+			});
+			const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+			const emailResult = await sendMagicLinkEmail({
+				email: user.email,
+				name: user.name,
+				magicLinkUrl: `${appUrl}/auth/magic-link/consume?token=${encodeURIComponent(rawToken)}`,
+			});
+			if (!emailResult.success) {
+				logger.warn(
+					{ userId: user.id, errorKind: emailResult.errorKind },
+					"Magic-link email delivery failed",
+				);
+			}
+		} catch (error) {
+			logger.error({ err: error, userId: user.id }, "Failed to issue magic-link login");
+		}
+	}
+
+	return { success: true, message: MAGIC_LINK_GENERIC_RESPONSE };
+}
+
+export default function MagicLinkRequestPage() {
+	const actionData = useActionData<typeof action>();
+	const navigation = useNavigation();
+	const isSubmitting = navigation.state === "submitting";
+
+	return (
+		<div className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center py-12">
+			<div className="w-full max-w-md">
+				<div className="text-center">
+					<div className="text-3xl">✉️</div>
+					<h1 className="mt-3 text-3xl font-bold text-slate-900">Sign in by email</h1>
+					<p className="mt-2 text-slate-600">We&apos;ll send you a secure, one-time link.</p>
+				</div>
+
+				<div className="mt-8 rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+					{actionData && "message" in actionData ? (
+						<div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+							{actionData.message}
+						</div>
+					) : (
+						<>
+							{actionData && "error" in actionData && (
+								<div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+									{actionData.error}
+								</div>
+							)}
+							<Form method="post" className="space-y-4">
+								<CsrfInput />
+								<div>
+									<label
+										htmlFor="magic-link-email"
+										className="block text-sm font-medium text-slate-700"
+									>
+										Email
+									</label>
+									<input
+										id="magic-link-email"
+										name="email"
+										type="email"
+										autoComplete="email"
+										required
+										className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+										placeholder="you@example.com"
+									/>
+								</div>
+								<button
+									type="submit"
+									disabled={isSubmitting}
+									className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+								>
+									{isSubmitting ? "Sending…" : "Email me a sign-in link"}
+								</button>
+							</Form>
+						</>
+					)}
+				</div>
+
+				<p className="mt-6 text-center text-sm text-slate-600">
+					<Link to="/login" className="font-medium text-emerald-600 hover:text-emerald-700">
+						Back to sign in
+					</Link>
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -124,14 +124,19 @@ export default function Login() {
 						</div>
 					</div>
 
-					<Form method="post" action="/auth/magic-link/request" className="space-y-4">
+					<Form
+						method="post"
+						action="/auth/magic-link/request"
+						aria-label="Sign in with email link"
+						className="space-y-4"
+					>
 						<CsrfInput />
 						<div>
 							<label
 								htmlFor="magic-link-email"
 								className="block text-sm font-medium text-slate-700"
 							>
-								Email
+								Email for sign-in link
 							</label>
 							<input
 								id="magic-link-email"
@@ -161,7 +166,7 @@ export default function Login() {
 						</div>
 					</div>
 
-					<Form method="post" className="space-y-4">
+					<Form method="post" aria-label="Sign in with password" className="space-y-4">
 						<CsrfInput />
 						<div>
 							<label htmlFor="email" className="block text-sm font-medium text-slate-700">

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -87,7 +87,10 @@ export default function Login() {
 	const { verified } = useLoaderData<typeof loader>();
 	const actionData = useActionData<typeof action>();
 	const navigation = useNavigation();
-	const isSubmitting = navigation.state === "submitting";
+	const isPasswordSubmitting =
+		navigation.state === "submitting" && navigation.formAction === "/login";
+	const isMagicLinkSubmitting =
+		navigation.state === "submitting" && navigation.formAction === "/auth/magic-link/request";
 
 	return (
 		<div className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center py-12">
@@ -117,7 +120,44 @@ export default function Login() {
 							<div className="w-full border-t border-slate-200" />
 						</div>
 						<div className="relative flex justify-center text-sm">
-							<span className="bg-white px-2 text-slate-500">or continue with email</span>
+							<span className="bg-white px-2 text-slate-500">or use a sign-in link</span>
+						</div>
+					</div>
+
+					<Form method="post" action="/auth/magic-link/request" className="space-y-4">
+						<CsrfInput />
+						<div>
+							<label
+								htmlFor="magic-link-email"
+								className="block text-sm font-medium text-slate-700"
+							>
+								Email
+							</label>
+							<input
+								id="magic-link-email"
+								name="email"
+								type="email"
+								autoComplete="email"
+								required
+								className="mt-1 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 shadow-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+								placeholder="you@example.com"
+							/>
+						</div>
+						<button
+							type="submit"
+							disabled={isMagicLinkSubmitting}
+							className="w-full rounded-lg border border-emerald-600 bg-emerald-50 px-4 py-2.5 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 disabled:opacity-50"
+						>
+							{isMagicLinkSubmitting ? "Sending…" : "Email me a sign-in link"}
+						</button>
+					</Form>
+
+					<div className="relative my-6">
+						<div className="absolute inset-0 flex items-center">
+							<div className="w-full border-t border-slate-200" />
+						</div>
+						<div className="relative flex justify-center text-sm">
+							<span className="bg-white px-2 text-slate-500">or sign in with password</span>
 						</div>
 					</div>
 
@@ -155,10 +195,10 @@ export default function Login() {
 
 						<button
 							type="submit"
-							disabled={isSubmitting}
+							disabled={isPasswordSubmitting}
 							className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:ring-offset-2 disabled:opacity-50"
 						>
-							{isSubmitting ? "Signing in…" : "Sign in"}
+							{isPasswordSubmitting ? "Signing in…" : "Sign in"}
 						</button>
 					</Form>
 				</div>

--- a/app/routes/magic-link.acceptance.test.ts
+++ b/app/routes/magic-link.acceptance.test.ts
@@ -28,6 +28,7 @@ vi.mock("~/services/logger.server", () => ({
 	logger: { error: vi.fn(), warn: vi.fn() },
 }));
 vi.mock("~/services/magic-link.server", () => ({
+	cleanupExpiredMagicLinks: vi.fn().mockResolvedValue(0),
 	issueLoginMagicLink: vi.fn().mockResolvedValue({
 		rawToken: acceptance.rawToken,
 		expiresAt: new Date(Date.now() + 600_000),
@@ -81,6 +82,9 @@ describe("passwordless magic-link acceptance", () => {
 		});
 		expect(requestResponse).toMatchObject({ success: true });
 
+		await vi.waitFor(() => {
+			expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1);
+		});
 		const sentEmail = (sendMagicLinkEmail as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
 		expect(sentEmail.magicLinkUrl).toContain(acceptance.rawToken);
 

--- a/app/routes/magic-link.acceptance.test.ts
+++ b/app/routes/magic-link.acceptance.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const acceptance = vi.hoisted(() => ({
+	rawToken: "acceptance-token-value".padEnd(43, "a"),
+	consumed: false,
+}));
+
+vi.mock("~/services/auth-timing.server", () => ({
+	performDummyHashComparison: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/services/auth.server", () => ({
+	getUserByEmail: vi.fn().mockResolvedValue({
+		id: "passwordless-user",
+		email: "passwordless@example.com",
+		name: "Passwordless User",
+		passwordHash: null,
+		emailVerified: true,
+		deletedAt: null,
+	}),
+}));
+vi.mock("~/services/csrf.server", () => ({
+	validateCsrfToken: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/services/email.server", () => ({
+	sendMagicLinkEmail: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock("~/services/logger.server", () => ({
+	logger: { error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("~/services/magic-link.server", () => ({
+	issueLoginMagicLink: vi.fn().mockResolvedValue({
+		rawToken: acceptance.rawToken,
+		expiresAt: new Date(Date.now() + 600_000),
+	}),
+	validateMagicLinkRedirectPath: vi.fn((value: string | null) => value ?? "/dashboard"),
+	isValidMagicLinkToken: vi.fn((token: string) => /^[A-Za-z0-9_-]{43}$/.test(token)),
+	hashMagicLinkToken: vi.fn((token: string) => `hash:${token}`),
+	consumeLoginMagicLink: vi.fn().mockImplementation(async () => {
+		if (acceptance.consumed) return null;
+		acceptance.consumed = true;
+		return { userId: "passwordless-user", redirectPath: "/dashboard" };
+	}),
+}));
+vi.mock("~/services/rate-limit.server", () => ({
+	checkLoginRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	checkRateLimit: vi.fn().mockReturnValue({ limited: false }),
+	getClientIp: vi.fn().mockReturnValue("127.0.0.1"),
+}));
+vi.mock("~/services/session.server", () => ({
+	createUserSession: vi.fn().mockImplementation((userId: string, redirectPath: string) => {
+		return new Response(null, {
+			status: 302,
+			headers: {
+				Location: redirectPath,
+				"Set-Cookie": `__greenroom_session=${userId}`,
+			},
+		});
+	}),
+}));
+
+import { action as consumeAction } from "~/routes/auth.magic-link.consume";
+import { action as requestAction } from "~/routes/auth.magic-link.request";
+import { sendMagicLinkEmail } from "~/services/email.server";
+import { magicLinkHandoffCookie } from "~/services/magic-link-handoff.server";
+import { createUserSession } from "~/services/session.server";
+
+describe("passwordless magic-link acceptance", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		acceptance.consumed = false;
+	});
+
+	it("requests a link and authenticates a user without a password", async () => {
+		const requestResponse = await requestAction({
+			request: new Request("http://localhost/auth/magic-link/request", {
+				method: "POST",
+				body: new URLSearchParams({ email: "passwordless@example.com" }),
+			}),
+			params: {},
+			context: {},
+		});
+		expect(requestResponse).toMatchObject({ success: true });
+
+		const sentEmail = (sendMagicLinkEmail as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+		expect(sentEmail.magicLinkUrl).toContain(acceptance.rawToken);
+
+		const handoff = await magicLinkHandoffCookie.serialize(acceptance.rawToken);
+		const consumeResponse = await consumeAction({
+			request: new Request("http://localhost/auth/magic-link/consume", {
+				method: "POST",
+				body: new URLSearchParams({ _csrf: "test" }),
+				headers: { Cookie: handoff.split(";")[0] },
+			}),
+			params: {},
+			context: {},
+		});
+
+		expect(consumeResponse.status).toBe(302);
+		expect(consumeResponse.headers.get("Location")).toBe("/dashboard");
+		expect(createUserSession).toHaveBeenCalledWith("passwordless-user", "/dashboard");
+		expect(createUserSession).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/services/__integration__/magic-link.integration.test.ts
+++ b/app/services/__integration__/magic-link.integration.test.ts
@@ -1,0 +1,83 @@
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../../src/db/index.js";
+import { magicLinkTokens } from "../../../src/db/schema.js";
+import {
+	consumeLoginMagicLink,
+	hashMagicLinkToken,
+	issueLoginMagicLink,
+} from "../magic-link.server.js";
+import { createTestUser } from "./seed.js";
+import { cleanDatabase } from "./setup.js";
+
+beforeEach(async () => {
+	await cleanDatabase();
+});
+
+describe("magic-link service integration", () => {
+	it("stores only the token hash, never the raw token", async () => {
+		const user = await createTestUser();
+		const issued = await issueLoginMagicLink({ userId: user.id });
+		const [stored] = await db
+			.select()
+			.from(magicLinkTokens)
+			.where(eq(magicLinkTokens.userId, user.id));
+
+		expect(stored?.tokenHash).toBe(hashMagicLinkToken(issued.rawToken));
+		expect(JSON.stringify(stored)).not.toContain(issued.rawToken);
+		expect(stored?.purpose).toBe("login");
+		expect(stored?.redirectPath).toBe("/dashboard");
+	});
+
+	it("allows exactly one of two simultaneous consumes to succeed", async () => {
+		const user = await createTestUser();
+		const { rawToken } = await issueLoginMagicLink({ userId: user.id });
+		const tokenHash = hashMagicLinkToken(rawToken);
+
+		const results = await Promise.all([
+			consumeLoginMagicLink(tokenHash),
+			consumeLoginMagicLink(tokenHash),
+		]);
+
+		expect(results.filter((result) => result !== null)).toHaveLength(1);
+		expect(results.filter((result) => result === null)).toHaveLength(1);
+	});
+
+	it("returns the same failure for expired and reused tokens", async () => {
+		const user = await createTestUser();
+		const expiredRawToken = "a".repeat(43);
+		await db.insert(magicLinkTokens).values({
+			userId: user.id,
+			tokenHash: hashMagicLinkToken(expiredRawToken),
+			purpose: "login",
+			redirectPath: "/dashboard",
+			expiresAt: new Date(Date.now() - 1000),
+		});
+
+		const { rawToken } = await issueLoginMagicLink({ userId: user.id });
+		const tokenHash = hashMagicLinkToken(rawToken);
+		expect(await consumeLoginMagicLink(tokenHash)).not.toBeNull();
+
+		const [expiredResult, reusedResult] = await Promise.all([
+			consumeLoginMagicLink(hashMagicLinkToken(expiredRawToken)),
+			consumeLoginMagicLink(tokenHash),
+		]);
+		expect(expiredResult).toBeNull();
+		expect(reusedResult).toBeNull();
+	});
+
+	it("revokes sibling login tokens after a successful consume", async () => {
+		const user = await createTestUser();
+		const first = await issueLoginMagicLink({ userId: user.id });
+		const second = await issueLoginMagicLink({ userId: user.id });
+
+		expect(await consumeLoginMagicLink(hashMagicLinkToken(first.rawToken))).not.toBeNull();
+		expect(await consumeLoginMagicLink(hashMagicLinkToken(second.rawToken))).toBeNull();
+
+		const unconsumed = await db
+			.select()
+			.from(magicLinkTokens)
+			.where(and(eq(magicLinkTokens.userId, user.id), eq(magicLinkTokens.purpose, "login")));
+		expect(unconsumed.every((token) => token.consumedAt !== null)).toBe(true);
+	});
+});

--- a/app/services/__integration__/setup.ts
+++ b/app/services/__integration__/setup.ts
@@ -9,6 +9,7 @@ import { sql } from "drizzle-orm";
 import { db } from "../../../src/db/index.js";
 
 const TABLES = [
+	"magic_link_tokens",
 	"rsvp_changes",
 	"event_assignments",
 	"events",

--- a/app/services/auth-timing.server.ts
+++ b/app/services/auth-timing.server.ts
@@ -1,0 +1,14 @@
+import bcrypt from "bcryptjs";
+
+const DUMMY_HASH = "$2a$12$000000000000000000000uGPOBOBOBOBOBOBOBOBOBOBOBOBOBOBO";
+
+export function comparePasswordWithHash(
+	password: string,
+	passwordHash: string | null | undefined,
+): Promise<boolean> {
+	return bcrypt.compare(password, passwordHash ?? DUMMY_HASH);
+}
+
+export async function performDummyHashComparison(value: string): Promise<void> {
+	await bcrypt.compare(value, DUMMY_HASH);
+}

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -6,6 +6,7 @@ import { Authenticator } from "remix-auth";
 import { FormStrategy } from "remix-auth-form";
 import { db } from "../../src/db/index.js";
 import { users } from "../../src/db/schema.js";
+import { comparePasswordWithHash } from "./auth-timing.server.js";
 import { destroyUserSession, getSession, getUserId, sessionStorage } from "./session.server.js";
 import { trackEvent } from "./telemetry.server.js";
 
@@ -33,9 +34,6 @@ function toAuthUser(user: UserRecord): AuthUser {
 
 export const authenticator = new Authenticator<AuthUser>();
 
-// Dummy hash for constant-time comparison when user doesn't exist
-const DUMMY_HASH = "$2a$12$000000000000000000000uGPOBOBOBOBOBOBOBOBOBOBOBOBOBOBO";
-
 authenticator.use(
 	new FormStrategy(async ({ form }) => {
 		const email = form.get("email");
@@ -52,8 +50,7 @@ authenticator.use(
 		const user = await getUserByEmail(email);
 
 		// Always run bcrypt to prevent timing-based user enumeration
-		const hashToCompare = user?.passwordHash ?? DUMMY_HASH;
-		const isValid = await bcrypt.compare(password, hashToCompare);
+		const isValid = await comparePasswordWithHash(password, user?.passwordHash);
 
 		if (!user || !user.passwordHash || !isValid) {
 			throw new Error("Invalid email or password.");

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -276,6 +276,26 @@ ${ctaButton(options.verificationUrl, "Verify Email Address")}
 	return result;
 }
 
+export async function sendMagicLinkEmail(options: {
+	email: string;
+	name: string;
+	magicLinkUrl: string;
+}): Promise<{ success: boolean; error?: string; errorKind?: EmailErrorKind }> {
+	const html = emailLayout(`
+<h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#0f172a;">Sign in to My Call Time</h2>
+<p style="color:#475569;margin:0 0 20px;">Hi ${escapeHtml(options.name)}, use this secure link to sign in to your account.</p>
+${ctaButton(options.magicLinkUrl, "Sign In to My Call Time")}
+<p style="color:#64748b;font-size:13px;margin:0;">This link expires in 10 minutes and can only be used once. If you didn't request it, you can safely ignore this email.</p>`);
+	const text = `Hi ${options.name},\n\nUse this secure link to sign in to My Call Time:\n\n${options.magicLinkUrl}\n\nThis link expires in 10 minutes and can only be used once. If you didn't request it, you can safely ignore this email.`;
+
+	return sendEmail({
+		to: options.email,
+		subject: "Your sign-in link - My Call Time",
+		html,
+		text,
+	});
+}
+
 export async function sendAvailabilityRequestNotification(options: {
 	requestId: string;
 	requestTitle: string;

--- a/app/services/magic-link-handoff.server.ts
+++ b/app/services/magic-link-handoff.server.ts
@@ -1,0 +1,30 @@
+import { createCookie } from "@remix-run/node";
+
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+	throw new Error("SESSION_SECRET environment variable is required");
+}
+
+const HANDOFF_COOKIE_MAX_AGE_SECONDS = 5 * 60;
+const CONSUME_PATH = "/auth/magic-link/consume";
+
+export const magicLinkHandoffCookie = createCookie("__magic_link_handoff", {
+	httpOnly: true,
+	maxAge: HANDOFF_COOKIE_MAX_AGE_SECONDS,
+	path: CONSUME_PATH,
+	sameSite: "lax",
+	secrets: [sessionSecret],
+	secure: process.env.NODE_ENV === "production",
+});
+
+export function serializeMagicLinkHandoff(rawToken: string): Promise<string> {
+	return magicLinkHandoffCookie.serialize(rawToken);
+}
+
+export function parseMagicLinkHandoff(request: Request): Promise<unknown> {
+	return magicLinkHandoffCookie.parse(request.headers.get("Cookie"));
+}
+
+export function clearMagicLinkHandoff(): Promise<string> {
+	return magicLinkHandoffCookie.serialize("", { maxAge: 0 });
+}

--- a/app/services/magic-link.server.test.ts
+++ b/app/services/magic-link.server.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	generateMagicLinkToken,
+	hashMagicLinkToken,
+	issueLoginMagicLink,
+	isValidMagicLinkToken,
+	validateMagicLinkRedirectPath,
+} from "./magic-link.server.js";
+
+describe("magic-link service", () => {
+	it("generates a 256-bit base64url token and hashes it as lowercase SHA-256 hex", () => {
+		const rawToken = generateMagicLinkToken();
+		const tokenHash = hashMagicLinkToken(rawToken);
+
+		expect(rawToken).toMatch(/^[A-Za-z0-9_-]{43}$/);
+		expect(isValidMagicLinkToken(rawToken)).toBe(true);
+		expect(tokenHash).toMatch(/^[a-f0-9]{64}$/);
+		expect(tokenHash).not.toContain(rawToken);
+	});
+
+	it.each([
+		"//evil.example",
+		"https://evil.example",
+		"javascript:alert(1)",
+		"\\evil.example",
+		"/\\evil.example",
+		"/https://evil.example",
+		"/%2Fevil.example",
+		"/%5Cevil.example",
+		"/%0Devil.example",
+		"/%252Fevil.example",
+		"/%25252525252Fevil.example",
+		"/%68ttps%3A%2F%2Fevil.example",
+	])("rejects unsafe redirect %s", (redirectPath) => {
+		expect(validateMagicLinkRedirectPath(redirectPath)).toBe("/dashboard");
+	});
+
+	it("accepts a strict local path", () => {
+		expect(validateMagicLinkRedirectPath("/groups/123/events?view=calendar")).toBe(
+			"/groups/123/events?view=calendar",
+		);
+	});
+
+	it("rejects expiry windows longer than 15 minutes", async () => {
+		await expect(issueLoginMagicLink({ userId: "user-1", expiryMinutes: 16 })).rejects.toThrow(
+			"between 1 and 15 minutes",
+		);
+	});
+});

--- a/app/services/magic-link.server.ts
+++ b/app/services/magic-link.server.ts
@@ -1,0 +1,146 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, eq, gt, isNull, lt, ne, sql } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { magicLinkTokens } from "../../src/db/schema.js";
+
+export const MAGIC_LINK_EXPIRY_MINUTES = 10;
+export const MAGIC_LINK_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const MAX_MAGIC_LINK_EXPIRY_MINUTES = 15;
+const DEFAULT_REDIRECT_PATH = "/dashboard";
+const URL_SCHEME_PATTERN = /^\/?[a-z][a-z0-9+.-]*:/i;
+const DANGEROUS_ENCODED_CHARACTER_PATTERN = /%(?:0[0-9a-f]|1[0-9a-f]|7f|2f|5c|3a)/i;
+
+function containsControlCharacter(value: string): boolean {
+	return Array.from(value).some((character) => {
+		const code = character.charCodeAt(0);
+		return code <= 31 || code === 127;
+	});
+}
+
+function isUnsafeRedirectPath(value: string): boolean {
+	return (
+		!value.startsWith("/") ||
+		value.startsWith("//") ||
+		value.includes("\\") ||
+		containsControlCharacter(value) ||
+		URL_SCHEME_PATTERN.test(value) ||
+		DANGEROUS_ENCODED_CHARACTER_PATTERN.test(value)
+	);
+}
+
+export function generateMagicLinkToken(): string {
+	return randomBytes(32).toString("base64url");
+}
+
+export function hashMagicLinkToken(rawToken: string): string {
+	return createHash("sha256").update(rawToken).digest("hex");
+}
+
+export function isValidMagicLinkToken(rawToken: string): boolean {
+	return MAGIC_LINK_TOKEN_PATTERN.test(rawToken);
+}
+
+export function validateMagicLinkRedirectPath(value: string | null | undefined): string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > 500 ||
+		isUnsafeRedirectPath(value)
+	) {
+		return DEFAULT_REDIRECT_PATH;
+	}
+
+	let decoded = value;
+	try {
+		for (let i = 0; i < 5; i++) {
+			const next = decodeURIComponent(decoded);
+			if (next === decoded) return value;
+			decoded = next;
+			if (isUnsafeRedirectPath(decoded)) return DEFAULT_REDIRECT_PATH;
+		}
+	} catch {
+		return DEFAULT_REDIRECT_PATH;
+	}
+
+	// Reject unusually deep encoding rather than risk a downstream decoder exposing a dangerous path.
+	return DEFAULT_REDIRECT_PATH;
+}
+
+export async function issueLoginMagicLink(options: {
+	userId: string;
+	redirectPath?: string | null;
+	expiryMinutes?: number;
+}): Promise<{ rawToken: string; expiresAt: Date }> {
+	const expiryMinutes = options.expiryMinutes ?? MAGIC_LINK_EXPIRY_MINUTES;
+	if (
+		!Number.isInteger(expiryMinutes) ||
+		expiryMinutes < 1 ||
+		expiryMinutes > MAX_MAGIC_LINK_EXPIRY_MINUTES
+	) {
+		throw new RangeError("Magic-link expiry must be between 1 and 15 minutes.");
+	}
+
+	const rawToken = generateMagicLinkToken();
+	const expiresAt = new Date(Date.now() + expiryMinutes * 60 * 1000);
+
+	await db.insert(magicLinkTokens).values({
+		userId: options.userId,
+		tokenHash: hashMagicLinkToken(rawToken),
+		purpose: "login",
+		redirectPath: validateMagicLinkRedirectPath(options.redirectPath),
+		expiresAt,
+	});
+
+	return { rawToken, expiresAt };
+}
+
+export async function consumeLoginMagicLink(tokenHash: string): Promise<{
+	userId: string;
+	redirectPath: string;
+} | null> {
+	return db.transaction(async (tx) => {
+		const [consumed] = await tx
+			.update(magicLinkTokens)
+			.set({ consumedAt: sql`now()` })
+			.where(
+				and(
+					eq(magicLinkTokens.tokenHash, tokenHash),
+					eq(magicLinkTokens.purpose, "login"),
+					isNull(magicLinkTokens.consumedAt),
+					gt(magicLinkTokens.expiresAt, sql`now()`),
+				),
+			)
+			.returning({
+				id: magicLinkTokens.id,
+				userId: magicLinkTokens.userId,
+				redirectPath: magicLinkTokens.redirectPath,
+			});
+
+		if (!consumed) return null;
+
+		await tx
+			.update(magicLinkTokens)
+			.set({ consumedAt: sql`now()` })
+			.where(
+				and(
+					eq(magicLinkTokens.userId, consumed.userId),
+					eq(magicLinkTokens.purpose, "login"),
+					isNull(magicLinkTokens.consumedAt),
+					ne(magicLinkTokens.id, consumed.id),
+				),
+			);
+
+		return {
+			userId: consumed.userId,
+			redirectPath: validateMagicLinkRedirectPath(consumed.redirectPath),
+		};
+	});
+}
+
+export async function cleanupExpiredMagicLinks(): Promise<number> {
+	const deleted = await db
+		.delete(magicLinkTokens)
+		.where(lt(magicLinkTokens.expiresAt, sql`now()`))
+		.returning({ id: magicLinkTokens.id });
+	return deleted.length;
+}

--- a/app/services/rate-limit.server.ts
+++ b/app/services/rate-limit.server.ts
@@ -57,7 +57,7 @@ export function checkRateLimit(
 	return { limited: false };
 }
 
-function getClientIp(request: Request): string {
+export function getClientIp(request: Request): string {
 	const forwarded = request.headers.get("x-forwarded-for");
 	if (forwarded) {
 		const ip = forwarded.split(",")[0].trim();

--- a/drizzle/0016_outstanding_solo.sql
+++ b/drizzle/0016_outstanding_solo.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."magic_link_purpose" AS ENUM('login', 'verify_email');--> statement-breakpoint
+CREATE TABLE "magic_link_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
+	"purpose" "magic_link_purpose" NOT NULL,
+	"redirect_path" varchar(500) DEFAULT '/dashboard' NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "magic_link_tokens" ADD CONSTRAINT "magic_link_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "magic_link_tokens_token_hash_idx" ON "magic_link_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "magic_link_tokens_user_created_at_idx" ON "magic_link_tokens" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "magic_link_tokens_expires_at_idx" ON "magic_link_tokens" USING btree ("expires_at");

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "4957071d-a56a-4cca-a29d-5c6d576419c3",
-  "prevId": "15630689-c3a4-4f14-ad88-577bcf704256",
+  "id": "8519d2d8-fe10-407e-b012-c9514446e40d",
+  "prevId": "53c8c260-ca19-4bee-b10b-788224acdb4e",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -177,6 +177,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "responded_at": {
           "name": "responded_at",
           "type": "timestamp with time zone",
@@ -245,6 +251,74 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_tokens": {
+      "name": "calendar_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_tokens_user_id_users_id_fk": {
+          "name": "calendar_tokens_user_id_users_id_fk",
+          "tableFrom": "calendar_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_tokens_user_id_unique": {
+          "name": "calendar_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "calendar_tokens_token_unique": {
+          "name": "calendar_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -777,6 +851,137 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "magic_link_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_path": {
+          "name": "redirect_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/dashboard'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_token_hash_idx": {
+          "name": "magic_link_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_tokens_user_created_at_idx": {
+          "name": "magic_link_tokens_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_tokens_expires_at_idx": {
+          "name": "magic_link_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_link_tokens_user_id_users_id_fk": {
+          "name": "magic_link_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_link_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.rsvp_changes": {
       "name": "rsvp_changes",
       "schema": "",
@@ -1093,6 +1298,14 @@
       "values": [
         "admin",
         "member"
+      ]
+    },
+    "public.magic_link_purpose": {
+      "name": "magic_link_purpose",
+      "schema": "public",
+      "values": [
+        "login",
+        "verify_email"
       ]
     }
   },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777905664500,
       "tag": "0015_sticky_leper_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1785730851236,
+      "tag": "0016_outstanding_solo",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -44,9 +44,10 @@ test.describe("Signup", () => {
 test.describe("Login", () => {
 	test("login with valid credentials redirects to dashboard", async ({ page }) => {
 		await page.goto("/login");
-		await page.getByLabel("Email").fill(td.admin.email);
-		await page.getByLabel("Password").fill("TestPassword123!");
-		await page.getByRole("button", { name: "Sign in" }).click();
+		const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+		await passwordForm.getByLabel("Email", { exact: true }).fill(td.admin.email);
+		await passwordForm.getByLabel("Password", { exact: true }).fill("TestPassword123!");
+		await passwordForm.getByRole("button", { name: "Sign in", exact: true }).click();
 
 		await expect(page).toHaveURL(/\/dashboard/);
 		await expect(page.getByText(/welcome back/i)).toBeVisible();
@@ -54,9 +55,10 @@ test.describe("Login", () => {
 
 	test("login with wrong password shows error", async ({ page }) => {
 		await page.goto("/login");
-		await page.getByLabel("Email").fill(td.admin.email);
-		await page.getByLabel("Password").fill("WrongPassword999!");
-		await page.getByRole("button", { name: "Sign in" }).click();
+		const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+		await passwordForm.getByLabel("Email", { exact: true }).fill(td.admin.email);
+		await passwordForm.getByLabel("Password", { exact: true }).fill("WrongPassword999!");
+		await passwordForm.getByRole("button", { name: "Sign in", exact: true }).click();
 
 		// Should stay on login page and show error
 		await expect(page).toHaveURL(/\/login/);
@@ -67,9 +69,11 @@ test.describe("Login", () => {
 		await page.goto("/login");
 
 		await expect(page.getByText("Welcome back")).toBeVisible();
-		await expect(page.getByLabel("Email")).toBeVisible();
-		await expect(page.getByLabel("Password")).toBeVisible();
-		await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+		await expect(page.getByLabel("Email for sign-in link", { exact: true })).toBeVisible();
+		const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+		await expect(passwordForm.getByLabel("Email", { exact: true })).toBeVisible();
+		await expect(passwordForm.getByLabel("Password", { exact: true })).toBeVisible();
+		await expect(passwordForm.getByRole("button", { name: "Sign in", exact: true })).toBeVisible();
 		await expect(page.getByRole("link", { name: /google/i })).toBeVisible();
 	});
 });

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -43,9 +43,10 @@ setup("seed and authenticate", async ({ page }) => {
 		const p = await context.newPage();
 		await p.goto("/login");
 		await p.waitForLoadState("networkidle");
-		await p.getByLabel("Email").fill(email);
-		await p.getByLabel("Password").fill(password);
-		await p.getByRole("button", { name: "Sign in" }).click();
+		const passwordForm = p.getByRole("form", { name: "Sign in with password" });
+		await passwordForm.getByLabel("Email", { exact: true }).fill(email);
+		await passwordForm.getByLabel("Password", { exact: true }).fill(password);
+		await passwordForm.getByRole("button", { name: "Sign in", exact: true }).click();
 		await p.waitForURL("**/dashboard", { timeout: 15_000 });
 		await context.storageState({ path: statePath });
 		await context.close();

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -7,8 +7,9 @@ import type { TestUser } from "./seed";
  */
 export async function loginAs(page: Page, user: TestUser): Promise<void> {
 	await page.goto("/login");
-	await page.getByLabel("Email").fill(user.email);
-	await page.getByLabel("Password").fill(user.password);
-	await page.getByRole("button", { name: "Sign in" }).click();
+	const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+	await passwordForm.getByLabel("Email", { exact: true }).fill(user.email);
+	await passwordForm.getByLabel("Password", { exact: true }).fill(user.password);
+	await passwordForm.getByRole("button", { name: "Sign in", exact: true }).click();
 	await page.waitForURL("**/dashboard");
 }

--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -50,9 +50,10 @@ test.describe("Mobile Forms (unauthenticated)", () => {
 
 		await page.goto("/login");
 
-		await expect(page.getByLabel("Email")).toBeVisible();
-		await expect(page.getByLabel("Password")).toBeVisible();
-		await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+		const passwordForm = page.getByRole("form", { name: "Sign in with password" });
+		await expect(passwordForm.getByLabel("Email", { exact: true })).toBeVisible();
+		await expect(passwordForm.getByLabel("Password", { exact: true })).toBeVisible();
+		await expect(passwordForm.getByRole("button", { name: "Sign in", exact: true })).toBeVisible();
 	});
 
 	test("signup form is usable on mobile viewport", async ({ page, isMobile }) => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -25,6 +25,7 @@ export const assignmentStatusEnum = pgEnum("assignment_status", [
 	"confirmed",
 	"declined",
 ]);
+export const magicLinkPurposeEnum = pgEnum("magic_link_purpose", ["login", "verify_email"]);
 
 // Users
 export const users = pgTable(
@@ -48,6 +49,28 @@ export const users = pgTable(
 		index("users_email_idx").on(table.email),
 		index("users_google_id_idx").on(table.googleId),
 		index("users_email_verification_token_idx").on(table.emailVerificationToken),
+	],
+);
+
+// Magic Link Tokens
+export const magicLinkTokens = pgTable(
+	"magic_link_tokens",
+	{
+		id: uuid("id").defaultRandom().primaryKey(),
+		userId: uuid("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		tokenHash: varchar("token_hash", { length: 64 }).notNull(),
+		purpose: magicLinkPurposeEnum("purpose").notNull(),
+		redirectPath: varchar("redirect_path", { length: 500 }).default("/dashboard").notNull(),
+		expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+		consumedAt: timestamp("consumed_at", { withTimezone: true }),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		uniqueIndex("magic_link_tokens_token_hash_idx").on(table.tokenHash),
+		index("magic_link_tokens_user_created_at_idx").on(table.userId, table.createdAt),
+		index("magic_link_tokens_expires_at_idx").on(table.expiresAt),
 	],
 );
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the approved passwordless magic-link design alongside the existing email/password and Google login flows.

- adds the `magic_link_purpose` enum and hashed, single-use `magic_link_tokens` table via generated Drizzle migration
- adds 256-bit token issuance, strict local redirect validation, atomic consumption, sibling-token revocation, and opportunistic expired-token cleanup
- adds generic, rate-limited, CSRF-protected request handling with shared bcrypt anti-enumeration work
- dispatches token persistence and ACS email delivery off the HTTP response path, closing the known-account timing side channel while preserving delivery failure logging
- runs expired-token cleanup best-effort after successful issuance without delaying or failing the request
- adds scanner-safe GET-to-cookie handoff and explicit CSRF-protected POST consumption with fresh session creation
- adds the ACS magic-link email template and a prominent magic-link option on the existing login page
- repairs the pre-existing 0011→0012 snapshot metadata link; the snapshot chain now validates through 0016

## Security and test coverage

- raw-token non-persistence and lowercase SHA-256 hashing
- open-redirect rejection for protocol-relative, scheme, backslash, control-character, encoded, double-encoded, and deeply encoded inputs
- real-Postgres concurrent consumption test proving exactly one of two simultaneous attempts succeeds
- expired/reused token equivalence and sibling revocation
- identical generic request responses for known and unknown accounts
- regression coverage proving pending token persistence and pending email delivery do not delay the generic response
- best-effort cleanup invocation and cleanup-failure isolation
- CSRF enforcement and IP/email-digest rate limits
- scanner-safe GET, one-time POST consumption, handoff-cookie clearing, and no-referrer policy
- acceptance flow: request link → capture issued token → consume → authenticated session, with no password

Quality gates passed: typecheck, Biome lint, production build, 795 unit/route tests, and the 4-test Postgres magic-link integration suite including the single-winner concurrency test.

## Intentionally deferred

- consolidating the existing email-verification flow onto `magic_link_tokens`
- removing password authentication
- dropping password or legacy verification columns

## Deliverability and risk notes

- ACS remains optional locally; when unconfigured, email delivery is the existing successful no-op.
- Request responses remain generic for missing accounts, suppressed recipients, and all delivery outcomes.
- Token issuance, email delivery retries, and cleanup are non-blocking side effects, so account-specific DB and ACS latency do not affect the response path.
- Rate limiting remains in-memory and therefore is not shared across multiple replicas, matching the existing auth limiter limitation.

This PR is Phase 1 of the approved magic-link design.
