### PR TITLE
Fix production magic-link consumption

### DIFF
--- a/.github/skills/greenroom-testing/SKILL.md
+++ b/.github/skills/greenroom-testing/SKILL.md
@@ -542,6 +542,27 @@ Any test calling these (directly or indirectly) needs timezone-controlled fixtur
 
 My Call Time has the `playwright-cli` skill (`.github/skills/playwright-cli/`) for browser automation.
 
+### Auth Cookie and Redirect Flows
+
+Mock-only route tests are not sufficient for authentication flows that cross redirects, use
+HttpOnly cookies, or atomically consume database-backed tokens. A production magic-link bug passed
+mocked tests because they manually supplied a cookie to the action and did not exercise the
+browser's cookie path rules for Remix `.data` requests. Mocked database results also cannot catch
+`expires_at` serialization or issue/consume hash mismatches.
+
+For these flows, require a real `GET -> redirect -> POST` test that:
+
+1. Uses the actual `Set-Cookie` header from the GET response.
+2. Follows the redirect with browser-compatible cookie path handling.
+3. Posts to the URL Remix uses in the browser, including its `.data` suffix.
+4. Exercises the real Postgres consume/update and verifies the authenticated redirect.
+5. Includes a Playwright test when the flow is user-facing.
+
+Token service integration tests must issue through the production service, inspect the stored row
+to confirm `expires_at > now()` and the stored hash matches the raw token, then consume that same
+token through the production service. Do not replace this with separately seeded issue and consume
+fixtures, because symmetric serialization and hashing defects would remain invisible.
+
 ### Accessible Locators
 
 - Give controls on the same page unique, user-friendly accessible names. Two fields labelled

--- a/app/routes/__integration__/magic-link-consume.integration.test.ts
+++ b/app/routes/__integration__/magic-link-consume.integration.test.ts
@@ -1,0 +1,106 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../../src/db/index.js";
+import { magicLinkTokens } from "../../../src/db/schema.js";
+import { createTestUser } from "../../services/__integration__/seed.js";
+import { cleanDatabase } from "../../services/__integration__/setup.js";
+import { generateCsrfToken } from "../../services/csrf.server.js";
+import { issueLoginMagicLink } from "../../services/magic-link.server.js";
+import { action, loader } from "../auth.magic-link.consume.js";
+
+type StoredCookie = {
+	name: string;
+	value: string;
+	path: string;
+};
+
+class TestCookieJar {
+	private readonly cookies = new Map<string, StoredCookie>();
+
+	store(setCookie: string): void {
+		const parts = setCookie.split(";").map((part) => part.trim());
+		const [nameValue = "", ...attributes] = parts;
+		const separator = nameValue.indexOf("=");
+		if (separator === -1) throw new Error("Invalid Set-Cookie header");
+
+		const name = nameValue.slice(0, separator);
+		const value = nameValue.slice(separator + 1);
+		const pathAttribute = attributes.find((attribute) =>
+			attribute.toLowerCase().startsWith("path="),
+		);
+		const path = pathAttribute?.slice("path=".length) ?? "/";
+		this.cookies.set(name, { name, value, path });
+	}
+
+	headerFor(requestPath: string): string {
+		return Array.from(this.cookies.values())
+			.filter(({ path }) => {
+				if (requestPath === path) return true;
+				if (!requestPath.startsWith(path)) return false;
+				return path.endsWith("/") || requestPath.charAt(path.length) === "/";
+			})
+			.map(({ name, value }) => `${name}=${value}`)
+			.join("; ");
+	}
+}
+
+beforeEach(async () => {
+	await cleanDatabase();
+});
+
+describe("magic-link consume route integration", () => {
+	it("survives the GET redirect and Remix .data POST before consuming in Postgres", async () => {
+		const user = await createTestUser();
+		const issued = await issueLoginMagicLink({ userId: user.id });
+		expect(issued.expiresAt.getTime()).toBeGreaterThan(Date.now() + 9 * 60 * 1000);
+
+		const jar = new TestCookieJar();
+		const linkResponse = await loader({
+			request: new Request(`http://localhost/auth/magic-link/consume?token=${issued.rawToken}`),
+			params: {},
+			context: {},
+		});
+		expect(linkResponse.status).toBe(302);
+		expect(linkResponse.headers.get("Location")).toBe("/auth/magic-link/consume");
+		expect(linkResponse.headers.get("Referrer-Policy")).toBe("no-referrer");
+		const handoffSetCookie = linkResponse.headers.get("Set-Cookie");
+		expect(handoffSetCookie).not.toBeNull();
+		jar.store(handoffSetCookie ?? "");
+
+		const cleanPath = "/auth/magic-link/consume";
+		const cleanResponse = await loader({
+			request: new Request(`http://localhost${cleanPath}`, {
+				headers: { Cookie: jar.headerFor(cleanPath) },
+			}),
+			params: {},
+			context: {},
+		});
+		expect(await cleanResponse.json()).toEqual({ hasToken: true });
+		expect(cleanResponse.headers.get("Referrer-Policy")).toBe("same-origin");
+
+		const csrfRequest = new Request(`http://localhost${cleanPath}`, {
+			headers: { Cookie: jar.headerFor(cleanPath) },
+		});
+		const { token: csrfToken, cookie: csrfSetCookie } = await generateCsrfToken(csrfRequest);
+		jar.store(csrfSetCookie);
+
+		const dataPath = "/auth/magic-link/consume.data";
+		const consumeResponse = await action({
+			request: new Request(`http://localhost${dataPath}`, {
+				method: "POST",
+				body: new URLSearchParams({ _csrf: csrfToken }),
+				headers: { Cookie: jar.headerFor(dataPath) },
+			}),
+			params: {},
+			context: {},
+		});
+
+		expect(consumeResponse.status).toBe(302);
+		expect(consumeResponse.headers.get("Location")).toBe("/dashboard");
+		const [stored] = await db
+			.select({ consumedAt: magicLinkTokens.consumedAt })
+			.from(magicLinkTokens)
+			.where(eq(magicLinkTokens.userId, user.id));
+		expect(stored?.consumedAt).not.toBeNull();
+	});
+});

--- a/app/routes/auth.magic-link.consume.test.ts
+++ b/app/routes/auth.magic-link.consume.test.ts
@@ -55,6 +55,7 @@ describe("magic-link consume route", () => {
 		expect((response as Response).status).toBe(302);
 		expect((response as Response).headers.get("Location")).toBe("/auth/magic-link/consume");
 		expect((response as Response).headers.get("Set-Cookie")).toContain("__magic_link_handoff=");
+		expect((response as Response).headers.get("Set-Cookie")).toContain("Path=/auth/magic-link");
 		expect(consumeLoginMagicLink).not.toHaveBeenCalled();
 		expect(createUserSession).not.toHaveBeenCalled();
 	});

--- a/app/routes/auth.magic-link.consume.tsx
+++ b/app/routes/auth.magic-link.consume.tsx
@@ -22,11 +22,12 @@ import { createUserSession } from "~/services/session.server";
 
 export const meta: MetaFunction = () => [
 	{ title: "Continue Sign-In — My Call Time" },
-	{ name: "referrer", content: "no-referrer" },
+	{ name: "referrer", content: "same-origin" },
 ];
 
-export const headers: HeadersFunction = () => ({
-	"Referrer-Policy": "no-referrer",
+export const headers: HeadersFunction = ({ actionHeaders, loaderHeaders }) => ({
+	"Referrer-Policy":
+		actionHeaders.get("Referrer-Policy") ?? loaderHeaders.get("Referrer-Policy") ?? "same-origin",
 });
 
 const CONSUME_PATH = "/auth/magic-link/consume";
@@ -50,7 +51,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 	const handoff = await parseMagicLinkHandoff(request);
 	const hasToken = typeof handoff === "string" && isValidMagicLinkToken(handoff);
-	return Response.json({ hasToken }, { headers: { "Referrer-Policy": "no-referrer" } });
+	return Response.json({ hasToken }, { headers: { "Referrer-Policy": "same-origin" } });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -65,7 +66,7 @@ export async function action({ request }: ActionFunctionArgs) {
 			{
 				status: 400,
 				headers: {
-					"Referrer-Policy": "no-referrer",
+					"Referrer-Policy": "same-origin",
 					"Set-Cookie": clearCookie,
 				},
 			},
@@ -79,7 +80,7 @@ export async function action({ request }: ActionFunctionArgs) {
 			{
 				status: 400,
 				headers: {
-					"Referrer-Policy": "no-referrer",
+					"Referrer-Policy": "same-origin",
 					"Set-Cookie": clearCookie,
 				},
 			},
@@ -88,7 +89,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const response = await createUserSession(consumed.userId, consumed.redirectPath);
 	response.headers.append("Set-Cookie", clearCookie);
-	response.headers.set("Referrer-Policy", "no-referrer");
+	response.headers.set("Referrer-Policy", "same-origin");
 	return response;
 }
 

--- a/app/services/__integration__/magic-link.integration.test.ts
+++ b/app/services/__integration__/magic-link.integration.test.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "../../../src/db/index.js";
 import { magicLinkTokens } from "../../../src/db/schema.js";
@@ -15,11 +15,17 @@ beforeEach(async () => {
 });
 
 describe("magic-link service integration", () => {
-	it("stores only the token hash, never the raw token", async () => {
+	it("issues a future-dated token whose exact hash can be consumed", async () => {
 		const user = await createTestUser();
 		const issued = await issueLoginMagicLink({ userId: user.id });
 		const [stored] = await db
-			.select()
+			.select({
+				tokenHash: magicLinkTokens.tokenHash,
+				purpose: magicLinkTokens.purpose,
+				redirectPath: magicLinkTokens.redirectPath,
+				expiresAt: magicLinkTokens.expiresAt,
+				stillValid: sql<boolean>`${magicLinkTokens.expiresAt} > now()`,
+			})
 			.from(magicLinkTokens)
 			.where(eq(magicLinkTokens.userId, user.id));
 
@@ -27,6 +33,12 @@ describe("magic-link service integration", () => {
 		expect(JSON.stringify(stored)).not.toContain(issued.rawToken);
 		expect(stored?.purpose).toBe("login");
 		expect(stored?.redirectPath).toBe("/dashboard");
+		expect(stored?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+		expect(stored?.stillValid).toBe(true);
+		expect(await consumeLoginMagicLink(hashMagicLinkToken(issued.rawToken))).toEqual({
+			userId: user.id,
+			redirectPath: "/dashboard",
+		});
 	});
 
 	it("allows exactly one of two simultaneous consumes to succeed", async () => {

--- a/app/services/magic-link-handoff.server.ts
+++ b/app/services/magic-link-handoff.server.ts
@@ -6,12 +6,12 @@ if (!sessionSecret) {
 }
 
 const HANDOFF_COOKIE_MAX_AGE_SECONDS = 5 * 60;
-const CONSUME_PATH = "/auth/magic-link/consume";
+const MAGIC_LINK_PATH = "/auth/magic-link";
 
 export const magicLinkHandoffCookie = createCookie("__magic_link_handoff", {
 	httpOnly: true,
 	maxAge: HANDOFF_COOKIE_MAX_AGE_SECONDS,
-	path: CONSUME_PATH,
+	path: MAGIC_LINK_PATH,
 	sameSite: "lax",
 	secrets: [sessionSecret],
 	secure: process.env.NODE_ENV === "production",

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,7 +1,21 @@
 import { expect, test } from "@playwright/test";
+import { issueTestMagicLink } from "./helpers/seed";
 import { ADMIN_STATE, loadTestData } from "./helpers/test-data";
 
 const td = loadTestData();
+
+function magicLinkUserId(projectName: string): string {
+	switch (projectName) {
+		case "Desktop Chrome":
+			return td.admin.id;
+		case "Mobile Safari":
+			return td.member.id;
+		case "Mobile Chrome":
+			return td.solo.id;
+		default:
+			throw new Error(`No magic-link test user for ${projectName}`);
+	}
+}
 
 test.describe("Signup", () => {
 	test("shows validation errors for empty form", async ({ page }) => {
@@ -42,6 +56,17 @@ test.describe("Signup", () => {
 });
 
 test.describe("Login", () => {
+	test("fresh magic link signs in through the clean continue page", async ({ page }, testInfo) => {
+		const rawToken = await issueTestMagicLink(magicLinkUserId(testInfo.project.name));
+
+		await page.goto(`/auth/magic-link/consume?token=${rawToken}`);
+		await expect(page).toHaveURL(/\/auth\/magic-link\/consume$/);
+		await page.getByRole("button", { name: "Continue to My Call Time" }).click();
+
+		await expect(page).toHaveURL(/\/dashboard/);
+		await expect(page.getByText(/welcome back/i)).toBeVisible();
+	});
+
 	test("login with valid credentials redirects to dashboard", async ({ page }) => {
 		await page.goto("/login");
 		const passwordForm = page.getByRole("form", { name: "Sign in with password" });

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -38,6 +38,24 @@ function getPool(): pg.Pool {
 	});
 }
 
+export async function issueTestMagicLink(userId: string): Promise<string> {
+	const pool = getPool();
+	const rawToken = crypto.randomBytes(32).toString("base64url");
+	const tokenHash = crypto.createHash("sha256").update(rawToken).digest("hex");
+
+	try {
+		await pool.query(
+			`INSERT INTO magic_link_tokens
+				(user_id, token_hash, purpose, redirect_path, expires_at)
+			VALUES ($1, $2, 'login', '/dashboard', now() + interval '10 minutes')`,
+			[userId, tokenHash],
+		);
+		return rawToken;
+	} finally {
+		await pool.end();
+	}
+}
+
 /**
  * Generate a unique 8-character invite code from the allowed character set.
  * Uses the same character set as the app (no ambiguous I/O/0/1).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const EXPLORER_PORT = 5337;
 const APP_PORT = 5176;
+const APP_BASE_URL = process.env.E2E_BASE_URL || `http://localhost:${APP_PORT}`;
 
 export default defineConfig({
 	testDir: "./e2e",
@@ -16,7 +17,7 @@ export default defineConfig({
 	workers: process.env.CI ? 1 : undefined,
 	reporter: process.env.CI ? [["github"], ["html"]] : "html",
 	use: {
-		baseURL: process.env.E2E_BASE_URL || `http://localhost:${APP_PORT}`,
+		baseURL: APP_BASE_URL,
 		screenshot: "only-on-failure",
 		trace: "on-first-retry",
 	},
@@ -82,6 +83,10 @@ export default defineConfig({
 			port: APP_PORT,
 			reuseExistingServer: !process.env.CI,
 			timeout: 60_000,
+			env: {
+				...process.env,
+				APP_URL: APP_BASE_URL,
+			},
 		},
 		{
 			command: `pnpm vite dev --config vite.explorer.config.ts --port ${EXPLORER_PORT}`,


### PR DESCRIPTION
## Phase 1 production hotfix

### Proven root cause

Production logs show the emailed token GET returned `302`, the clean `/auth/magic-link/consume` page returned `200`, and only after the user selected Continue did `POST /auth/magic-link/consume.data` return `400`. The user therefore reached the Continue page; the failure was not on the email click or GET redirect.

The handoff cookie used `Path=/auth/magic-link/consume`, but hydrated Remix forms POST to the sibling `/auth/magic-link/consume.data` URL. Browser cookie path matching excludes `.data` from that exact path, so the action received no handoff token and returned the generic invalid/expired response before touching the valid database row.

Real-Postgres checks rule out the other leading causes: issuance stores `expires_at` in the future, `expires_at > now()` is true, the SHA-256 of the unmodified base64url token matches the stored hash, and direct atomic consumption succeeds.

### Fix

Scope the signed handoff cookie to `/auth/magic-link`, which covers both the clean page and Remix data action while preserving HttpOnly, SameSite=Lax, Secure-in-production, short expiry, CSRF, scanner-safe GET, and single-use consumption. The token-bearing GET remains `no-referrer`; the clean page uses `same-origin` so Remix forwarded actions retain valid origin context without exposing a token in the URL.

### Regression coverage

- Real Postgres service test: production issue -> stored expiry/hash inspection -> production consume.
- Real Postgres route test: token GET -> actual Set-Cookie -> clean redirect -> CSRF-protected `.data` POST -> consumed row and authenticated redirect. This test returns `400` with the original cookie path and `302` with the fix.
- Playwright: fresh issued links sign in through the clean Continue page on Desktop Chrome, Mobile Safari, and Mobile Chrome.
- Testing skill now requires real cookie/redirect/database round trips for authentication flows.

### Validation

- Typecheck, lint, build, and 795 unit tests pass.
- Magic-link Postgres integration tests: 5 pass.
- Component explorer: 172 pass, 18 skipped.
- GitHub Actions: check, playwright-explorer, and full playwright-e2e all pass.