### PR TITLE
Fix event creation for availability request creators

### DIFF
--- a/.github/skills/greenroom-security/SKILL.md
+++ b/.github/skills/greenroom-security/SKILL.md
@@ -113,6 +113,9 @@ if (!canManage) throw new Response("Forbidden", { status: 403 });
 
 **Gotchas / checklist when you touch owner-scoped actions:**
 
+- UI affordance gates must honor the same permission model as the server: **admin OR configured
+  member permission OR resource owner**. Never gate UI on `isAdmin` alone when the server allows
+  more, or authorized members will be silently blocked from actions the server accepts.
 - The check has **three coupled sites** — the action guard, the loader data-loading branch, and
   the JSX gate (`{canManage && ...}`). If you only fix the action, the creator gets a 403-free
   request but never sees the button; if you only fix the UI, they see the button and get a 403.

--- a/.github/skills/greenroom-security/SKILL.md
+++ b/.github/skills/greenroom-security/SKILL.md
@@ -76,6 +76,12 @@ control over it even if they are only a plain group member. In My Call Time this
 **events**: the person who created an event can edit it, delete it, **and manage its
 participants/roles** — the same as a group admin.
 
+It also applies when deriving events from an **availability request**. A request creator may
+create single or batch events from that request even when `membersCanCreateEvents` is disabled.
+Load the request, verify `request.groupId === groupId`, then authorize when the user is the request
+creator or `groupMemberHasPermission(..., "membersCanCreateEvents")` returns true. Never persist a
+client-supplied `createdFromRequestId` before that group-scope and ownership check.
+
 There is no `requireGroupAdmin`-style helper for this because ownership depends on the loaded
 resource (its `createdById`), not just the group. Compute a `canManage` flag once and reuse it
 for the loader, the UI, and every mutating intent in the action:

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -117,6 +117,8 @@ function NavBar() {
 					onClick={() => setMobileOpen(!mobileOpen)}
 					className="flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 sm:hidden"
 					aria-label="Toggle menu"
+					aria-controls="mobile-navigation"
+					aria-expanded={mobileOpen}
 				>
 					{mobileOpen ? (
 						<X className="pointer-events-none h-5 w-5" />
@@ -128,7 +130,11 @@ function NavBar() {
 
 			{/* Mobile menu */}
 			{mobileOpen && (
-				<div className="border-t border-slate-100 bg-white px-4 pb-4 pt-2 sm:hidden">
+				<div
+					id="mobile-navigation"
+					aria-label="Mobile navigation"
+					className="border-t border-slate-100 bg-white px-4 pb-4 pt-2 sm:hidden"
+				>
 					{user ? (
 						<div className="space-y-1">
 							<div className="mb-2 flex items-center gap-3 border-b border-slate-100 pb-3">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -132,7 +132,6 @@ function NavBar() {
 			{mobileOpen && (
 				<div
 					id="mobile-navigation"
-					aria-label="Mobile navigation"
 					className="border-t border-slate-100 bg-white px-4 pb-4 pt-2 sm:hidden"
 				>
 					{user ? (

--- a/app/routes/groups.$groupId.availability.$requestId.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId.test.ts
@@ -19,6 +19,7 @@ vi.mock("~/services/groups.server", () => ({
 		profileImage: null,
 	}),
 	isGroupAdmin: vi.fn().mockResolvedValue(false),
+	groupMemberHasPermission: vi.fn().mockResolvedValue(false),
 	getGroupById: vi.fn(),
 }));
 
@@ -68,7 +69,12 @@ import {
 	updateReminderSentAt,
 } from "~/services/availability.server";
 import { sendAvailabilityReminderNotification } from "~/services/email.server";
-import { getGroupById, isGroupAdmin, requireGroupMember } from "~/services/groups.server";
+import {
+	getGroupById,
+	groupMemberHasPermission,
+	isGroupAdmin,
+	requireGroupMember,
+} from "~/services/groups.server";
 import { checkReminderRateLimit } from "~/services/rate-limit.server";
 import { sendAvailabilityReminderWebhook } from "~/services/webhook.server";
 
@@ -871,6 +877,7 @@ describe("availability request loader", () => {
 			profileImage: null,
 		});
 		(isGroupAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+		(groupMemberHasPermission as ReturnType<typeof vi.fn>).mockResolvedValue(false);
 		(getAvailabilityRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockAvailRequest);
 		(getUserResponse as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 		(getReminderSentAt as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -886,6 +893,47 @@ describe("availability request loader", () => {
 
 		expect(result.availRequest).toEqual(mockAvailRequest);
 		expect(result.reminderSentAt).toBeNull();
+	});
+
+	it("allows the request creator to access event creation controls", async () => {
+		const result = await loader({
+			request: new Request("http://localhost/groups/g1/availability/r1"),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result.canCreateEventsFromRequest).toBe(true);
+	});
+
+	it("allows admins and configured members to access event creation controls", async () => {
+		(getAvailabilityRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+			...mockAvailRequest,
+			createdById: "other-user",
+		});
+		(groupMemberHasPermission as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+		const result = await loader({
+			request: new Request("http://localhost/groups/g1/availability/r1"),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result.canCreateEventsFromRequest).toBe(true);
+	});
+
+	it("hides event creation controls from an unrelated member", async () => {
+		(getAvailabilityRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+			...mockAvailRequest,
+			createdById: "other-user",
+		});
+
+		const result = await loader({
+			request: new Request("http://localhost/groups/g1/availability/r1"),
+			params: { groupId: "g1", requestId: "r1" },
+			context: {},
+		});
+
+		expect(result.canCreateEventsFromRequest).toBe(false);
 	});
 
 	it("returns reminderSentAt when available", async () => {

--- a/app/routes/groups.$groupId.availability.$requestId.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId.test.ts
@@ -905,7 +905,7 @@ describe("availability request loader", () => {
 		expect(result.canCreateEventsFromRequest).toBe(true);
 	});
 
-	it("allows admins and configured members to access event creation controls", async () => {
+	it("allows a non-owner member with membersCanCreateEvents to access event creation controls", async () => {
 		(getAvailabilityRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
 			...mockAvailRequest,
 			createdById: "other-user",
@@ -919,6 +919,7 @@ describe("availability request loader", () => {
 		});
 
 		expect(result.canCreateEventsFromRequest).toBe(true);
+		expect(groupMemberHasPermission).toHaveBeenCalledWith("user-1", "g1", "membersCanCreateEvents");
 	});
 
 	it("hides event creation controls from an unrelated member", async () => {

--- a/app/routes/groups.$groupId.availability.$requestId.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId.tsx
@@ -41,7 +41,12 @@ import {
 } from "~/services/availability.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { sendAvailabilityReminderNotification } from "~/services/email.server";
-import { getGroupById, isGroupAdmin, requireGroupMember } from "~/services/groups.server";
+import {
+	getGroupById,
+	groupMemberHasPermission,
+	isGroupAdmin,
+	requireGroupMember,
+} from "~/services/groups.server";
 import {
 	checkAvailabilityResponseRateLimit,
 	checkReminderRateLimit,
@@ -76,6 +81,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 	// Fetch reminderSentAt separately — gracefully returns null if migration 0012 hasn't run
 	const reminderSentAt = await getReminderSentAt(requestId);
+	const canCreateEventsFromRequest =
+		availRequest.createdById === user.id ||
+		(await groupMemberHasPermission(user.id, groupId, "membersCanCreateEvents"));
 
 	return {
 		availRequest,
@@ -86,6 +94,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		user,
 		nonRespondentCount,
 		reminderSentAt,
+		canCreateEventsFromRequest,
 	};
 }
 
@@ -294,6 +303,7 @@ export default function AvailabilityRequestDetail() {
 		user,
 		nonRespondentCount,
 		reminderSentAt,
+		canCreateEventsFromRequest,
 	} = useLoaderData<typeof loader>();
 	const parentData = useRouteLoaderData<typeof groupLayoutLoader>("routes/groups.$groupId");
 	const timezone = parentData?.user?.timezone ?? undefined;
@@ -520,7 +530,7 @@ export default function AvailabilityRequestDetail() {
 							requestId={availRequest.id}
 							timeRange={hasTimeRange ? timeRange : null}
 							timezone={timezone}
-							batchMode={isAdmin}
+							batchMode={canCreateEventsFromRequest}
 							onBatchCreate={(dates) => {
 								navigate(
 									`/groups/${availRequest.groupId}/availability/${availRequest.id}/batch?dates=${dates.join(",")}`,

--- a/app/routes/groups.$groupId.availability.$requestId.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId.tsx
@@ -323,7 +323,9 @@ export default function AvailabilityRequestDetail() {
 	const [notes, setNotes] = useState<Record<string, string>>(
 		(userNotes as Record<string, string>) ?? {},
 	);
-	const [view, setView] = useState<"respond" | "results">("respond");
+	const [view, setView] = useState<"respond" | "results">(
+		searchParams.get("view") === "results" ? "results" : "respond",
+	);
 	const isClosed = availRequest.status === "closed";
 	const timeRange = formatTimeRange(availRequest.requestedStartTime, availRequest.requestedEndTime);
 	const hasTimeRange = timeRange !== "All day";

--- a/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.test.ts
@@ -9,12 +9,13 @@ beforeEach(() => {
 // --- Mocks (before imports) ---
 
 vi.mock("~/services/groups.server", () => ({
-	requireGroupAdminOrPermission: vi.fn().mockResolvedValue({
+	requireGroupMember: vi.fn().mockResolvedValue({
 		id: "user-1",
 		email: "test@test.com",
 		name: "Test User",
 		timezone: "UTC",
 	}),
+	groupMemberHasPermission: vi.fn().mockResolvedValue(true),
 	getGroupWithMembers: vi.fn().mockResolvedValue(null),
 	getGroupMembersWithPreferences: vi.fn().mockResolvedValue([]),
 }));
@@ -65,7 +66,7 @@ import {
 import { getAvailabilityRequest } from "~/services/availability.server";
 import { validateCsrfToken } from "~/services/csrf.server";
 import { createEventsFromAvailability } from "~/services/events.server";
-import { requireGroupAdminOrPermission } from "~/services/groups.server";
+import { groupMemberHasPermission, requireGroupMember } from "~/services/groups.server";
 
 // --- Helpers ---
 
@@ -110,7 +111,9 @@ describe("batch route action", () => {
 			title: "March Schedule",
 			status: "open",
 			requestedDates: ["2026-03-15", "2026-03-16"],
+			createdById: "user-1",
 		});
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(true);
 		(createEventsFromAvailability as ReturnType<typeof vi.fn>).mockResolvedValue([
 			{
 				id: "ev-1",
@@ -125,7 +128,7 @@ describe("batch route action", () => {
 		]);
 	});
 
-	it("requires authentication via requireGroupAdminOrPermission", async () => {
+	it("requires group membership", async () => {
 		const formData = createFormData(validFormData);
 		try {
 			await action(actionArgs(formData));
@@ -133,11 +136,34 @@ describe("batch route action", () => {
 			// redirect expected
 		}
 
-		expect(requireGroupAdminOrPermission).toHaveBeenCalledWith(
-			expect.any(Request),
-			"g1",
-			"membersCanCreateEvents",
+		expect(requireGroupMember).toHaveBeenCalledWith(expect.any(Request), "g1");
+	});
+
+	it("allows a non-admin creator to batch-create events from their request", async () => {
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(false);
+
+		await action(actionArgs(createFormData(validFormData)));
+
+		expect(createEventsFromAvailability).toHaveBeenCalledWith(
+			expect.objectContaining({ requestId: "req-1", createdById: "user-1" }),
 		);
+	});
+
+	it("rejects an unrelated non-admin from batch-creating events", async () => {
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(false);
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			title: "March Schedule",
+			status: "open",
+			requestedDates: ["2026-03-15", "2026-03-16"],
+			createdById: "other-user",
+		} as never);
+
+		await expect(action(actionArgs(createFormData(validFormData)))).rejects.toMatchObject({
+			status: 403,
+		});
+		expect(createEventsFromAvailability).not.toHaveBeenCalled();
 	});
 
 	it("validates CSRF token", async () => {

--- a/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
+++ b/app/routes/groups.$groupId.availability.$requestId_.batch.tsx
@@ -27,7 +27,8 @@ import {
 import {
 	getGroupMembersWithPreferences,
 	getGroupWithMembers,
-	requireGroupAdminOrPermission,
+	groupMemberHasPermission,
+	requireGroupMember,
 } from "~/services/groups.server";
 import { checkEventCreateRateLimit } from "~/services/rate-limit.server";
 import { sendBatchEventsCreatedWebhook } from "~/services/webhook.server";
@@ -43,11 +44,19 @@ export const meta: MetaFunction = () => {
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const requestId = params.requestId ?? "";
-	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
+	const user = await requireGroupMember(request, groupId);
 
 	const availRequest = await getAvailabilityRequest(requestId);
 	if (!availRequest || availRequest.groupId !== groupId) {
 		throw new Response("Not Found", { status: 404 });
+	}
+	const hasGroupPermission = await groupMemberHasPermission(
+		user.id,
+		groupId,
+		"membersCanCreateEvents",
+	);
+	if (!hasGroupPermission && availRequest.createdById !== user.id) {
+		throw new Response("Forbidden", { status: 403 });
 	}
 
 	const url = new URL(request.url);
@@ -70,15 +79,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
 	const requestId = params.requestId ?? "";
-	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
-
-	const rateCheck = checkEventCreateRateLimit(user.id);
-	if (rateCheck.limited) {
-		return Response.json(
-			{ error: "You've created too many events today. Please try again later." },
-			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
-		);
-	}
+	const user = await requireGroupMember(request, groupId);
 
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
@@ -98,6 +99,22 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const availRequest = await getAvailabilityRequest(requestId);
 	if (!availRequest || availRequest.groupId !== groupId) {
 		throw new Response("Not Found", { status: 404 });
+	}
+	const hasGroupPermission = await groupMemberHasPermission(
+		user.id,
+		groupId,
+		"membersCanCreateEvents",
+	);
+	if (!hasGroupPermission && availRequest.createdById !== user.id) {
+		throw new Response("Forbidden", { status: 403 });
+	}
+
+	const rateCheck = checkEventCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ error: "You've created too many events today. Please try again later." },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
 	}
 
 	if (typeof title !== "string" || !title.trim()) {

--- a/app/routes/groups.$groupId.events.new.test.ts
+++ b/app/routes/groups.$groupId.events.new.test.ts
@@ -17,13 +17,14 @@ vi.mock("~/services/auth.server", () => ({
 }));
 
 vi.mock("~/services/groups.server", () => ({
-	requireGroupAdminOrPermission: vi.fn().mockResolvedValue({
+	requireGroupMember: vi.fn().mockResolvedValue({
 		id: "user-1",
 		email: "test@example.com",
 		name: "Test User",
 		profileImage: null,
 		timezone: "America/New_York",
 	}),
+	groupMemberHasPermission: vi.fn().mockResolvedValue(true),
 	getGroupWithMembers: vi.fn().mockResolvedValue({
 		group: { id: "g1", name: "Test Group" },
 		members: [{ id: "user-1", name: "Test User", email: "test@example.com" }],
@@ -36,7 +37,6 @@ vi.mock("~/services/events.server", () => ({
 	bulkAssignToEvent: vi.fn(),
 	autoAssignFromAvailability: vi.fn().mockResolvedValue([]),
 	getAvailabilityForEventDate: vi.fn().mockResolvedValue([]),
-	getAvailabilityRequestGroupId: vi.fn().mockResolvedValue("g1"),
 }));
 
 vi.mock("~/services/availability.server", () => ({
@@ -54,12 +54,13 @@ vi.mock("~/services/csrf.server", () => ({
 }));
 
 import { action } from "~/routes/groups.$groupId.events.new";
+import { getAvailabilityRequest } from "~/services/availability.server";
 import {
 	autoAssignFromAvailability,
 	bulkAssignToEvent,
-	getAvailabilityRequestGroupId,
+	createEvent,
 } from "~/services/events.server";
-import { getGroupWithMembers } from "~/services/groups.server";
+import { getGroupWithMembers, groupMemberHasPermission } from "~/services/groups.server";
 
 function makeRequest(fields: Record<string, string | string[]>) {
 	const formData = new FormData();
@@ -90,6 +91,8 @@ const validEvent = {
 describe("events.new validation", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(true);
+		vi.mocked(getAvailabilityRequest).mockResolvedValue(null);
 	});
 
 	it("returns error when title is empty", async () => {
@@ -187,7 +190,25 @@ describe("events.new validation", () => {
 		expect((result as Response).status).toBe(302);
 	});
 
+	it("rejects an ordinary member from creating an unrelated event", async () => {
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(false);
+
+		await expect(
+			action({
+				request: makeRequest(validEvent),
+				params: { groupId: "g1" },
+				context: {},
+			}),
+		).rejects.toMatchObject({ status: 403 });
+		expect(createEvent).not.toHaveBeenCalled();
+	});
+
 	it("auto-assigns available/maybe members when creating from availability request", async () => {
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			createdById: "user-1",
+		} as never);
 		const result = await action({
 			request: makeRequest({
 				...validEvent,
@@ -215,7 +236,11 @@ describe("events.new validation", () => {
 	it("auto-assigns for all event types when from availability", async () => {
 		for (const eventType of ["rehearsal", "show", "other"]) {
 			vi.clearAllMocks();
-			vi.mocked(getAvailabilityRequestGroupId).mockResolvedValue("g1");
+			vi.mocked(getAvailabilityRequest).mockResolvedValue({
+				id: "req-1",
+				groupId: "g1",
+				createdById: "user-1",
+			} as never);
 			const fields: Record<string, string> = {
 				...validEvent,
 				eventType,
@@ -234,34 +259,76 @@ describe("events.new validation", () => {
 		}
 	});
 
-	it("does not auto-assign when availability request belongs to a different group", async () => {
-		vi.mocked(getAvailabilityRequestGroupId).mockResolvedValue("other-group");
-		const result = await action({
-			request: makeRequest({
-				...validEvent,
-				fromRequestId: "req-from-other-group",
+	it("rejects an availability request that belongs to a different group", async () => {
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-from-other-group",
+			groupId: "other-group",
+			createdById: "user-1",
+		} as never);
+
+		await expect(
+			action({
+				request: makeRequest({
+					...validEvent,
+					fromRequestId: "req-from-other-group",
+				}),
+				params: { groupId: "g1" },
+				context: {},
 			}),
-			params: { groupId: "g1" },
-			context: {},
-		});
-		expect(result).toBeInstanceOf(Response);
-		expect((result as Response).status).toBe(302);
-		expect(autoAssignFromAvailability).not.toHaveBeenCalled();
+		).rejects.toMatchObject({ status: 404 });
+		expect(createEvent).not.toHaveBeenCalled();
 	});
 
-	it("does not auto-assign when availability request does not exist", async () => {
-		vi.mocked(getAvailabilityRequestGroupId).mockResolvedValue(null);
-		const result = await action({
-			request: makeRequest({
-				...validEvent,
-				fromRequestId: "nonexistent-req",
+	it("rejects an availability request that does not exist", async () => {
+		await expect(
+			action({
+				request: makeRequest({
+					...validEvent,
+					fromRequestId: "nonexistent-req",
+				}),
+				params: { groupId: "g1" },
+				context: {},
 			}),
+		).rejects.toMatchObject({ status: 404 });
+		expect(createEvent).not.toHaveBeenCalled();
+	});
+
+	it("allows a non-admin creator to create an event from their availability request", async () => {
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(false);
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			createdById: "user-1",
+		} as never);
+
+		const result = await action({
+			request: makeRequest({ ...validEvent, fromRequestId: "req-1" }),
 			params: { groupId: "g1" },
 			context: {},
 		});
+
 		expect(result).toBeInstanceOf(Response);
-		expect((result as Response).status).toBe(302);
-		expect(autoAssignFromAvailability).not.toHaveBeenCalled();
+		expect(createEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ createdById: "user-1", createdFromRequestId: "req-1" }),
+		);
+	});
+
+	it("rejects an unrelated non-admin from creating an event from the request", async () => {
+		vi.mocked(groupMemberHasPermission).mockResolvedValue(false);
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			createdById: "other-user",
+		} as never);
+
+		await expect(
+			action({
+				request: makeRequest({ ...validEvent, fromRequestId: "req-1" }),
+				params: { groupId: "g1" },
+				context: {},
+			}),
+		).rejects.toMatchObject({ status: 403 });
+		expect(createEvent).not.toHaveBeenCalled();
 	});
 
 	it("assigns selected performers with Performer role before auto-assign when creating show from availability", async () => {
@@ -274,7 +341,11 @@ describe("events.new validation", () => {
 			callOrder.push("autoAssignFromAvailability");
 			return [];
 		});
-		vi.mocked(getAvailabilityRequestGroupId).mockResolvedValue("g1");
+		vi.mocked(getAvailabilityRequest).mockResolvedValue({
+			id: "req-1",
+			groupId: "g1",
+			createdById: "user-1",
+		} as never);
 
 		// Mock group with all the performers as members
 		vi.mocked(getGroupWithMembers).mockResolvedValue({

--- a/app/routes/groups.$groupId.events.new.tsx
+++ b/app/routes/groups.$groupId.events.new.tsx
@@ -31,12 +31,12 @@ import {
 	bulkAssignToEvent,
 	createEvent,
 	getAvailabilityForEventDate,
-	getAvailabilityRequestGroupId,
 } from "~/services/events.server";
 import {
 	getGroupMembersWithPreferences,
 	getGroupWithMembers,
-	requireGroupAdminOrPermission,
+	groupMemberHasPermission,
+	requireGroupMember,
 } from "~/services/groups.server";
 import { checkEventCreateRateLimit } from "~/services/rate-limit.server";
 import { sendEventCreatedWebhook } from "~/services/webhook.server";
@@ -48,7 +48,7 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
+	const user = await requireGroupMember(request, groupId);
 
 	const url = new URL(request.url);
 	const fromRequestId = url.searchParams.get("fromRequest");
@@ -58,12 +58,23 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 	let availabilityData: Array<{ userId: string; userName: string; status: string }> = [];
 	if (fromRequestId) {
 		const req = await getAvailabilityRequest(fromRequestId);
-		if (req && req.groupId === groupId) {
-			fromRequest = { id: req.id, title: req.title };
-			if (prefillDate) {
-				availabilityData = await getAvailabilityForEventDate(fromRequestId, prefillDate);
-			}
+		if (!req || req.groupId !== groupId) {
+			throw new Response("Not Found", { status: 404 });
 		}
+		const hasGroupPermission = await groupMemberHasPermission(
+			user.id,
+			groupId,
+			"membersCanCreateEvents",
+		);
+		if (!hasGroupPermission && req.createdById !== user.id) {
+			throw new Response("Forbidden", { status: 403 });
+		}
+		fromRequest = { id: req.id, title: req.title };
+		if (prefillDate) {
+			availabilityData = await getAvailabilityForEventDate(fromRequestId, prefillDate);
+		}
+	} else if (!(await groupMemberHasPermission(user.id, groupId, "membersCanCreateEvents"))) {
+		throw new Response("Forbidden", { status: 403 });
 	}
 
 	const groupData = await getGroupWithMembers(groupId);
@@ -74,15 +85,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
 	const groupId = params.groupId ?? "";
-	const user = await requireGroupAdminOrPermission(request, groupId, "membersCanCreateEvents");
-
-	const rateCheck = checkEventCreateRateLimit(user.id);
-	if (rateCheck.limited) {
-		return Response.json(
-			{ error: "You've created too many events today. Please try again later." },
-			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
-		);
-	}
+	const user = await requireGroupMember(request, groupId);
 
 	const formData = await request.formData();
 	await validateCsrfToken(request, formData);
@@ -100,6 +103,33 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const formTimezone = formData.get("timezone");
 	const timezone =
 		typeof formTimezone === "string" && formTimezone ? formTimezone : (user.timezone ?? undefined);
+
+	let validatedFromRequestId: string | undefined;
+	if (typeof fromRequestId === "string" && fromRequestId) {
+		const availabilityRequest = await getAvailabilityRequest(fromRequestId);
+		if (!availabilityRequest || availabilityRequest.groupId !== groupId) {
+			throw new Response("Not Found", { status: 404 });
+		}
+		const hasGroupPermission = await groupMemberHasPermission(
+			user.id,
+			groupId,
+			"membersCanCreateEvents",
+		);
+		if (!hasGroupPermission && availabilityRequest.createdById !== user.id) {
+			throw new Response("Forbidden", { status: 403 });
+		}
+		validatedFromRequestId = availabilityRequest.id;
+	} else if (!(await groupMemberHasPermission(user.id, groupId, "membersCanCreateEvents"))) {
+		throw new Response("Forbidden", { status: 403 });
+	}
+
+	const rateCheck = checkEventCreateRateLimit(user.id);
+	if (rateCheck.limited) {
+		return Response.json(
+			{ error: "You've created too many events today. Please try again later." },
+			{ status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+		);
+	}
 
 	if (typeof title !== "string" || !title.trim()) {
 		return { error: "Title is required." };
@@ -145,8 +175,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		endTime: localTimeToUTC(date, endTime, timezone),
 		location: typeof location === "string" ? location.trim() || undefined : undefined,
 		createdById: user.id,
-		createdFromRequestId:
-			typeof fromRequestId === "string" && fromRequestId ? fromRequestId : undefined,
+		createdFromRequestId: validatedFromRequestId,
 		callTime: hasCallTime ? localTimeToUTC(date, callTime.trim(), timezone) : undefined,
 		timezone,
 	});
@@ -170,22 +199,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 	// Auto-assign available/maybe members when creating from an availability request
 	// (onConflictDoNothing skips members already assigned as Performers above)
-	const validFromRequestIdForAssign =
-		typeof fromRequestId === "string" && fromRequestId ? fromRequestId : null;
-	if (validFromRequestIdForAssign && typeof date === "string") {
-		// Validate the availability request belongs to this group (IDOR prevention)
-		const requestGroupId = await getAvailabilityRequestGroupId(validFromRequestIdForAssign);
-		if (requestGroupId === groupId) {
-			await autoAssignFromAvailability(event.id, validFromRequestIdForAssign, date);
-		}
+	if (validatedFromRequestId && typeof date === "string") {
+		await autoAssignFromAvailability(event.id, validatedFromRequestId, date);
 	}
 
 	// Fire-and-forget email notifications
 	const appUrl = process.env.APP_URL ?? "http://localhost:5173";
 	const eventUrl = `${appUrl}/groups/${groupId}/events/${event.id}`;
 	const preferencesUrl = `${appUrl}/groups/${groupId}/notifications`;
-	const validFromRequestId =
-		typeof fromRequestId === "string" && fromRequestId ? fromRequestId : null;
+	const validFromRequestId = validatedFromRequestId ?? null;
 
 	void (async () => {
 		const [groupData, membersWithPrefs] = await Promise.all([

--- a/app/services/groups.server.ts
+++ b/app/services/groups.server.ts
@@ -356,6 +356,19 @@ export async function requireGroupAdmin(request: Request, groupId: string) {
 	return user;
 }
 
+export async function groupMemberHasPermission(
+	userId: string,
+	groupId: string,
+	permission: "membersCanCreateRequests" | "membersCanCreateEvents",
+): Promise<boolean> {
+	const role = await getUserRole(userId, groupId);
+	if (role === "admin") return true;
+	if (role !== "member") return false;
+
+	const group = await getGroupById(groupId);
+	return group?.[permission] === true;
+}
+
 /**
  * Require that the user is either a group admin OR a member with the specified permission enabled.
  * Use this instead of requireGroupAdmin for actions that can optionally be opened to members.

--- a/e2e/availability.spec.ts
+++ b/e2e/availability.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { ADMIN_STATE, loadTestData, MEMBER_STATE } from "./helpers/test-data";
 
 const td = loadTestData();
@@ -79,26 +79,52 @@ test.describe("View Availability Results", () => {
 	});
 });
 
-test.describe("Create Events From Owned Availability Request", () => {
+test.describe("Create Events From Availability Results", () => {
 	test.use({ storageState: MEMBER_STATE });
 
-	test("non-admin creator can batch-create events from their request", async ({ page }) => {
-		const ownedRequest = td.creatorAvailabilityRequest;
+	async function createEventsFromResults(
+		page: Page,
+		request: { id: string; dates: string[] },
+		title: string,
+	) {
 		await page.goto(
-			`/groups/${td.group.id}/availability/${ownedRequest.id}/batch?dates=${ownedRequest.dates.join(",")}`,
+			`/groups/${td.eventPermissionGroup.id}/availability/${request.id}?view=results`,
 		);
 
-		await expect(
-			page.getByRole("heading", { name: `Create ${ownedRequest.dates.length} Events` }),
-		).toBeVisible();
-		await page.locator("#title").fill("Member-Created Rehearsals");
+		await expect(page.getByRole("button", { name: "Select Top 5" })).toBeVisible();
+		await page.goto(
+			`/groups/${td.eventPermissionGroup.id}/availability/${request.id}/batch?dates=${request.dates.slice(0, 5).join(",")}`,
+		);
+
+		await expect(page.getByRole("heading", { name: "Create 5 Events" })).toBeVisible();
+		await page.locator("#title").fill(title);
 		await page.getByRole("button", { name: /Review Events/ }).click();
-		await page
-			.getByRole("button", { name: `Create ${ownedRequest.dates.length} Events`, exact: true })
-			.click();
+		await page.getByRole("button", { name: "Create 5 Events", exact: true }).click();
 
 		await page.waitForURL(/batchSuccess=true/);
 		await expect(page.getByText(/Successfully created/)).toBeVisible();
+		await page.getByRole("link", { name: "View Events" }).click();
+		await expect(page.getByText(title, { exact: true })).toHaveCount(5);
+	}
+
+	test("non-admin creator with membersCanCreateEvents sees the affordance and persists events", async ({
+		page,
+	}, testInfo) => {
+		await createEventsFromResults(
+			page,
+			td.permissionCreatorAvailabilityRequest,
+			`Permission Creator ${testInfo.project.name} Retry ${testInfo.retry}`,
+		);
+	});
+
+	test("non-owner member with membersCanCreateEvents sees the affordance and persists events", async ({
+		page,
+	}, testInfo) => {
+		await createEventsFromResults(
+			page,
+			td.permissionAvailabilityRequest,
+			`Permission Non-Owner ${testInfo.project.name} Retry ${testInfo.retry}`,
+		);
 	});
 
 	test("unrelated non-admin cannot create events from another user's request", async ({ page }) => {

--- a/e2e/availability.spec.ts
+++ b/e2e/availability.spec.ts
@@ -9,8 +9,11 @@ test.describe("Availability Request List", () => {
 	test("shows availability requests for the group", async ({ page }) => {
 		await page.goto(`/groups/${td.group.id}/availability`);
 
-		await expect(page.getByText(td.availabilityRequest.title)).toBeVisible();
-		await expect(page.getByText(/open/i)).toBeVisible();
+		const requestCard = page.getByRole("link", {
+			name: new RegExp(td.availabilityRequest.title),
+		});
+		await expect(requestCard).toBeVisible();
+		await expect(requestCard.getByText("Open", { exact: true })).toBeVisible();
 	});
 });
 
@@ -73,6 +76,39 @@ test.describe("View Availability Results", () => {
 
 		// Should see the "Close Request" button (admin-only)
 		await expect(page.getByRole("button", { name: /close request/i })).toBeVisible();
+	});
+});
+
+test.describe("Create Events From Owned Availability Request", () => {
+	test.use({ storageState: MEMBER_STATE });
+
+	test("non-admin creator can batch-create events from their request", async ({ page }) => {
+		const ownedRequest = td.creatorAvailabilityRequest;
+		await page.goto(
+			`/groups/${td.group.id}/availability/${ownedRequest.id}/batch?dates=${ownedRequest.dates.join(",")}`,
+		);
+
+		await expect(
+			page.getByRole("heading", { name: `Create ${ownedRequest.dates.length} Events` }),
+		).toBeVisible();
+		await page.locator("#title").fill("Member-Created Rehearsals");
+		await page.getByRole("button", { name: /Review Events/ }).click();
+		await page
+			.getByRole("button", { name: `Create ${ownedRequest.dates.length} Events`, exact: true })
+			.click();
+
+		await page.waitForURL(/batchSuccess=true/);
+		await expect(page.getByText(/Successfully created/)).toBeVisible();
+	});
+
+	test("unrelated non-admin cannot create events from another user's request", async ({ page }) => {
+		const date = td.availabilityRequest.dates[0];
+		const response = await page.goto(
+			`/groups/${td.group.id}/events/new?fromRequest=${td.availabilityRequest.id}&date=${date}`,
+		);
+
+		expect(response?.status()).toBe(403);
+		await expect(page.getByRole("heading", { name: "Error 403" })).toBeVisible();
 	});
 });
 

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -30,6 +30,7 @@ setup("seed and authenticate", async ({ page }) => {
 			solo: { id: solo.user.id, email: solo.user.email, name: solo.user.name },
 			group: { id: data.group.id, name: data.group.name, inviteCode: data.group.inviteCode },
 			availabilityRequest: data.availabilityRequest,
+			creatorAvailabilityRequest: data.creatorAvailabilityRequest,
 		}),
 	);
 

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -31,6 +31,9 @@ setup("seed and authenticate", async ({ page }) => {
 			group: { id: data.group.id, name: data.group.name, inviteCode: data.group.inviteCode },
 			availabilityRequest: data.availabilityRequest,
 			creatorAvailabilityRequest: data.creatorAvailabilityRequest,
+			eventPermissionGroup: data.eventPermissionGroup,
+			permissionAvailabilityRequest: data.permissionAvailabilityRequest,
+			permissionCreatorAvailabilityRequest: data.permissionCreatorAvailabilityRequest,
 		}),
 	);
 

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -29,6 +29,9 @@ export interface TestData {
 	group: TestGroup;
 	availabilityRequest: TestAvailabilityRequest;
 	creatorAvailabilityRequest: TestAvailabilityRequest;
+	eventPermissionGroup: TestGroup;
+	permissionAvailabilityRequest: TestAvailabilityRequest;
+	permissionCreatorAvailabilityRequest: TestAvailabilityRequest;
 	cleanup: () => Promise<void>;
 }
 
@@ -87,7 +90,13 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 	const membershipMemberId = crypto.randomUUID();
 	const availabilityRequestId = crypto.randomUUID();
 	const creatorAvailabilityRequestId = crypto.randomUUID();
+	const eventPermissionGroupId = crypto.randomUUID();
+	const eventPermissionMembershipAdminId = crypto.randomUUID();
+	const eventPermissionMembershipMemberId = crypto.randomUUID();
+	const permissionAvailabilityRequestId = crypto.randomUUID();
+	const permissionCreatorAvailabilityRequestId = crypto.randomUUID();
 	const inviteCode = generateTestInviteCode();
+	const eventPermissionInviteCode = generateTestInviteCode();
 
 	const passwordHash = bcrypt.hashSync(TEST_PASSWORD, 10);
 
@@ -110,6 +119,11 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 		name: `Test Group ${prefix}`,
 		inviteCode,
 	};
+	const eventPermissionGroup: TestGroup = {
+		id: eventPermissionGroupId,
+		name: `Event Permission Group ${prefix}`,
+		inviteCode: eventPermissionInviteCode,
+	};
 
 	// Generate future dates for availability request
 	const requestDates: string[] = [];
@@ -126,6 +140,16 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 	const creatorAvailabilityRequest: TestAvailabilityRequest = {
 		id: creatorAvailabilityRequestId,
 		title: `E2E Member Availability ${prefix}`,
+		dates: requestDates,
+	};
+	const permissionAvailabilityRequest: TestAvailabilityRequest = {
+		id: permissionAvailabilityRequestId,
+		title: `E2E Permission Availability ${prefix}`,
+		dates: requestDates,
+	};
+	const permissionCreatorAvailabilityRequest: TestAvailabilityRequest = {
+		id: permissionCreatorAvailabilityRequestId,
+		title: `E2E Permission Member Availability ${prefix}`,
 		dates: requestDates,
 	};
 
@@ -197,6 +221,11 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 		 VALUES ($1, $2, $3, $4, NOW(), NOW())`,
 		[groupId, group.name, inviteCode, adminId],
 	);
+	await pool.query(
+		`INSERT INTO groups (id, name, invite_code, created_by_id, members_can_create_events, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, true, NOW(), NOW())`,
+		[eventPermissionGroupId, eventPermissionGroup.name, eventPermissionInviteCode, adminId],
+	);
 
 	// Insert memberships
 	await pool.query(
@@ -208,6 +237,17 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 		`INSERT INTO group_memberships (id, group_id, user_id, role, joined_at)
 		 VALUES ($1, $2, $3, 'member', NOW())`,
 		[membershipMemberId, groupId, memberId],
+	);
+	await pool.query(
+		`INSERT INTO group_memberships (id, group_id, user_id, role, joined_at)
+		 VALUES ($1, $2, $3, 'admin', NOW()), ($4, $2, $5, 'member', NOW())`,
+		[
+			eventPermissionMembershipAdminId,
+			eventPermissionGroupId,
+			adminId,
+			eventPermissionMembershipMemberId,
+			memberId,
+		],
 	);
 
 	// Insert availability request
@@ -237,6 +277,24 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 			memberId,
 		],
 	);
+	await pool.query(
+		`INSERT INTO availability_requests (id, group_id, title, date_range_start, date_range_end, requested_dates, status, created_by_id, created_at)
+		 VALUES
+			($1, $2, $3, $4, $5, $6, 'open', $7, NOW()),
+			($8, $2, $9, $4, $5, $6, 'open', $10, NOW())`,
+		[
+			permissionAvailabilityRequestId,
+			eventPermissionGroupId,
+			permissionAvailabilityRequest.title,
+			`${requestDates[0]}T00:00:00Z`,
+			`${requestDates[requestDates.length - 1]}T00:00:00Z`,
+			JSON.stringify(requestDates),
+			adminId,
+			permissionCreatorAvailabilityRequestId,
+			permissionCreatorAvailabilityRequest.title,
+			memberId,
+		],
+	);
 
 	// Close the seeding pool — cleanup will create its own if needed
 	await pool.end();
@@ -247,27 +305,49 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 			// Clean up in reverse dependency order
 			await cleanupPool.query(
 				`DELETE FROM availability_responses WHERE request_id IN (
-					SELECT id FROM availability_requests WHERE group_id = $1
+					SELECT id FROM availability_requests WHERE group_id IN ($1, $2)
 				)`,
-				[groupId],
+				[groupId, eventPermissionGroupId],
 			);
 			await cleanupPool.query(
 				`DELETE FROM event_assignments WHERE event_id IN (
-					SELECT id FROM events WHERE group_id = $1
+					SELECT id FROM events WHERE group_id IN ($1, $2)
 				)`,
-				[groupId],
+				[groupId, eventPermissionGroupId],
 			);
-			await cleanupPool.query(`DELETE FROM events WHERE group_id = $1`, [groupId]);
-			await cleanupPool.query(`DELETE FROM availability_requests WHERE group_id = $1`, [groupId]);
-			await cleanupPool.query(`DELETE FROM group_memberships WHERE group_id = $1`, [groupId]);
-			await cleanupPool.query(`DELETE FROM groups WHERE id = $1`, [groupId]);
+			await cleanupPool.query(`DELETE FROM events WHERE group_id IN ($1, $2)`, [
+				groupId,
+				eventPermissionGroupId,
+			]);
+			await cleanupPool.query(`DELETE FROM availability_requests WHERE group_id IN ($1, $2)`, [
+				groupId,
+				eventPermissionGroupId,
+			]);
+			await cleanupPool.query(`DELETE FROM group_memberships WHERE group_id IN ($1, $2)`, [
+				groupId,
+				eventPermissionGroupId,
+			]);
+			await cleanupPool.query(`DELETE FROM groups WHERE id IN ($1, $2)`, [
+				groupId,
+				eventPermissionGroupId,
+			]);
 			await cleanupPool.query(`DELETE FROM users WHERE id IN ($1, $2)`, [adminId, memberId]);
 		} finally {
 			await cleanupPool.end();
 		}
 	};
 
-	return { admin, member, group, availabilityRequest, creatorAvailabilityRequest, cleanup };
+	return {
+		admin,
+		member,
+		group,
+		availabilityRequest,
+		creatorAvailabilityRequest,
+		eventPermissionGroup,
+		permissionAvailabilityRequest,
+		permissionCreatorAvailabilityRequest,
+		cleanup,
+	};
 }
 
 /**

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -28,6 +28,7 @@ export interface TestData {
 	member: TestUser;
 	group: TestGroup;
 	availabilityRequest: TestAvailabilityRequest;
+	creatorAvailabilityRequest: TestAvailabilityRequest;
 	cleanup: () => Promise<void>;
 }
 
@@ -85,6 +86,7 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 	const membershipAdminId = crypto.randomUUID();
 	const membershipMemberId = crypto.randomUUID();
 	const availabilityRequestId = crypto.randomUUID();
+	const creatorAvailabilityRequestId = crypto.randomUUID();
 	const inviteCode = generateTestInviteCode();
 
 	const passwordHash = bcrypt.hashSync(TEST_PASSWORD, 10);
@@ -119,6 +121,11 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 	const availabilityRequest: TestAvailabilityRequest = {
 		id: availabilityRequestId,
 		title: `E2E Availability ${prefix}`,
+		dates: requestDates,
+	};
+	const creatorAvailabilityRequest: TestAvailabilityRequest = {
+		id: creatorAvailabilityRequestId,
+		title: `E2E Member Availability ${prefix}`,
 		dates: requestDates,
 	};
 
@@ -217,6 +224,19 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 			adminId,
 		],
 	);
+	await pool.query(
+		`INSERT INTO availability_requests (id, group_id, title, date_range_start, date_range_end, requested_dates, status, created_by_id, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, 'open', $7, NOW())`,
+		[
+			creatorAvailabilityRequestId,
+			groupId,
+			creatorAvailabilityRequest.title,
+			`${requestDates[0]}T00:00:00Z`,
+			`${requestDates[requestDates.length - 1]}T00:00:00Z`,
+			JSON.stringify(requestDates),
+			memberId,
+		],
+	);
 
 	// Close the seeding pool — cleanup will create its own if needed
 	await pool.end();
@@ -247,7 +267,7 @@ export async function seedTestData(prefix: string): Promise<TestData> {
 		}
 	};
 
-	return { admin, member, group, availabilityRequest, cleanup };
+	return { admin, member, group, availabilityRequest, creatorAvailabilityRequest, cleanup };
 }
 
 /**

--- a/e2e/helpers/test-data.ts
+++ b/e2e/helpers/test-data.ts
@@ -11,6 +11,9 @@ export interface SharedTestData {
 	group: { id: string; name: string; inviteCode: string };
 	availabilityRequest: { id: string; title: string; dates: string[] };
 	creatorAvailabilityRequest: { id: string; title: string; dates: string[] };
+	eventPermissionGroup: { id: string; name: string; inviteCode: string };
+	permissionAvailabilityRequest: { id: string; title: string; dates: string[] };
+	permissionCreatorAvailabilityRequest: { id: string; title: string; dates: string[] };
 }
 
 /**
@@ -32,6 +35,9 @@ export function loadTestData(): SharedTestData {
 			group: { id: "", name: "", inviteCode: "" },
 			availabilityRequest: { id: "", title: "", dates: [] },
 			creatorAvailabilityRequest: { id: "", title: "", dates: [] },
+			eventPermissionGroup: { id: "", name: "", inviteCode: "" },
+			permissionAvailabilityRequest: { id: "", title: "", dates: [] },
+			permissionCreatorAvailabilityRequest: { id: "", title: "", dates: [] },
 		};
 	}
 	const raw = fs.readFileSync(path, "utf-8");

--- a/e2e/helpers/test-data.ts
+++ b/e2e/helpers/test-data.ts
@@ -10,6 +10,7 @@ export interface SharedTestData {
 	solo: { id: string; email: string; name: string };
 	group: { id: string; name: string; inviteCode: string };
 	availabilityRequest: { id: string; title: string; dates: string[] };
+	creatorAvailabilityRequest: { id: string; title: string; dates: string[] };
 }
 
 /**
@@ -30,6 +31,7 @@ export function loadTestData(): SharedTestData {
 			solo: { id: "", email: "", name: "" },
 			group: { id: "", name: "", inviteCode: "" },
 			availabilityRequest: { id: "", title: "", dates: [] },
+			creatorAvailabilityRequest: { id: "", title: "", dates: [] },
 		};
 	}
 	const raw = fs.readFileSync(path, "utf-8");

--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -24,11 +24,18 @@ test.describe("Hamburger Menu", () => {
 
 		// Open menu
 		await page.getByRole("button", { name: /toggle menu/i }).click();
+		const mobileNavigation = page.locator('[aria-label="Mobile navigation"]');
 
 		// Nav links should be visible in the mobile menu
-		await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
-		await expect(page.getByRole("link", { name: "Groups" })).toBeVisible();
-		await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+		await expect(
+			mobileNavigation.getByRole("link", { name: "Dashboard", exact: true }),
+		).toBeVisible();
+		await expect(
+			mobileNavigation.getByRole("link", { name: "Groups", exact: true }),
+		).toBeVisible();
+		await expect(
+			mobileNavigation.getByRole("link", { name: "Settings", exact: true }),
+		).toBeVisible();
 	});
 
 	test("navigation links work from hamburger menu", async ({ page, isMobile }) => {
@@ -39,7 +46,8 @@ test.describe("Hamburger Menu", () => {
 
 		// Open menu and navigate to Groups
 		await page.getByRole("button", { name: /toggle menu/i }).click();
-		await page.getByRole("link", { name: "Groups" }).click();
+		const mobileNavigation = page.locator('[aria-label="Mobile navigation"]');
+		await mobileNavigation.getByRole("link", { name: "Groups", exact: true }).click();
 		await expect(page).toHaveURL(/\/groups/);
 	});
 });

--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -24,15 +24,13 @@ test.describe("Hamburger Menu", () => {
 
 		// Open menu
 		await page.getByRole("button", { name: /toggle menu/i }).click();
-		const mobileNavigation = page.locator('[aria-label="Mobile navigation"]');
+		const mobileNavigation = page.locator("#mobile-navigation");
 
 		// Nav links should be visible in the mobile menu
 		await expect(
 			mobileNavigation.getByRole("link", { name: "Dashboard", exact: true }),
 		).toBeVisible();
-		await expect(
-			mobileNavigation.getByRole("link", { name: "Groups", exact: true }),
-		).toBeVisible();
+		await expect(mobileNavigation.getByRole("link", { name: "Groups", exact: true })).toBeVisible();
 		await expect(
 			mobileNavigation.getByRole("link", { name: "Settings", exact: true }),
 		).toBeVisible();
@@ -46,7 +44,7 @@ test.describe("Hamburger Menu", () => {
 
 		// Open menu and navigate to Groups
 		await page.getByRole("button", { name: /toggle menu/i }).click();
-		const mobileNavigation = page.locator('[aria-label="Mobile navigation"]');
+		const mobileNavigation = page.locator("#mobile-navigation");
 		await mobileNavigation.getByRole("link", { name: "Groups", exact: true }).click();
 		await expect(page).toHaveURL(/\/groups/);
 	});


### PR DESCRIPTION
## True root cause

The availability results UI gated the "Create Event" / batch controls on `isAdmin` only. It ignored the group's `membersCanCreateEvents` setting, even though the single-event and batch-event server routes already accepted non-admin members when that setting was enabled. Authorized members were therefore silently blocked because they could not see the UI affordance.

The originally described server-authorization issue was not the cause of the reported real-world failure. The new request-creator clause still fixes a separate latent case: a request creator can now create single or batch events from their own group-scoped request even when `membersCanCreateEvents` is disabled.

## Fix

- Use one results-page capability that allows an admin, a member with `membersCanCreateEvents`, or the group-scoped availability-request creator.
- Apply the same rule to the results UI, single-event loader/action, and batch-event loader/action.
- Validate request existence and group ownership before persisting `createdFromRequestId`.
- Keep unrelated members without the configured permission blocked with 403 and cross-group/missing requests hidden with 404.
- Document that UI affordance gates must mirror server authorization instead of using `isAdmin` alone.

## Regression coverage

- Loader unit coverage explicitly proves `canCreateEventsFromRequest` is true for a non-owner member when `membersCanCreateEvents=true`, while retaining the unrelated/no-permission negative case.
- Playwright seeds a dedicated group with `membersCanCreateEvents=true` and proves both a non-admin request creator and a non-owner member can see the results-page batch affordance and persist five events from the request.
- The existing no-permission group still proves an unrelated non-admin receives 403.
- The flag-only Playwright case was mutation-checked against an `isAdmin`-only UI gate and failed at the missing batch affordance as expected.

## Quality gates

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test` (803 tests)
- `pnpm exec playwright test e2e/availability.spec.ts --project='Desktop Chrome'` (8 tests)
